### PR TITLE
Infamous "postWorst not found!!" problem in case of bad GPS signal fixed

### DIFF
--- a/Common/Header/PointGPS.h
+++ b/Common/Header/PointGPS.h
@@ -18,7 +18,6 @@
  * provides basic operations on GPS fixes.
  */
 class CPointGPS : public CPoint3D {
-  static const unsigned MAX_TIME_DELTA = 16 * 3600; // 16h
   unsigned _time;
   
 public:
@@ -47,12 +46,7 @@ typedef std::vector<CPointGPS> CPointGPSArray;
  */
 inline int CPointGPS::TimeDelta(unsigned ref) const
 {
-  int delta = _time - ref;
-  if(delta < 0) {
-    if(delta < -(int)(DAY_SECONDS - MAX_TIME_DELTA))
-      delta += DAY_SECONDS;
-  }
-  return delta;
+  return _time - ref;
 }
 
 


### PR DESCRIPTION
Verified with pausing a Condor for some time and then resuming the simulation. Also checked that passing 00:00 UTC does not produce any OLC specific errors in RUNTIMIE.LOG.
