### PR TITLE
ON/OFF translation tokens for the usage in dialog windows without abbreviation

### DIFF
--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -961,6 +961,10 @@ _@M956_ "Anti Aliasing"
 # Page 1.5 name, keep short:
 _@M957_ "Contest"
 
+# ON/OFF in dialog windows (not Menu)
+_@M958_ "ON"
+_@M959_ "OFF"
+
 #
 # Paragliding lock/unlock screen feature
 #

--- a/Common/Source/dlgConfiguration.cpp
+++ b/Common/Source/dlgConfiguration.cpp
@@ -1854,8 +1854,8 @@ static void setVariables(void) {
   if (wp) {
     DataFieldEnum* dfe;
     dfe = (DataFieldEnum*)wp->GetDataField();
-	// LKTOKEN  _@M491_ = "OFF" 
-    dfe->addEnumText(gettext(TEXT("_@M491_")));
+	// LKTOKEN  _@M959_ = "OFF" 
+    dfe->addEnumText(gettext(TEXT("_@M959_")));
 	// LKTOKEN  _@M496_ = "ON/Fixed" 
     dfe->addEnumText(gettext(TEXT("_@M496_")));
 	// LKTOKEN  _@M497_ = "ON/Scaled" 
@@ -1996,8 +1996,8 @@ static void setVariables(void) {
   if (wp) {
     DataFieldEnum* dfe;
     dfe = (DataFieldEnum*)wp->GetDataField();
-	// LKTOKEN  _@M491_ = "OFF" 
-    dfe->addEnumText(gettext(TEXT("_@M491_")));
+	// LKTOKEN  _@M959_ = "OFF" 
+    dfe->addEnumText(gettext(TEXT("_@M959_")));
 	// LKTOKEN  _@M393_ = "Line" 
     dfe->addEnumText(gettext(TEXT("_@M393_")));
 	// LKTOKEN  _@M609_ = "Shade" 
@@ -2290,8 +2290,8 @@ static void setVariables(void) {
   if (wp) {
     DataFieldEnum* dfe;
     dfe = (DataFieldEnum*)wp->GetDataField();
-	// LKTOKEN  _@M491_ = "OFF" 
-    dfe->addEnumText(gettext(TEXT("_@M491_")));
+	// LKTOKEN  _@M959_ = "OFF" 
+    dfe->addEnumText(gettext(TEXT("_@M959_")));
 	// LKTOKEN  _@M427_ = "Mark center" 
     dfe->addEnumText(gettext(TEXT("_@M427_")));
 	// LKTOKEN  _@M518_ = "Pan to center" 
@@ -3285,8 +3285,8 @@ static void setVariables(void) {
   if (wp) {
     DataFieldEnum* dfe;
     dfe = (DataFieldEnum*)wp->GetDataField();
-	// LKTOKEN  _@M491_ = "OFF" 
-    dfe->addEnumText(gettext(TEXT("_@M491_")));
+	// LKTOKEN  _@M959_ = "OFF" 
+    dfe->addEnumText(gettext(TEXT("_@M959_")));
     dfe->addEnumText(gettext(TEXT("Flap")));
     dfe->addEnumText(gettext(TEXT("SC")));
     dfe->Set(EnableExternalTriggerCruise);
@@ -3298,10 +3298,10 @@ static void setVariables(void) {
   if (wp) {
     DataFieldEnum* dfe;
     dfe = (DataFieldEnum*)wp->GetDataField();
-	// LKTOKEN  _@M894_ = "ON" 
-    dfe->addEnumText(gettext(TEXT("_@M894_")));
-	// LKTOKEN  _@M491_ = "OFF" 
-    dfe->addEnumText(gettext(TEXT("_@M491_")));
+	// LKTOKEN  _@M958_ = "ON" 
+    dfe->addEnumText(gettext(TEXT("_@M958_")));
+	// LKTOKEN  _@M959_ = "OFF" 
+    dfe->addEnumText(gettext(TEXT("_@M959_")));
     dfe->Set(Appearance.InverseInfoBox);
     wp->RefreshDisplay();
   }

--- a/Common/Source/dlgTools.cpp
+++ b/Common/Source/dlgTools.cpp
@@ -678,7 +678,7 @@ void LoadChildsFromXML(WindowControl *Parent,
         }
         if (_tcsicmp(DataType, TEXT("boolean"))==0){
           W->SetDataField(
-            new DataFieldBoolean(EditFormat, DisplayFmt, false, gettext(TEXT("_@M894_")), gettext(TEXT("_@M491_")), // ON OFF
+            new DataFieldBoolean(EditFormat, DisplayFmt, false, gettext(TEXT("_@M958_")), gettext(TEXT("_@M959_")), // ON OFF
               (DataField::DataAccessCallback_t) CallBackLookup(LookUpTable, OnDataAccess))
           );
         }


### PR DESCRIPTION
Many languages do not have so short words like ON/OFF. A lot of them have longer words and currently LK forces translators to abbreviate them in order to fit them on Menu buttons. The same tokens were reused in dialog windows (like System Setup) and looked there really wrong among other not abbreviated options.
