### PR TITLE
bug fix: vanishing trail points in circling zoom with trail drift on

### DIFF
--- a/Common/Source/Draw/LKDrawTrail.cpp
+++ b/Common/Source/Draw/LKDrawTrail.cpp
@@ -15,7 +15,7 @@ using std::max;
 
 // #define SKIPPOINTS 1		// skip closer points for drawing, causing flashing
 
-//#define TRAIL_DRIFT_FIX 1
+#define TRAIL_DRIFT_FIX 1
 //      Attempts to fix bug that caused trail points to disappear
 //      (more so in stronger winds and when more zoomed in) while
 //      in circling zoom with “trail drift” on.


### PR DESCRIPTION
This attempts to fix a bug that caused trail points to disappear in circling zoom with trail drift on (more a problem with stronger winds and when more zoomed in).  I'm not set up to compile a PNA EXE (and sim mode doesn't allow wind, I guess), so I can't confirm that this fixed the problem.  If someone wants to compile a PNA EXE with this change and send it to me, I'll test to confirm the fix.  Thanks, Eric
