### PR TITLE
Alpha blended airspace

### DIFF
--- a/Common/Data/Dialogs/dlgConfiguration.xml
+++ b/Common/Data/Dialogs/dlgConfiguration.xml
@@ -59,6 +59,12 @@
 <WndProperty Name="prpAirspaceOutline" Caption="_@M771_" X=2 Y=-1 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H114_">
 <DataField name="" DataType="boolean"/>
 </WndProperty>
+<WndProperty Name="prpAirspaceFillType" Caption="_@M940_" X=2 Y=-1 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H890_">
+<DataField name="" DataType="enum" OnDataAccess="OnAirspaceFillType"/>
+</WndProperty>
+<WndProperty Name="prpAirspaceOpacity" Caption="_@M944_" X=2 Y=-1 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H891_">
+<DataField name="" DataType="enum"/>
+</WndProperty>
 </WndFrame>
 <WndFrame Name="frmTerrain" X=70 Y=0 Width=-246 Height=222 Font=2>
 <WndProperty Name="prpEnableTerrain" Caption="_@M705_" X=2 Y=-1 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H115_">

--- a/Common/Data/Dialogs/dlgConfiguration_L.xml
+++ b/Common/Data/Dialogs/dlgConfiguration_L.xml
@@ -59,6 +59,12 @@
 <WndProperty Name="prpAirspaceOutline" Caption="_@M771_" X=2 Y=-1 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H114_">
 <DataField name="" DataType="boolean"/>
 </WndProperty>
+<WndProperty Name="prpAirspaceFillType" Caption="_@M940_" X=2 Y=-1 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H890_">
+<DataField name="" DataType="enum" OnDataAccess="OnAirspaceFillType"/>
+</WndProperty>
+<WndProperty Name="prpAirspaceOpacity" Caption="_@M944_" X=2 Y=-1 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H891_">
+<DataField name="" DataType="enum"/>
+</WndProperty>
 </WndFrame>
 <WndFrame Name="frmTerrain" X=0 Y=0 Width=235 Height=222 Font=2>
 <WndProperty Name="prpEnableTerrain" Caption="_@M705_" X=2 Y=-1 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H115_">

--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -1340,6 +1340,17 @@ If you have no AirSpeed probe, Estimated Airspeed will be used. See the manual f
 @889
 No help available on this item!
 
+@890
+[Airspace area filling]
+Airspace area can be denoted by outlines only, pattern filling, or semi-transparent colors.
+[Outlines only] there will be only lines on airspace area borders 
+[Pattern] airspace area will be filled with selected pattern of selected color
+[Semi-Transparent] airspace area will be filled with selected solid semi-transparent color (opacity of the color can be set in 'Opacity' item)
+
+@891
+[Opacity of semi-transparent airspace]
+Defines how much transparent (->0%) / opaque (->100%) will be airspace area filled with solid semi-transparent color.
+
 @9999
 No help available on this item!
 

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -1,5 +1,5 @@
 # LK8000 ENGLISH MESSAGES - ENG_MSG.TXT
-# MASTER UPDATED:  110126
+# MASTER UPDATED:  110129
 #
 # This file is loaded on startup and all messages are stored internally.
 # If you are translating these messages, try to respect sizes.
@@ -944,6 +944,11 @@ _@M936_ "Competition Class"
 _@M937_ "Competition Class: "
 _@M938_ "Competition ID"
 _@M939_ "Competition ID: "
+_@M940_ "Filling "
+_@M941_ "Outlines only"
+_@M942_ "Patterns"
+_@M943_ "Semi-Transparent"
+_@M944_ "Opacity "
 
 #
 # Infoboxes in Description / Tile order. 

