### PR TITLE
remove TriggerGPSUpdate() for LKext1 device 

### DIFF
--- a/Common/Source/Devices/devLKext1.cpp
+++ b/Common/Source/Devices/devLKext1.cpp
@@ -167,8 +167,7 @@ static BOOL LK8EX1(PDeviceDescriptor_t d, TCHAR *String, NMEA_INFO *GPS_INFO)
 
 
   // currently unused in LK, but ready for next future
-  // TriggerVarioUpdate();
-  TriggerGPSUpdate();
+  TriggerVarioUpdate();
 
   return TRUE;
 }


### PR DESCRIPTION
prevent the sofware slowdown if more than one NMEA frame / second
