### PR TITLE
Fix: Flying below or above NOFLY ASP zones causes the yellow warning to ...

### DIFF
--- a/Common/Source/LKAirspace.cpp
+++ b/Common/Source/LKAirspace.cpp
@@ -500,7 +500,7 @@ bool CAirspace::FinishWarning()
         
       // Events for NON-FLY zones
       case aweMovingOutsideNonfly:
-        if ( (abs_hdistance > (_hdistancemargin + hdistance_histeresis)) ||
+        if ( (_hdistance > (_hdistancemargin + hdistance_histeresis)) ||
              (!IsAltitudeInside(_lastknownalt, _lastknownagl, AirspaceWarningVerticalMargin + vdistance_histeresis))
           ) {
             // Far away horizontally _or_ vertically


### PR DESCRIPTION
...disappear

http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=5868
