### PR TITLE
Fixed a problem of 0m obstacle warning

### DIFF
--- a/Common/Source/Calculations.cpp
+++ b/Common/Source/Calculations.cpp
@@ -3503,8 +3503,7 @@ static void CheckGlideThroughTerrain(NMEA_INFO *Basic, DERIVED_INFO *Calculated)
 			 - SAFETYALTITUDETERRAIN;
 
 		// Reminder: we already have a glide range on destination.
-		// start searching for obstacles with a virtual altitude = now+50m
-		minaltitude=CALCULATED_INFO.NavAltitude+50;
+		minaltitude=CALCULATED_INFO.NavAltitude;
 		maxaltitude=minaltitude*2;
 
 		// if no far obstacle will be found, we shall use the first obstacle. 
@@ -3542,7 +3541,7 @@ static void CheckGlideThroughTerrain(NMEA_INFO *Basic, DERIVED_INFO *Calculated)
 		Calculated->FarObstacle_Lon = oldfarlon;
 		Calculated->FarObstacle_Dist = oldfardist;
 		// 0-50m positive rounding
-		Calculated->FarObstacle_AltArriv = -1*(newaltitude-minaltitude);
+		Calculated->FarObstacle_AltArriv = minaltitude - newaltitude;
 
 #endif
 


### PR DESCRIPTION
Until now LK8000 engine could print 0m for a long time as an obstacle
warning printing arrival height in red at the same time. Presented height
should be rounded to the bottom (floor) not top (ceil) of the needed height
difference. See more in Michel post from "20/12/2009 :  13:24:12" on:
http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=3174&whichpage=2&SearchTerms=obstacle%2C0

Adding 50m here caused 2 problems:
1. It increased the altitude for calculations and it was not reverted by
   that 50m before presentation. It was the cause of printing 0m instead of
   -50m.
2. If a glider is from 0-49m too low to pass the obstacle the pilot will
   not be warned because the path will be calculated as reachable in
   FarFinalGlideThroughTerrain().
