### PR TITLE
NavFunctions: Use precise formula in FindLatitudeLongitude()

### DIFF
--- a/Common/Source/Library/NavFunctions.cpp
+++ b/Common/Source/Library/NavFunctions.cpp
@@ -173,8 +173,8 @@ void FindLatitudeLongitude(double Lat, double Lon,
     if(cosLat==0)
       result = Lon;
     else {
-      result = Lon+(double)asin(sin(Bearing)*sinDistance/cosLat);
-      result = (double)fmod((result+M_PI),(M_2PI));
+      result = (double)atan2(sin(Bearing)*sinDistance*cosLat,cos(Distance)-sin(Lat)*sin(*lat_out));
+      result = (double)fmod((Lon-result+M_PI),(M_2PI));
       result = result - M_PI;
     }
     result *= RAD_TO_DEG;


### PR DESCRIPTION
The previously used formula is an approximation for dlon < pi/2. Tests have
shown though that this approximation is returning much larger errors than
acceptable.

Example: FindLatitudeLongitude(51 N 7 W, 135 deg, 50 km) returns a point
that is about 50.186 km away. Using the more precise formula fixes this
problem and returns a point that is exactly 50.000 km away.

This is relevant for the AirspaceParser that uses this function to convert
arcs into polygons.

see http://williams.best.vwh.net/avform.htm#LL
