### PR TITLE
OLC fixed for long LK suspend

### DIFF
--- a/Common/Source/Trace.cpp
+++ b/Common/Source/Trace.cpp
@@ -87,24 +87,30 @@ void CTrace::Push(CPoint *point)
       delete _front;
       _size--;
       
-      CPointCostSet::iterator nextIt = _compressionCostSet.find(next);
-      if(nextIt == _compressionCostSet.end()) {
+      if(next != _back) {
+        // _back and _front are not stored in a _compressionCostSet so skip below actions when next == _back
+        CPointCostSet::iterator nextIt = _compressionCostSet.find(next);
+        if(nextIt == _compressionCostSet.end()) {
 #ifndef TEST_CONTEST
-	if (warnings>=0) {
-          StartupStore(_T("%s:%u - ERROR: next not found!!\n"), _T(__FILE__), __LINE__);
-	  warnings--;
-        }
+          if (warnings>=0) {
+            StartupStore(_T("%s:%u - ERROR: next not found!!\n"), _T(__FILE__), __LINE__);
+            warnings--;
+          }
 #endif
-        _valid = false;
-        return;
+          _valid = false;
+        }
+        _compressionCostSet.erase(nextIt);
       }
-      _compressionCostSet.erase(nextIt);
       
       _front = next;
       _front->_prevDistance = 0;
       _front->_distanceCost = 0;
       _front->_timeCost = 0;
       _front->_prev = 0;
+      
+      if(!_valid)
+        // interrupt further operations
+        return;
     }
   }
   


### PR DESCRIPTION
That should help a bit. Code did not assume that 2 consequitive GPS fixes can come in time longer than 2,5 hours.
