### PR TITLE
don't show just-disabled bottom bar

### DIFF
--- a/Common/Source/Dialogs/dlgBottomBar.cpp
+++ b/Common/Source/Dialogs/dlgBottomBar.cpp
@@ -6,6 +6,8 @@
    $Id: dlgBottomBar.cpp,v 1.1 2011/12/21 10:29:29 root Exp root $
 */
 
+#define BB_AUTO_ADV // auto-advance BB if active BB gets disabled
+
 #include "externs.h"
 #include "LKProfiles.h"
 #include <aygshell.h>
@@ -17,6 +19,9 @@
 
 #include "Utils.h"
 
+#ifdef BB_AUTO_ADV
+#include "LKInterface.h"
+#endif
 
 static bool changed = false;
 static WndForm *wf=NULL;
@@ -214,6 +219,11 @@ void dlgBottomBarShowModal(void){
                  gettext(TEXT("_@M1607_")), // bottom bar config saved
                  TEXT(""), MB_OK);
 
+    #ifdef BB_AUTO_ADV
+    // If the user just disabled the currently-shown BB stripe, then
+    // automatically advance to the next enabled stripe.
+    if (!ConfBB[BottomMode]) BottomBarChange(true);
+    #endif
   }
 
 


### PR DESCRIPTION
This is a very simple change I mentioned March 7  and April 4 in a forum topic (http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=5583) on a related subject.  You didn’t respond, so I’m not sure you’ve considered this change.  Here it is, though.  Take it if you like it.  It simply “auto-advances” to the next enabled bottom bar, if you disable the currently-selected bottom bar – eliminating the possible confusion caused by returning to the map screen and still seeing the bottom bar you just disabled.

Eric
