### PR TITLE
Analysis airspace fix

### DIFF
--- a/Common/Source/Airspace.cpp
+++ b/Common/Source/Airspace.cpp
@@ -2176,10 +2176,8 @@ void ScanAirspaceLine(double *lats, double *lons, double *heights,
     if (!((h_max<=AirspaceCircle[k].Base.Altitude)||
 	  (h_min>=AirspaceCircle[k].Top.Altitude))) {
 
-      // ignore if scan line doesn't intersect bounds
-      if (msRectOverlap(&lineRect, &AirspaceCircle[k].bounds) && 
-	  line_rect_intersection (x1, y1, dx, dy, 
-				  &AirspaceCircle[k].bounds)) {
+      // ignore if scan line doesn't overlap airspace bounds
+      if (msRectOverlap(&lineRect, &AirspaceCircle[k].bounds)) {
 
 	for (i=0; i<AIRSPACE_SCANSIZE_X; i++) {
 	  latitude = lats[i];
@@ -2214,12 +2212,9 @@ void ScanAirspaceLine(double *lats, double *lons, double *heights,
     // ignore if outside scan height
     if (!((h_max<=AirspaceArea[k].Base.Altitude)||
 	  (h_min>=AirspaceArea[k].Top.Altitude))) {
-
-      // ignore if scan line doesn't intersect bounds
-      if (msRectOverlap(&lineRect, &AirspaceArea[k].bounds) && 
-	  line_rect_intersection (x1, y1, dx, dy, 
-				  &AirspaceArea[k].bounds)) {
-
+      
+      // ignore if scan line doesn't overlap airspace bounds
+      if (msRectOverlap(&lineRect, &AirspaceArea[k].bounds) ) {
 	for (i=0; i<AIRSPACE_SCANSIZE_X; i++) {
 	  latitude = lats[i];
 	  longitude = lons[i];


### PR DESCRIPTION
Fix solves following bug: http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=3598

When an aircraft was inside airspace's boundary and the Anlysis dialog airspaces draw line did not cross that boundary (because airspace is too big) the airspace was not printed in the Analysis Airspace dialog. I think removing that check will not hurt at all and all airspaces appeared automagically :-)

Now that Anylysis page will be my the most favorite fly-time Analysis :-)