--- a/Common/Header/MapWindow.h
+++ b/Common/Header/MapWindow.h
@@ -598,6 +598,9 @@ class MapWindow {
   static int TargetDrag_State;
   static double TargetDrag_Latitude;
   static double TargetDrag_Longitude;
+ 
+  // include declaration for alpha blended drawing
+  #include "MapWindowA.h"
 };
 
 void PolygonRotateShift(POINT* poly, int n, int x, int y, 

--- a/Common/Header/MapWindowA.h
+++ b/Common/Header/MapWindowA.h
@@ -1,0 +1,81 @@
+ // the folowing code is included inside MapWindow class
+ 
+ // declaration of interface for alpha blended drawing 
+ public:
+   
+  // check if alpha blending is supported (valid after calling AlphaBlendInit())
+  static bool AlphaBlendSupported() {
+    return AlphaBlendF != NULL;
+  }    
+ 
+ private:
+   
+  typedef BOOL (WINAPI *TAlphaBlendF)(HDC,int,int,int,int,HDC,int,int,int,int,BLENDFUNCTION); 
+
+  // pointer to AlphaBlend() function (initialized in AlphaBlendInit())
+  static TAlphaBlendF AlphaBlendF;
+  
+  // tries to locate AlphaBlend() function and initializes some data needed for alpha blending;
+  // sets pointer to AlphaBlend function (AlphaBlendF) 
+  // (returns false when AlphaBlending is not supported)
+  static bool AlphaBlendInit();
+  
+  // release resources used for alpha blending
+  static void AlphaBlendDestroy();
+  
+  // performs AlphaBlend
+  static void DoAlphaBlend(HDC dstHdc, const RECT dstRect, HDC srcHdc, const RECT srcRect, BYTE globalOpacity);
+
+ // declaration of interface for alpha blended air space drawing
+ public:
+  
+  enum EAirspaceFillType
+  {
+    asp_fill_none    = 0,  // airspace drawing using no filling
+    asp_fill_pattern = 1,  // airspace drawing using bitmap patterns
+    asp_fill_ablend  = 2,  // airspace drawing using alpha blend 
+  };
+  
+  // set airspace drawing type
+  static void SetAirSpaceFillType(int fillType) {
+    AirspaceFillType = fillType;
+  }
+
+  // get airspace drawing type
+  static int GetAirSpaceFillType(void) {
+    return AirspaceFillType;
+  }
+  
+  // set alpha blended airspace opacity (0..100)
+  static void SetAirSpaceOpacity(int opacity) {
+    AirspaceOpacity = opacity;
+  }
+
+  // get alpha blended airspace opacity
+  static int GetAirSpaceOpacity(void) {
+    return AirspaceOpacity;    
+  }
+  
+ private:
+
+  // airspace drawing type
+  static int AirspaceFillType;
+  
+  // alpha blended airspace opacity (0..100)
+  static BYTE AirspaceOpacity;
+ 
+  // solid brushes for airspace drawing (initialized in InitAirSpaceSldBrushes())
+  static HBRUSH hAirSpaceSldBrushes[NUMAIRSPACECOLORS];
+ 
+  // initialize solid color brushes for airspace drawing (initializes hAirSpaceSldBrushes[])
+  static void InitAirSpaceSldBrushes(const COLORREF colours[]);
+
+  static HBRUSH GetAirSpaceSldBrushByClass(int i) {
+    return hAirSpaceSldBrushes[iAirspaceColour[i]];
+  }
+
+  // draw airspace using alpha blending
+  static void ClearTptAirSpace(HDC hdc, const RECT rc);
+  
+  // draw airspace using alpha blending
+  static void DrawTptAirSpace(HDC hdc, const RECT rc);

--- a/Common/Header/Utils.h
+++ b/Common/Header/Utils.h
@@ -67,6 +67,8 @@ extern const TCHAR szRegistryFinishLine[];
 extern const TCHAR szRegistryFinishRadius[];
 extern const TCHAR szRegistryAirspaceWarning[];
 extern const TCHAR szRegistryAirspaceBlackOutline[];
+extern const TCHAR szRegistryAirspaceFillType[];
+extern const TCHAR szRegistryAirspaceOpacity[];
 extern const TCHAR szRegistryWarningTime[];
 extern const TCHAR szRegistryAcknowledgementTime[];
 extern const TCHAR szRegistryCircleZoom[];

--- a/Common/Source/MapWindow.cpp
+++ b/Common/Source/MapWindow.cpp
@@ -1420,7 +1420,9 @@ LRESULT CALLBACK MapWindow::MapWndProc (HWND hWnd, UINT uMsg, WPARAM wParam,
       hdcDrawWindow = CreateCompatibleDC(hdcScreen);
       hDCTemp = CreateCompatibleDC(hdcDrawWindow);
       hDCMask = CreateCompatibleDC(hdcDrawWindow);
-
+    
+      AlphaBlendInit();
+    
       #if LKOBJ
       hBackgroundBrush = LKBrush_White;
       hInvBackgroundBrush[0] = LKBrush_White;
@@ -1723,6 +1725,7 @@ LRESULT CALLBACK MapWindow::MapWndProc (HWND hWnd, UINT uMsg, WPARAM wParam,
       DeleteDC(hDCMask);
       DeleteObject(hDrawBitMap);
       DeleteObject(hMaskBitMap);
+      AlphaBlendDestroy();
 
       DeleteObject(hTurnPoint);
       DeleteObject(hSmall);
@@ -3240,7 +3243,14 @@ QuickRedraw: // 100318 speedup redraw
 		SelectObject(hdcDrawWindow, hfOld);
 		goto QuickRedraw;
 	}
-  if ( OnAirSpace >0 ) DrawAirSpace(hdc, rc); // VENTA3 default is true, always true at startup no regsave
+  
+  if (OnAirSpace > 0)  // VENTA3 default is true, always true at startup no regsave 
+  {
+    if (GetAirSpaceFillType() == asp_fill_ablend)
+      DrawTptAirSpace(hdc, rc);
+    else
+      DrawAirSpace(hdc, rc);
+  }
 
  	if (DONTDRAWTHEMAP) { // 100319
 		SelectObject(hdcDrawWindow, hfOld);

--- a/Common/Source/MapWindow2.cpp
+++ b/Common/Source/MapWindow2.cpp
@@ -1700,44 +1700,46 @@ void MapWindow::DrawAirSpace(HDC hdc, const RECT rc)
   
   bool found = false;
 
-  if (AirspaceCircle) {
-    // draw without border
-    for(i=0;i<NumberOfAirspaceCircles;i++) {
-      if (AirspaceCircle[i].Visible==2) {
-	if (!found) {
-	  ClearAirSpace(true);
-	  found = true;
-	}
-        // this color is used as the black bit
-        SetTextColor(hDCTemp,
-                     Colours[iAirspaceColour[AirspaceCircle[i].Type]]);
-        // get brush, can be solid or a 1bpp bitmap
-        SelectObject(hDCTemp,
-                     hAirspaceBrushes[iAirspaceBrush[AirspaceCircle[i].Type]]);
-        Circle(hDCTemp,
-               AirspaceCircle[i].Screen.x ,
-               AirspaceCircle[i].Screen.y ,
-               AirspaceCircle[i].ScreenR ,rc, true, true);
+  if (GetAirSpaceFillType() != asp_fill_none) {
+    if (AirspaceCircle) {
+      // draw without border
+      for(i=0;i<NumberOfAirspaceCircles;i++) {
+        if (AirspaceCircle[i].Visible==2) {
+	  if (!found) {
+            ClearAirSpace(true);
+            found = true;
+          }
+          // this color is used as the black bit
+          SetTextColor(hDCTemp,
+                       Colours[iAirspaceColour[AirspaceCircle[i].Type]]);
+          // get brush, can be solid or a 1bpp bitmap
+          SelectObject(hDCTemp,
+                       hAirspaceBrushes[iAirspaceBrush[AirspaceCircle[i].Type]]);
+          Circle(hDCTemp,
+                 AirspaceCircle[i].Screen.x ,
+                 AirspaceCircle[i].Screen.y ,
+                 AirspaceCircle[i].ScreenR ,rc, true, true);
+        }
       }
     }
-  }
 
-  if (AirspaceArea) {
-    for(i=0;i<NumberOfAirspaceAreas;i++) {
-      if(AirspaceArea[i].Visible ==2) {
-	if (!found) {
-	  ClearAirSpace(true);
-	  found = true;
-	}
-        // this color is used as the black bit
-        SetTextColor(hDCTemp, 
-                     Colours[iAirspaceColour[AirspaceArea[i].Type]]);
-        SelectObject(hDCTemp,
-                     hAirspaceBrushes[iAirspaceBrush[AirspaceArea[i].Type]]);         
-        ClipPolygon(hDCTemp,
-                    AirspaceScreenPoint+AirspaceArea[i].FirstPoint,
-                    AirspaceArea[i].NumPoints, rc, true);
-      }      
+    if (AirspaceArea) {
+      for(i=0;i<NumberOfAirspaceAreas;i++) {
+        if(AirspaceArea[i].Visible ==2) {
+          if (!found) {
+            ClearAirSpace(true);
+            found = true;
+          }
+          // this color is used as the black bit
+          SetTextColor(hDCTemp, 
+                       Colours[iAirspaceColour[AirspaceArea[i].Type]]);
+          SelectObject(hDCTemp,
+                       hAirspaceBrushes[iAirspaceBrush[AirspaceArea[i].Type]]);         
+          ClipPolygon(hDCTemp,
+                      AirspaceScreenPoint+AirspaceArea[i].FirstPoint,
+                      AirspaceArea[i].NumPoints, rc, true);
+        }      
+      }
     }
   }
   

--- a/Common/Source/MapWindowA.cpp
+++ b/Common/Source/MapWindowA.cpp
@@ -1,0 +1,225 @@
+/*
+   LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+   Released under GNU/GPL License v.2
+   See CREDITS.TXT file for authors and copyrights
+
+   $Id: MapWindow2.cpp,v 8.16 2010/12/26 22:05:15 root Exp root $
+*/
+
+#include "StdAfx.h"
+#include "compatibility.h"
+#include "options.h"
+#include "Defines.h"
+
+#include "MapWindow.h"
+#include "externs.h"
+#include "Terrain.h"
+
+
+// pointer to AlphaBlend() function (initialized in AlphaBlendInit())
+//static 
+MapWindow::TAlphaBlendF MapWindow::AlphaBlendF = NULL;
+
+// airspace drawing type
+//static 
+int MapWindow::AirspaceFillType = MapWindow::asp_fill_pattern;
+
+// alpha blended airspace opacity (0..100)
+//static 
+BYTE MapWindow::AirspaceOpacity = 30;
+
+  // solid brushes for airspace drawing (initialized in InitAirSpaceSldBrushes())
+//static 
+HBRUSH MapWindow::hAirSpaceSldBrushes[NUMAIRSPACECOLORS];
+
+
+// tries to locate AlphaBlend() function and initializes some data needed for alpha blending;
+// sets pointer to AlphaBlend function (AlphaBlendF) 
+// (returns false when AlphaBlending is not supported)
+//static
+bool MapWindow::AlphaBlendInit() {
+  #if (WINDOWSPC>0)
+    AlphaBlendF = AlphaBlend;
+  #else
+    AlphaBlendF = (TAlphaBlendF) GetProcAddress(GetModuleHandle(TEXT("coredll.dll")), TEXT("AlphaBlend"));
+  #endif
+
+  if (AlphaBlendF == NULL) {
+    StartupStore(_T("error getting CoreDll::AlphaBlend() address\n"));
+    return false;
+  }
+
+  InitAirSpaceSldBrushes(Colours);
+  
+  return true;
+} // AlphaBlendInit()
+
+
+// release resources used for alpha blending
+//static 
+void MapWindow::AlphaBlendDestroy() {
+  for (int i = 0; i < NUMAIRSPACECOLORS; i++) {
+    if (hAirSpaceSldBrushes[i] != NULL) {
+      DeleteObject(hAirSpaceSldBrushes[i]);
+      hAirSpaceSldBrushes[i] = NULL;
+    }
+  }
+} // AlphaBlendDestroy()
+
+
+// performs AlphaBlend
+//static 
+void MapWindow::DoAlphaBlend(HDC dstHdc, const RECT dstRect, HDC srcHdc, const RECT srcRect, BYTE globalOpacity) {
+  if (AlphaBlendF == NULL)
+    return;
+  
+  //BLENDFUNCTION bf = { AC_SRC_OVER, 0, globalOpacity, AC_SRC_ALPHA };
+  // we are not using per-pixel alpha, so do not use AC_SRC_ALPHA flag
+  BLENDFUNCTION bf = { AC_SRC_OVER, 0, globalOpacity, 0 };
+  
+  AlphaBlendF(
+    dstHdc, dstRect.left, dstRect.top, dstRect.right - dstRect.left, dstRect.bottom - dstRect.top,
+    srcHdc, srcRect.left, srcRect.top, srcRect.right - srcRect.left, srcRect.bottom - srcRect.top, bf);
+} // DoAlphaBlend()
+
+
+
+// initialize solid color brushes for airspace drawing (initializes hAirSpaceSldBrushes[])
+//static 
+void MapWindow::InitAirSpaceSldBrushes(const COLORREF colours[]) {
+  // initialize solid color brushes for airspace drawing
+  for (int i = 0; i < NUMAIRSPACECOLORS; i++) {
+    if (hAirSpaceSldBrushes[i] != NULL)
+      DeleteObject(hAirSpaceSldBrushes[i]);
+    
+    hAirSpaceSldBrushes[i] = CreateSolidBrush(colours[i]);
+  }
+} // InitAirSpaceSldBrushes()
+
+
+
+// draw airspace using alpha blending
+//static 
+void MapWindow::ClearTptAirSpace(HDC hdc, const RECT rc) {
+  // select temp bitmap
+  SelectObject(hDCTemp, hDrawBitMapTmp);
+  
+  // copy original bitmap into temp (for saving fully transparent areas)
+  int width  = rc.right - rc.left;
+  int height = rc.bottom - rc.top;
+  BitBlt(hDCTemp, rc.left, rc.top, width, height, hdc, rc.left, rc.top, SRCCOPY);
+} // ClearTptAirSpace()
+
+
+// TODO code: optimise airspace drawing (same as DrawAirSpace())
+// draw airspace using alpha blending
+//static 
+void MapWindow::DrawTptAirSpace(HDC hdc, const RECT rc) {
+  // since standard GDI functions (brushes, pens...) ignore alpha octet in ARGB 
+  // color value and don't set it in the resulting bitmap, we cannot use
+  // perpixel alpha blending, instead we use global opacity for alpha blend 
+  // (same opacity for all pixels); for fully "transparent" areas (without 
+  // airspace) we must copy destination bitmap into source bitmap first so that 
+  // alpha blending of such areas results in the same pixels as origin pixels 
+  // in destination 
+
+  unsigned int i;
+
+  bool found = false;
+
+  if (AirspaceCircle) {
+    // draw without border
+    for(i = 0; i < NumberOfAirspaceCircles; i++) {
+      if (AirspaceCircle[i].Visible == 2) {
+        if (!found) {
+          found = true;
+          ClearTptAirSpace(hdc, rc);
+        }
+        
+        // set filling brush
+        SelectObject(hDCTemp, GetAirSpaceSldBrushByClass(AirspaceCircle[i].Type));
+        Circle(hDCTemp,
+               AirspaceCircle[i].Screen.x ,
+               AirspaceCircle[i].Screen.y ,
+               AirspaceCircle[i].ScreenR ,rc, true, true);
+      }
+    }
+  }
+
+
+  if (AirspaceArea) {
+    for(i = 0; i < NumberOfAirspaceAreas; i++) {
+      if(AirspaceArea[i].Visible == 2) {
+        if (!found) {
+          found = true;
+          ClearTptAirSpace(hdc, rc);
+        }
+        
+        // set filling brush
+        SelectObject(hDCTemp, GetAirSpaceSldBrushByClass(AirspaceArea[i].Type));
+        ClipPolygon(hDCTemp,
+                    AirspaceScreenPoint + AirspaceArea[i].FirstPoint,
+                    AirspaceArea[i].NumPoints, rc, true);
+      }
+    }
+  }
+
+  // alpha blending
+  if (found)
+    DoAlphaBlend(hdc, rc, hDCTemp, rc, (255 * GetAirSpaceOpacity()) / 100);
+  
+  
+  // draw it again, just the outlines
+  
+  // we will be drawing directly into given hdc, so store original PEN object
+  HPEN hOrigPen = (HPEN) SelectObject(hdc, GetStockObject(WHITE_PEN));
+
+  if (AirspaceCircle) {
+    for(i = 0; i < NumberOfAirspaceCircles; i++) {
+      if (AirspaceCircle[i].Visible) {
+        if (bAirspaceBlackOutline) {
+          SelectObject(hdc, GetStockObject(BLACK_PEN));
+        } else {
+          SelectObject(hdc, hAirspacePens[AirspaceCircle[i].Type]);
+        }
+        
+        Circle(hdc,
+               AirspaceCircle[i].Screen.x ,
+               AirspaceCircle[i].Screen.y ,
+               AirspaceCircle[i].ScreenR ,rc, true, false);
+      }
+    }
+  }
+
+  if (AirspaceArea) {
+    for(i = 0; i < NumberOfAirspaceAreas; i++) {
+      if(AirspaceArea[i].Visible) {
+        if (bAirspaceBlackOutline) {
+          SelectObject(hdc, GetStockObject(BLACK_PEN));
+        } else {
+          SelectObject(hdc, hAirspacePens[AirspaceArea[i].Type]);
+        }
+
+        POINT *pstart = AirspaceScreenPoint + AirspaceArea[i].FirstPoint;
+        ClipPolygon(hdc, pstart,
+                    AirspaceArea[i].NumPoints, rc, false);
+        
+        if (AirspaceArea[i].NumPoints>2) {
+          // JMW close if open
+          if ((pstart[0].x != pstart[AirspaceArea[i].NumPoints-1].x) ||
+              (pstart[0].y != pstart[AirspaceArea[i].NumPoints-1].y)) {
+            POINT ps[2];
+            ps[0] = pstart[0];
+            ps[1] = pstart[AirspaceArea[i].NumPoints-1];
+            _Polyline(hdc, ps, 2, rc);
+          }
+        }
+      }
+    }
+  }
+
+  // restore original PEN
+  SelectObject(hdc, hOrigPen);
+} // DrawTptAirSpace()
+
+

--- a/Common/Source/Utils.cpp
+++ b/Common/Source/Utils.cpp
@@ -147,6 +147,8 @@ const TCHAR *szRegistryAirspacePriority[] = {  TEXT("AirspacePriority0"),
 
 const TCHAR szRegistryAirspaceWarning[]= TEXT("AirspaceWarn");
 const TCHAR szRegistryAirspaceBlackOutline[]= TEXT("AirspaceBlackOutline");
+const TCHAR szRegistryAirspaceFillType[]= TEXT("AirspaceFillType");
+const TCHAR szRegistryAirspaceOpacity[]= TEXT("AirspaceOpacity");
 const TCHAR szRegistryAltMargin[]=	   TEXT("AltMargin");
 const TCHAR szRegistryAltMode[]=  TEXT("AltitudeMode");
 const TCHAR szRegistrySafetyAltitudeMode[]=  TEXT("SafetyAltitudeMode");
@@ -706,6 +708,14 @@ void ReadRegistrySettings(void)
       }
 
     }
+
+  Temp = MapWindow::GetAirSpaceFillType();
+  if(GetFromRegistry(szRegistryAirspaceFillType,&Temp) == ERROR_SUCCESS)
+    MapWindow::SetAirSpaceFillType(Temp);
+
+  Temp = MapWindow::GetAirSpaceOpacity();
+  if(GetFromRegistry(szRegistryAirspaceOpacity,&Temp) == ERROR_SUCCESS)
+    MapWindow::SetAirSpaceOpacity(Temp);
 
   Temp = MapWindow::bAirspaceBlackOutline;
   GetFromRegistry(szRegistryAirspaceBlackOutline,&Temp);

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,8 @@ SRC_FILES :=\
 	$(SRC)/LKDrawTraffic.cpp	$(SRC)/LKSimulator.cpp\
 	$(SRC)/LKBestAlternate.cpp \
 	$(SRC)/MapWindow.cpp 		$(SRC)/MapWindow2.cpp \
-	$(SRC)/MapWindow3.cpp 		$(SRC)/Utils2.cpp \
+	$(SRC)/MapWindow3.cpp 		$(SRC)/MapWindowA.cpp \
+	$(SRC)/Utils2.cpp \
 	$(SRC)/McReady.cpp 		$(SRC)/Message.cpp \
 	$(SRC)/NavFunctions.cpp		$(SRC)/OnLineContest.cpp \
 	$(SRC)/Parser.cpp		$(SRC)/Port.cpp \


### PR DESCRIPTION
Alpha blended airspace drawing.
Adds:
- interface into MapWindow (separated MapWindowA.h included directly into MapWindow class, it's in separate file because MapWindow.h is oversized already)
- implementation in MapWindowA.cpp
- configuration items in Airspace System Config for selecting drawing outlines only/patterns/alpha blended color + opacity for alpha blending (including EN help)

Note:
- AlphaBlendInit(), AlphaBlendDestroy(), DoAlphaBlend() are designed to be used for alpha blending of other GUI components (while I'm not sure, that for example making transparent boxes below is a good idea - for decreasing the readability especially on sunlight)
