### PR TITLE
Handle missing space in airspace file parser (V sentence)

### DIFF
--- a/Common/Source/LKAirspace.cpp
+++ b/Common/Source/LKAirspace.cpp
@@ -1520,7 +1520,8 @@ void CAirspaceManager::FillAirspacesFromOpenAir(ZZIP_FILE *fp)
         break;
       
       case _T('V'):
-        p++; p++; //skip V and space
+        p++; //skip V
+        if (*p==' ') p++;   //skip space if present
         if(StartsWith(p, TEXT("X="))) {
             if (ReadCoords(p+2,&CenterX, &CenterY))
               break;


### PR DESCRIPTION
Officially released airspace files contains V sentences
with no space beetween V and X characters. After this patch airspace parser can read that files too.
