### PR TITLE
ALL_BELOW airspaces filtering mode fixed

### DIFF
--- a/Common/Data/Dialogs/dlgConfiguration.LKAIRSPACE.xml
+++ b/Common/Data/Dialogs/dlgConfiguration.LKAIRSPACE.xml
@@ -39,13 +39,13 @@
 <WndButton Name="cmdAirspaceColours"  Caption="_@M189_" X=100 Y=2 Width=70  Height=22 Font=2 OnClickNotify="OnAirspaceColoursClicked" />
 <WndButton Name="cmdAirspaceMode"  Caption="_@M286_" X=170 Y=2 Width=70  Height=22 Font=2 OnClickNotify="OnAirspaceModeClicked" />
 
-<WndProperty Name="prpAirspaceDisplay" Caption="_@M67_" X=2 Y=-1 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H108_">
+<WndProperty Name="prpAirspaceDisplay" Caption="_@M67_" X=2 Y=-1 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H1250_">
 <DataField name="" DataType="enum"  Min=0 Max=50 Step=1 OnDataAccess="OnAirspaceDisplay" />
 </WndProperty>
 <WndProperty Name="prpClipAltitude" Caption="_@M183_"      X=2 Y=-1   Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H109_">
 <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min=0 Max=20000 Step=10/>
 </WndProperty>
-<WndProperty Name="prpAltWarningMargin" Caption="_@M1630_" X=2 Y=-999 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H110_">
+<WndProperty Name="prpAltWarningMargin" Caption="_@M1630_" X=2 Y=-999 Width=-246 Height=22 CaptionWidth=150 Font=2 Help="_@H1251_">
 <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min=0 Max=20000 Step=10/>
 </WndProperty>
 <!-- Moved to new dlgAirspaceWarningParams - this have to be enabled if LKAIRSPACE is not defined!

--- a/Common/Data/Dialogs/dlgConfiguration_L.LKAIRSPACE.xml
+++ b/Common/Data/Dialogs/dlgConfiguration_L.LKAIRSPACE.xml
@@ -39,13 +39,13 @@
 <WndButton Name="cmdAirspaceColours"  Caption="_@M189_" X=72 Y=2 Width=70  Height=22 Font=2 OnClickNotify="OnAirspaceColoursClicked" />
 <WndButton Name="cmdAirspaceMode"  Caption="_@M286_" X=142 Y=2 Width=70  Height=22 Font=2 OnClickNotify="OnAirspaceModeClicked" />
 
-<WndProperty Name="prpAirspaceDisplay" Caption="_@M67_" X=2 Y=-1  Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H108_">
+<WndProperty Name="prpAirspaceDisplay" Caption="_@M67_" X=2 Y=-1  Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H1250_">
 <DataField name="" DataType="enum"  Min=0 Max=50 Step=1 OnDataAccess="OnAirspaceDisplay"/>
 </WndProperty>
 <WndProperty Name="prpClipAltitude" Caption="_@M183_" X=2 Y=-1 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H109_">
 <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min=0 Max=20000 Step=10/>
 </WndProperty>
-<WndProperty Name="prpAltWarningMargin" Caption="_@M1630_" X=2 Y=-999 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H110_">
+<WndProperty Name="prpAltWarningMargin" Caption="_@M1630_" X=2 Y=-999 Width=235 Height=22 CaptionWidth=150 Font=2 Help="_@H1251_">
 <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min=0 Max=20000 Step=10/>
 </WndProperty>
 <!-- Moved to new dlgAirspaceWarningParams - this have to be enabled if LKAIRSPACE is not defined!

--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -43,6 +43,7 @@ The file name of the secondary airspace file.
 For each airfield, you can add additional informations inside this file located in _Waypoints subdirectory.
 Here you can change this default file name to something else.
 
+# 108 OBSOLETED BY 1250 in 2.3
 @108
 Controls filtering of airspace for display and warnings.  The airspace filter button also allows filtering of display and warnings independently for each airspace class.
 [All on] All is displayed.
@@ -53,6 +54,7 @@ Controls filtering of airspace for display and warnings.  The airspace filter bu
 @109
 For clip airspace mode, this is the altitude below which airspace is displayed.
 
+# 110 OBSOLETED BY 1251 in 2.3
 @110
 For auto airspace mode, this is the altitude above/below which airspace is included.
 
@@ -1532,7 +1534,15 @@ Enable or disable each page in the rotating sequence.
 If all items in a page are disabled, then this page will be skipped.
 A page will be still reachable with a custom keys, eventually.
 
+@1250
+Controls filtering of airspace for display and warnings.  The airspace filter button also allows filtering of display and warnings independently for each airspace class.
+[All on] All is displayed.
+[Clip] Only airspace below the clip altitude.
+[Auto] All within a height margin of the glider.
+[All below] All airspace below the glider and within height margin above.
+
+@1251
+Height margin used to control airspace display filtering on the moving map used only in AUTO and ALL BELOW modes. For AUTO it determines the height above and below the glider for which airspaces should be shown. ALL BELLOW mode will show airspaces up to specified height above the glider and all airspaces below it.
+
 @9999
 No help available on this item!
-
-

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -1510,7 +1510,7 @@ _@M1620_ "3.1 COMN "
 _@M1621_ "3.2 HIST "
 
 # New airspace messages
-_@M1630_ "Auto Margin "
+_@M1630_ "Height margin "
 
 
 

--- a/Common/Source/dlgConfiguration.cpp
+++ b/Common/Source/dlgConfiguration.cpp
@@ -534,7 +534,7 @@ static void OnAirspaceDisplay(DataField *Sender, DataField::DataAccessKind_t Mod
       wp = (WndProperty*)wf->FindByName(TEXT("prpClipAltitude"));
       if (wp) wp->SetVisible(altmode==CLIP);
       wp = (WndProperty*)wf->FindByName(TEXT("prpAltWarningMargin"));
-      if (wp) wp->SetVisible(altmode==AUTO);
+      if (wp) wp->SetVisible(altmode==AUTO || altmode==ALLBELOW);
     break;
 	default: 
 		StartupStore(_T("........... DBG-908%s"),NEWLINE); 


### PR DESCRIPTION
ALL_BELOW airspaces filtering mode includes height margin in calculations so GUI should not disable it. Help files updated to better describe the feature.
