### PR TITLE
Fix infoboxes and nearest asp if no nearest asp

### DIFF
--- a/Common/Source/LKAirspace.cpp
+++ b/Common/Source/LKAirspace.cpp
@@ -2097,7 +2097,6 @@ void CAirspaceManager::AirspaceWarning(NMEA_INFO *Basic, DERIVED_INFO *Calculate
   CCriticalSection::CGuard guard(_csairspaces);
   CAirspaceList::iterator it;
 
-  if ( _airspaces_near.size() == 0 ) return;
    // We need a valid GPS fix in FLY mode
    if (Basic->NAVWarning && !SIMMODE) return;
   


### PR DESCRIPTION
If you have no more nearest airspace because for example you disabled in
configuration all airspaces, or you changed position in SIM very far away,
we still get the old values because they are no more calculated.
This fix enables distance calculation on selected asp or
clears infoboxes if there is no selected asp.
