### PR TITLE
Fix DeadLock

### DIFF
--- a/Common/Header/lk8000.h
+++ b/Common/Header/lk8000.h
@@ -17,6 +17,8 @@ typedef struct _DATAOPTIONS
   TCHAR Title[TITLE_SIZE + 1];
 } DATAOPTIONS;
 
+extern void LockStartupStore();
+extern void UnlockStartupStore();
 
 extern void UnlockEventQueue();
 extern void LockEventQueue();

--- a/Common/Source/Locking.cpp
+++ b/Common/Source/Locking.cpp
@@ -22,6 +22,10 @@ CRITICAL_SECTION  CritSec_TaskData;
 bool csTaskDataInitialized = false;
 
 
+CRITICAL_SECTION  CritSec_StartupStore;
+bool csStartupStoreInitialized = false;
+
+
 static int csCount_TaskData = 0;
 static int csCount_FlightData = 0;
 static int csCount_EventQueue = 0;
@@ -42,6 +46,8 @@ void InitCriticalSections() {
   InitializeCriticalSection(&CritSec_TerrainDataCalculations);
   csTerrainDataCalculationsInitialized = true;
 
+  InitializeCriticalSection(&CritSec_StartupStore);
+  csStartupStoreInitialized = true;
 }
 
 void DeInitCriticalSections() {
@@ -59,6 +65,8 @@ void DeInitCriticalSections() {
   DeleteCriticalSection(&CritSec_TerrainDataGraphics);
   csTerrainDataCalculationsInitialized = false;
 
+  DeleteCriticalSection(&CritSec_StartupStore);
+  csStartupStoreInitialized = false;
 }
 
 
@@ -171,4 +179,15 @@ void UnlockEventQueue() {
   LeaveCriticalSection(&CritSec_EventQueue);
 }
 
+void LockStartupStore() {
+	if (csStartupStoreInitialized)	{
+		EnterCriticalSection(&CritSec_StartupStore);
+	}
+}
+
+void UnlockStartupStore() {
+	if (csStartupStoreInitialized)	{
+		LeaveCriticalSection(&CritSec_StartupStore);
+	}
+}
 

--- a/Common/Source/MessageLog.cpp
+++ b/Common/Source/MessageLog.cpp
@@ -107,7 +107,7 @@ void StartupStore(const TCHAR *Str, ...)
   _vstprintf(buf, Str, ap);
   va_end(ap);
 
-  CheckAndLockFlightData();
+  LockStartupStore();
 
   FILE *startupStoreFile = NULL;
   static TCHAR szFileName[MAX_PATH];
@@ -131,6 +131,6 @@ void StartupStore(const TCHAR *Str, ...)
     }
     fclose(startupStoreFile);
   }
-  CheckAndUnlockFlightData();
+  UnlockStartupStore();
 }
 


### PR DESCRIPTION
two different resource (GPS_INFO & startupStoreFile) use same critical section -> DeadLock

Detected In this Case :

```
First Thread Call Graph

     MapWindow::DrawThread()
         MapWindow::UpdateInfo
              LockFlightData()                         ------> this is Loked Second
                  MapWindow::Zoom::UpdateMapScale()
                      MapWindow::Zoom::CalculateAutoZoom()
                          LockTaskData()                                   -------> Dead Lock*
                          UnLockTaskData()

Second Thread Call Graph

    CalculationThread()
         DoCalculationsSlow()
                DoRangeWaypointList()
                    LockTaskData()                 ------> this is Loked First
                        StartupStore()
                            LockFlightData()          ------> Deadlock
                            UnlockLockFlightData()
                    UnLockTaskData()
```

for avoiding dead lock, two rules must be respected:

```
1. each shared resource must be owner of her lock
2. access the shared resource always in the same order
```
