### PR TITLE
prevent climb mode when on tow

### DIFF
--- a/Common/Header/options.h
+++ b/Common/Header/options.h
@@ -92,6 +92,9 @@
  //#define NEWSMARTZOOM		1	// stretch bitmap for fast zoom, uncompleted work (almost working)
  //#define USEBIGZOOM		1	// will fast redraw only terrain, with no topology &c.
 
+#define TOW_CRUISE // keep climb mode from engaging while on tow (unless turning steeply
+                   // enough to warrant detection of the start of free flight)
+                   // Eric Carden, 6/28/12
 
 
 /*

--- a/Common/Source/Calc/FreeFlight.cpp
+++ b/Common/Source/Calc/FreeFlight.cpp
@@ -34,6 +34,7 @@
 #define FF_MAXTOWTIME	1200			// 20 minutes
 
 
+
 bool DetectFreeFlying(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
 
   static bool   ffDetected=false;
@@ -139,10 +140,29 @@ bool DetectFreeFlying(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
     goto lastcheck;
   }
 
+#ifdef TOW_CRUISE
+  // If circling, we assume that we're in free flight and use the
+  // start-of-circling time and position.  Turning.cpp makes sure
+  // we aren't circling while on tow by imposing a 12 deg/sec turn
+  // rate limit for on-tow turning.
+#else
   // If circling we assume that we are in free flight already, using the start of circling time and position.
   // But we must be sure that we are not circling.. while towed. A 12 deg/sec turn rate will make it quite sure.
   // Of course nobody can circle while winchlaunched, so in this case FF is immediately detected.
+#endif
+
+#ifdef TOW_CRUISE
+  // The 12 deg/sec check is now done in Turning.cpp, so there's no
+  // need to do it here, too.  Doing it here, too, could allow the
+  // possibility of climb mode engaging without FF detection, if the
+  // climb rate goes above 12 deg/sec for just a split second.
+  //if (Calculated->Circling && (winchdetected ||
+  //   (fabs(Calculated->TurnRate) >= 12))) {
+
+  if (Calculated->Circling) {
+#else
   if (Calculated->Circling && ( winchdetected || ( fabs(Calculated->TurnRate) >=12 ) ) ) {
+#endif
 
     if (UseContestEngine()) {
       CContestMgr::Instance().Add(new CPointGPS(static_cast<unsigned>(Calculated->ClimbStartTime),

--- a/Common/Source/Calc/Turning.cpp
+++ b/Common/Source/Calc/Turning.cpp
@@ -32,6 +32,7 @@ extern void ThermalBand(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 #define CLIMB 2
 #define WAITCRUISE 3
 
+
 extern WindAnalyser *windanalyser;
 extern ThermalLocator thermallocator;
 
@@ -198,7 +199,17 @@ _forcereset:
       // WE CANNOT do this, because we also may need Circling mode to detect FF!!
       // if( (Calculated->FreeFlying && ((Basic->Time  - StartTime) > CruiseClimbSwitch))|| forcecircling) {
        if( (!ISCAR && !ISGAAIRCRAFT && ((Basic->Time  - StartTime) > CruiseClimbSwitch))|| forcecircling) { 
-        Calculated->Circling = TRUE;
+
+         #ifdef TOW_CRUISE
+         // If free flight (FF) hasn’t yet been detected, then we may
+         // still be on tow.  The following prevents climb mode from
+         // engaging due to normal on-aerotow turns.
+
+         if (!Calculated->FreeFlying && (fabs(Calculated->TurnRate) < 12))
+           break;
+         #endif
+
+       Calculated->Circling = TRUE;
         // JMW Transition to climb
         MODE = CLIMB;
 	// Probably a replay flight, with fast forward with no cruise init


### PR DESCRIPTION
This change fixes the issue discussed in this forum topic: http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=6425.  The issue was that LK allowed climb mode to engage during an aerotow when turning at a rate low enough to not trigger the start of free flight.  This change makes it so that climb mode only engages on aerotow when the turn rate is high enough to trigger the start of free flight.  In the above forum topic, you (Paolo) asked that I push this for you to examine.
