### PR TITLE
Close the handles returned from CreateProcess()

### DIFF
--- a/Common/Source/InputEvents.cpp
+++ b/Common/Source/InputEvents.cpp
@@ -2524,6 +2524,8 @@ void InputEvents::eventRun(const TCHAR *misc) {
   }
 
   ::WaitForSingleObject(pi.hProcess, INFINITE);
+  ::CloseHandle(pi.hProcess);
+  ::CloseHandle(pi.hThread);
   StartupStore(_T("... RUN TERMINATED%s"),NEWLINE);
 }
 

--- a/Common/Source/LKUtils.cpp
+++ b/Common/Source/LKUtils.cpp
@@ -342,6 +342,8 @@ bool LKRun(const TCHAR *prog, const int runmode, const DWORD dwaitime) {
 		return false;
 	}
 	::WaitForSingleObject(pi.hProcess, dwaitime);
+	::CloseHandle(pi.hProcess);
+	::CloseHandle(pi.hThread);
 	StartupStore(_T(". LKRun exec terminated%s"),NEWLINE);
 	return true;
   }


### PR DESCRIPTION
MSDN says: "Handles in PROCESS_INFORMATION must be closed with
CloseHandle when they are no longer needed."
