### PR TITLE
lkm topology labels can be encoded in UTF8

### DIFF
--- a/Common/Source/Topology.cpp
+++ b/Common/Source/Topology.cpp
@@ -693,7 +693,8 @@ bool XShapeLabel::renderSpecial(HDC hDC, int x, int y, bool retval) {
   if (label && ((MapWindow::DeclutterLabels==MAPLABELS_ALLON)||(MapWindow::DeclutterLabels==MAPLABELS_ONLYTOPO))) {
 
 	TCHAR Temp[100];
-	int size = MultiByteToWideChar(CP_ACP, 0, label, -1, Temp, 100) - 1;			//ANSI to UNICODE
+  int size = utf2unicode(label, Temp, 100);
+    
 	if (size <= 0) return false;													//Do not waste time with null labels
 
 	SetBkMode(hDC,TRANSPARENT);


### PR DESCRIPTION
Hi Paolo,
I've made simple change allowing LKM topo labels to be in UTF8.
It's fully backward compatible - i.e. current LKM (ASCII labels) are working with no changes. Now there can be national characters in labels (I have such manually changed maps).
