### PR TITLE
add optional glide footprint around active WP

### DIFF
--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -416,14 +416,14 @@ Draw overlay values on moving map.
 [Full mode] will add also left overlays values and the clock, if enabled. See the manual.
 
 @194
-This determines whether the the glide terrain range is calculated and drawn as a line on the map area:
-[OFF] Disables display
+This determines whether the glide range is shown on the map:
+[OFF] Not shown
 [Line] Draws a dashed line at the glide range
-[Shade] Shades terrain outside glide range
-When glide terrain is shown, a RED CROSS will appear if the current destination is reachable in terms of glide ratio, but unreachable because of an obstacle. 
-The obstacle is indicated together with a boxed value, which is the altitude you need to gain to pass the obstacle. 
-This altitude takes into account the terrain safety margin you have configured in safety menu.
-NOTICE: Glide terrain SHADE is shown ONLY during flight. When on ground, it is NOT displayed.
+[Shade] Shades terrain outside glide range (only during flight, not when on ground)
+[...+NextWP] Also shows glide range from active waypoint (WP) given current predicted arrival altitude at WP
+With any choice but "OFF", a red "X" will appear if the current destination is reachable in terms of glide ratio, but unreachable because of an obstacle.
+By the red "X" is shown the altitude you must gain to clear the obstacle.
+This altitude takes into account the terrain safety margin configured in safety menu.
 
 # 195 UNUSED SINCE 2.4
 @195

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -1,4 +1,4 @@
-# LK8000 ENGLISH MESSAGES - ENG_MSG.TXT
+﻿# LK8000 ENGLISH MESSAGES - ENG_MSG.TXT
 # MASTER UPDATED:  120312
 #
 # This file is loaded on startup and all messages are stored internally.
@@ -107,13 +107,17 @@ _@M91_ "Always use safety MC"
 _@M92_ "Amber"
 _@M93_ "Analysis"
 # 94 REMOVED after v2.3
-_@M94_ "Animation"
+# _@M94_ "Animation"
+# 94 reused for next-WP glide terrain line
+_@M94_ "Line+NextWP"
 _@M95_ "Append to task"
 _@M96_ "Arm start"
 _@M97_ "Arm"
 _@M98_ "ArrivalAltitude"
 # 99 REMOVED after v2.3
-_@M99_ "Arrow head"
+#_@M99_ "Arrow head"
+# 99 reused for next-WP glide terrain line
+_@M99_ "Shade+NextWP"
 _@M100_ "Ask"
 _@M101_ "Assigned task time"
 _@M102_ "Auto Advance: ARMED"
@@ -343,7 +347,7 @@ _@M322_ "Geoid Altitude "
 _@M323_ "Ghost "
 _@M324_ "Glide Bar indicator "
 _@M325_ "Glide Polar"
-_@M326_ "Glide terrain line "
+_@M326_ "Glide Terrain Line "
 _@M327_ "Glider position "
 _@M328_ "Glider"
 _@M329_ "Goto Home"

--- a/Common/Data/Language/ToDo.TXT
+++ b/Common/Data/Language/ToDo.TXT
@@ -33,6 +33,7 @@ Things to be fixed in LK languages files/tokens:
 - Changed HELP 199 FLarm on Map
 - New H1213 pg autozoom threshold
 - New help 916 -> 924
+- Changed help 194.  Only significant change was addition of description of new [...+NextWP] options.  Other changes were too minor to require translation.
 
   NEW MSG TOKENS
   --------------
@@ -55,6 +56,7 @@ Things to be fixed in LK languages files/tokens:
 - _@M1761 ..  new infoboxes
 - _@M1693 ..  new infoboxes
 - _@M1774 ..  new infoboxes
+- _@M94_ & _@M99_ ..  new [...+NextWP] glide terrain line options
 
   MENU files to be checked and translated?
 

--- a/Common/Header/Calculations.h
+++ b/Common/Header/Calculations.h
@@ -240,6 +240,9 @@ typedef struct _DERIVED_INFO
 } DERIVED_INFO;
 
 
+#ifdef GTL2
+void DoAlternates(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int AltWaypoint);
+#endif
 int DoCalculations(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 int DoCalculationsVario(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 void DoCalculationsSlow(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
@@ -328,7 +331,14 @@ bool ValidStartSpeed(NMEA_INFO *Basic, DERIVED_INFO *Calculated, DWORD Margin);
 void InsertThermalHistory(double ThTime,  double ThLat, double ThLon, double ThBase,double ThTop, double ThAvg);
 void InitThermalHistory(void);
 
+#ifdef GTL2
+double FinalGlideThroughTerrain(const double bearing,
+                                const double start_lat,
+                                const double start_lon,
+                                const double start_alt,
+#else
 double FinalGlideThroughTerrain(const double bearing, NMEA_INFO *Basic, 
+#endif
                                 DERIVED_INFO *Calculated,
                                 double *retlat, double *retlon,
                                 const double maxrange,

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -840,6 +840,10 @@
 #define CURTYPE ModeType[ModeIndex]
 #define INVERTCOLORS  (Appearance.InverseInfoBox)
 #define TASKINDEX       Task[ActiveWayPoint].Index
+#ifdef GTL2
+#define ACTIVE_WP_IS_AAT_AREA (AATEnabled && (ActiveWayPoint > 0) \
+                              && ValidTaskPoint(ActiveWayPoint + 1))
+#endif
 
 #define DONTDRAWTHEMAP !MapWindow::mode.AnyPan()&&MapSpaceMode!=MSM_MAP
 #define MAPMODE8000    !MapWindow::mode.AnyPan()&&MapSpaceMode==MSM_MAP

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -41,6 +41,10 @@
   extern void Globals_Init(void);
 #endif
 
+#ifdef GTL2
+GEXTERN pointObj GlideFootPrint2[NUMTERRAINSWEEPS+1];
+#endif
+
 GEXTERN bool MenuActive GEXTFALSE;
 GEXTERN HANDLE dataTriggerEvent;
 

--- a/Common/Header/MapWindow.h
+++ b/Common/Header/MapWindow.h
@@ -381,6 +381,12 @@ class MapWindow {
   static void DrawDashLine(HDC , const int , const POINT , const POINT , 
 			   const COLORREF , 
 			   const RECT rc);
+
+  #ifdef GTL2
+  static void DrawDashPoly(HDC hdc, const int width, const COLORREF color,
+                           POINT* pt, const int npoints, const RECT rc);
+  #endif
+
   /* Not used
   static void DrawDotLine(HDC, const POINT , const POINT , const COLORREF , 
 			  const RECT rc);
@@ -609,6 +615,9 @@ class MapWindow {
   static      HPEN hpMapScale2;
   static      HPEN hpTerrainLine;
   static      HPEN hpTerrainLineBg;
+#ifdef GTL2
+  static      HPEN hpTerrainLine2Bg; // for next-WP glide terrain line
+#endif
   static      HPEN hpVisualGlideLightRed; // VENTA3
   static      HPEN hpVisualGlideHeavyRed; // 
   static      HPEN hpVisualGlideLightBlack; // VENTA3
@@ -704,6 +713,9 @@ private:
   static void CalculateOrientationNormal(void);
 
   static POINT Groundline[NUMTERRAINSWEEPS+1];
+#ifdef GTL2
+  static POINT Groundline2[NUMTERRAINSWEEPS+1];
+#endif
 
   static bool targetMoved;
   static double targetMovedLat;

--- a/Common/Header/options.h
+++ b/Common/Header/options.h
@@ -95,6 +95,10 @@
  //#define TOW_CRUISE // keep climb mode from engaging while on tow (unless turning steeply
                       // enough to warrant detection of the start of free flight)
                       // Eric Carden, 6/28/12
+#define GTL2 // Draws a glide terrain line around the next (active) task waypoint.
+             // Includes addition of MSG tokens "Line+NextWP" & "Shade+NextWP"
+             // and change in HELP message 194 (for "Glide Terrain Line" setting).
+             // Eric Carden, September 13, 2012
 
  // Modify best cruise track calculation to assume goal arrival
  // altitude of safety altitude (not current flight altitude).

--- a/Common/Source/Calc/BestAlternate.cpp
+++ b/Common/Source/Calc/BestAlternate.cpp
@@ -173,7 +173,12 @@ void SearchBestAlternate(NMEA_INFO *Basic,
 				WayPointCalc[sortApproxIndex[i]].Bearing = wp_bearing;
             
 				bool out_of_range;
+			#ifdef GTL2
+				double distance_soarable = FinalGlideThroughTerrain(wp_bearing, Basic->Latitude,
+					Basic->Longitude, Calculated->NavAltitude, Calculated,
+			#else
 				double distance_soarable = FinalGlideThroughTerrain(wp_bearing, Basic, Calculated,
+			#endif
 					NULL, NULL, wp_distance, &out_of_range, NULL);
             
 				if ((distance_soarable>= wp_distance)||(arrival_altitude<0)) {

--- a/Common/Source/Calc/DoAlternates.cpp
+++ b/Common/Source/Calc/DoAlternates.cpp
@@ -7,6 +7,9 @@
 */
 
 #include "externs.h"
+#ifdef GTL2
+#include "Waypointparser.h"
+#endif
 
 
 /*
@@ -14,6 +17,18 @@
  * Colors VGR are used by DrawNearest &c.
  */
 void DoAlternates(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int AltWaypoint) {
+
+  #ifdef GTL2
+  // If flying an AAT and working on the RESWP_OPTIMIZED waypoint, then use
+  // this "optimized" waypoint to store data for the AAT virtual waypoint.
+
+  if ((AltWaypoint == RESWP_OPTIMIZED) && 
+    (!ISPARAGLIDER || (AATEnabled && !DoOptimizeRoute()))) {
+    WayPointList[AltWaypoint].Latitude  = Task[ActiveWayPoint].AATTargetLat;
+    WayPointList[AltWaypoint].Longitude = Task[ActiveWayPoint].AATTargetLon;
+    WaypointAltitudeFromTerrain(&WayPointList[AltWaypoint]);
+  }
+  #endif
 
   // handle virtual wps as alternates
   if (AltWaypoint<=RESWP_END) {
@@ -36,7 +51,7 @@ void DoAlternates(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int AltWaypoint) {
   // We need to calculate arrival also for BestAlternate, since the last "reachable" could be
   // even 60 seconds old and things may have changed drastically
   *altwp_arrival = CalculateWaypointArrivalAltitude(Basic, Calculated, AltWaypoint);
-
+  
   WayPointCalc[AltWaypoint].VGR = GetVisualGlideRatio(*altwp_arrival, *altwp_gr);
 } 
 

--- a/Common/Source/Calc/DoCalculations.cpp
+++ b/Common/Source/Calc/DoCalculations.cpp
@@ -34,7 +34,9 @@ extern double CalculateLDRotary(ldrotary_s *buf, DERIVED_INFO *Calculated);
 extern void AverageThermal(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 extern void Turning(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 extern void ConditionMonitorsUpdate(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
+#ifndef GTL2
 extern void DoAlternates(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int AltWaypoint); // VENTA3
+#endif
 extern void DistanceToHome(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 extern bool FlightTimes(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
 extern void AverageClimbRate(NMEA_INFO *Basic, DERIVED_INFO *Calculated);
@@ -72,12 +74,27 @@ BOOL DoCalculations(NMEA_INFO *Basic, DERIVED_INFO *Calculated)
 	DoAlternates(Basic,Calculated,RESWP_TEAMMATE);
 	DoAlternates(Basic,Calculated,RESWP_FLARMTARGET);
 	DoAlternates(Basic,Calculated,HomeWaypoint); 	
+	#ifdef GTL2
+	if (DoOptimizeRoute() || ACTIVE_WP_IS_AAT_AREA)
+		DoAlternates(Basic, Calculated, RESWP_OPTIMIZED);
+	#else
 	if (DoOptimizeRoute()) DoAlternates(Basic,Calculated,RESWP_OPTIMIZED); 	
+	#endif
 	for (int i=RESWP_FIRST_MARKER; i<=RESWP_LAST_MARKER; i++) {
 		if (WayPointList[i].Latitude==RESWP_INVALIDNUMBER) continue;
 		DoAlternates(Basic,Calculated,i);
 	}
+  #ifndef GTL2
   }
+  #else
+  } else {
+    // The following is needed only for the next-WP glide terrain line,
+    // not for the main/primary glide terrain line.
+
+    if ((FinalGlideTerrain > 2) && (DoOptimizeRoute() || ACTIVE_WP_IS_AAT_AREA))
+      DoAlternates(Basic, Calculated, RESWP_OPTIMIZED);
+  }
+  #endif
 
   if (!TargetDialogOpen) {
     // don't calculate these if optimise function being invoked or

--- a/Common/Source/Calc/DoCommon.cpp
+++ b/Common/Source/Calc/DoCommon.cpp
@@ -11,7 +11,9 @@
 
 
 extern void InsertCommonList(int newwp);
+#ifndef GTL2
 extern void DoAlternates(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int AltWaypoint);
+#endif
 
 
 

--- a/Common/Source/Calc/DoRecent.cpp
+++ b/Common/Source/Calc/DoRecent.cpp
@@ -8,7 +8,9 @@
 
 #include "externs.h"
 
+#ifndef GTL2
 extern void DoAlternates(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int AltWaypoint);
+#endif
 
 
 // Load and save the recent list

--- a/Common/Source/Calc/GlideThroughTerrain.cpp
+++ b/Common/Source/Calc/GlideThroughTerrain.cpp
@@ -36,7 +36,12 @@ void CheckGlideThroughTerrain(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
 	}
 
 	distance_soarable = 
+	#ifdef GTL2
+		FinalGlideThroughTerrain(Calculated->WaypointBearing, Basic->Latitude,
+                Basic->Longitude, Calculated->NavAltitude, Calculated, &lat, &lon, 
+	#else
 		FinalGlideThroughTerrain(Calculated->WaypointBearing, Basic, Calculated, &lat, &lon, 
+	#endif
 		Calculated->WaypointDistance, &out_of_range, NULL);
 
 	// Calculate obstacles ONLY if we are in glide range, otherwise it is useless 

--- a/Common/Source/Calc/ResetFlightStats.cpp
+++ b/Common/Source/Calc/ResetFlightStats.cpp
@@ -16,6 +16,16 @@ extern AATDistance aatdistance;
 
 
 
+#ifdef GTL2
+void ClearGTL2(void) {
+  for (int i=0; i<=NUMTERRAINSWEEPS; i++) {
+    GlideFootPrint2[i].x = 0;
+    GlideFootPrint2[i].y = 0;
+  }
+}
+#endif
+
+
 //
 // This is called only by calculations thread, at init, at restart of a replay flight, and also on takeoff
 // IT SHOULD NEVER HAPPEN DURING REAL FLIGHT, AFTER TAKEOFF!
@@ -84,6 +94,10 @@ void ResetFlightStats(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
       Calculated->GlideFootPrint[i].x = 0;
       Calculated->GlideFootPrint[i].y = 0;
     }
+    #ifdef GTL2
+    ClearGTL2(); // clear GlideFootPrint2
+    #endif
+    
     Calculated->TerrainWarningLatitude = 0.0;
     Calculated->TerrainWarningLongitude = 0.0;
 

--- a/Common/Source/Calc/TerrainFootprint.cpp
+++ b/Common/Source/Calc/TerrainFootprint.cpp
@@ -14,17 +14,30 @@ void TerrainFootprint(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
   double bearing, distance;
   double lat, lon;
   bool out_of_range;
+  #ifdef GTL2
+  double ScreenRange = MapWindow::GetApproxScreenRange();
+  #endif
 
   // estimate max range (only interested in at most one screen distance away)
   // except we need to scan for terrain base, so 20km search minimum is required
+  #ifdef GTL2
+  double mymaxrange = max(20000.0, ScreenRange);
+  #else
   double mymaxrange = max(20000.0, MapWindow::GetApproxScreenRange());
+  #endif
 
   Calculated->TerrainBase = Calculated->TerrainAlt;
 
   for (int i=0; i<=NUMTERRAINSWEEPS; i++) {
     bearing = (i*360.0)/NUMTERRAINSWEEPS;
     distance = FinalGlideThroughTerrain(bearing, 
+                                      #ifdef GTL2
+                                        Basic->Latitude,
+                                        Basic->Longitude,
+                                        Calculated->NavAltitude,
+                                      #else
                                         Basic, 
+                                      #endif
                                         Calculated, &lat, &lon,
                                         mymaxrange, &out_of_range,
 					&Calculated->TerrainBase);
@@ -38,5 +51,85 @@ void TerrainFootprint(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
     Calculated->GlideFootPrint[i].y = lat;
   }
   Calculated->Experimental = Calculated->TerrainBase;
+  
+  #ifdef GTL2
+  // Now calculate the 2nd glide footprint, which is the glide range
+  // after reaching the next task waypoint.  First, let's make sure
+  // we're flying a task.
+  
+  if ((FinalGlideTerrain > 2) && ValidTaskPoint(ActiveWayPoint)) {
+    // Only bother calculating the footprint, if
+    // we can reach the next waypoint.
+    
+    double lat_wp, lon_wp; // location of footprint "center"
+    bool AATandMTP  = ACTIVE_WP_IS_AAT_AREA; // MTP: mid-task point
+    bool DoOptRoute = DoOptimizeRoute();
+    int  wp_index = 0; // index for WayPointCalc and WayPointList
+    
+    if (DoOptRoute || AATandMTP) {
+      // The next line is just to force an immediate refresh of
+      // arrival altitude for an AAT or "optimized" virtual WP.
+      // Without this, the glide line could briefly (1-2 seconds)
+      // be drawn using the arrival altitude of the previously-
+      // active WP.
+      DoAlternates(Basic, Calculated, RESWP_OPTIMIZED);
+      wp_index = RESWP_OPTIMIZED;
+      lat_wp   = Task[ActiveWayPoint].AATTargetLat;
+      lon_wp   = Task[ActiveWayPoint].AATTargetLon;
+    } else {
+      wp_index = TASKINDEX;
+      lat_wp   = WayPointList[TASKINDEX].Latitude;
+      lon_wp   = WayPointList[TASKINDEX].Longitude;
+    }
+    
+    double alt_arriv = WayPointCalc[wp_index].AltArriv[AltArrivMode];
+    
+    // Calculate arrival altitude relative to the "terrain height"
+    // safety setting.
+
+    double alt_arriv_agl = (CheckSafetyAltitudeApplies(wp_index)) ?
+           (alt_arriv + SAFETYALTITUDEARRIVAL) : alt_arriv;
+
+    // relative to "terrain height":
+    alt_arriv = alt_arriv_agl - SAFETYALTITUDETERRAIN;
+
+    // Only bother calculating the 2nd glide footprint, if its
+    // center (the next WP) is reachable above "terrain height".
+
+    if (alt_arriv > 0) { // WP reachable above "terrain height"
+
+      double alt_arriv_msl = alt_arriv_agl +
+                             WayPointList[wp_index].Altitude;
+      const double PanLatitude  = MapWindow::GetPanLatitude();
+      const double PanLongitude = MapWindow::GetPanLongitude();
+
+      // Rewrite "mymaxrange" to the distance from the next WP
+      // to the center of the screen/map.  Then add "ScreenRange"
+      // to make sure to cover the entire screen.
+
+      DistanceBearing(lat_wp, lon_wp, PanLatitude,
+                      PanLongitude, &mymaxrange, NULL);
+      mymaxrange += ScreenRange;
+      
+      for (int i=0; i<=NUMTERRAINSWEEPS; i++) {
+        bearing = (i * 360.0) / NUMTERRAINSWEEPS;
+
+        distance = FinalGlideThroughTerrain(bearing, lat_wp, lon_wp,
+                                            alt_arriv_msl,
+                                            Calculated, &lat, &lon,
+                                            mymaxrange, &out_of_range,
+                                            NULL);
+
+        if (out_of_range)
+          FindLatitudeLongitude(lat_wp, lon_wp, 
+                                bearing, distance,
+                                &lat, &lon);
+
+        GlideFootPrint2[i].x = lon;
+        GlideFootPrint2[i].y = lat;
+      }
+    } // if reachable above "terrain height"
+  } // if valid task point
+  #endif
 }
 

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -1991,6 +1991,12 @@ static void setVariables(void) {
     dfe->addEnumText(gettext(TEXT("_@M393_")));
 	// LKTOKEN  _@M609_ = "Shade" 
     dfe->addEnumText(gettext(TEXT("_@M609_")));
+    #ifdef GTL2
+        // LKTOKEN  _@M94_  = "Line+NextWP"
+    dfe->addEnumText(gettext(TEXT("_@M94_")));
+        // LKTOKEN  _@M99_  = "Shade+NextWP"
+    dfe->addEnumText(gettext(TEXT("_@M99_")));
+    #endif
     dfe->Set(FinalGlideTerrain);
     wp->RefreshDisplay();
   }

--- a/Common/Source/Draw/CalculateScreen.cpp
+++ b/Common/Source/Draw/CalculateScreen.cpp
@@ -315,6 +315,11 @@ void MapWindow::CalculateScreenPositionsGroundline(void) {
   if (FinalGlideTerrain) {
     LatLon2Screen(DerivedDrawInfo.GlideFootPrint,
 		  Groundline, NUMTERRAINSWEEPS+1, 1);
+    #ifdef GTL2
+    if (FinalGlideTerrain > 2) // show next-WP line
+      LatLon2Screen(GlideFootPrint2,
+                    Groundline2, NUMTERRAINSWEEPS+1, 1);
+    #endif
   }
 }
 

--- a/Common/Source/Draw/CalculateWaypointReachable.cpp
+++ b/Common/Source/Draw/CalculateWaypointReachable.cpp
@@ -18,7 +18,13 @@ bool CheckLandableReachableTerrainNew(NMEA_INFO *Basic, DERIVED_INFO *Calculated
   double lat, lon;
   bool out_of_range;
 
+#ifdef GTL2
+  double distance_soarable = FinalGlideThroughTerrain(LegBearing, Basic->Latitude,
+                                                      Basic->Longitude, Calculated->NavAltitude,
+                                                      Calculated, &lat, &lon,
+#else
   double distance_soarable = FinalGlideThroughTerrain(LegBearing, Basic, Calculated, &lat, &lon,
+#endif
                                                       LegToGo, &out_of_range, NULL);
 
   if ((out_of_range)||(distance_soarable> LegToGo)) {

--- a/Common/Source/Draw/Draw_Primitives.cpp
+++ b/Common/Source/Draw/Draw_Primitives.cpp
@@ -113,23 +113,42 @@ void MapWindow::DrawDashLine(HDC hdc, const int width,
   int i;
   HPEN hpDash,hpOld;
   POINT pt[2];
+  #ifdef GTL2
+  int Offset = ((width - 1) / 2) + 1;
+               // amount to shift 1st line to center
+               // the group of lines properly
+  #endif
+
   //Create a dot pen
   hpDash = (HPEN)CreatePen(PS_DASH, 1, cr);
   hpOld = (HPEN)SelectObject(hdc, hpDash);
 
+  #ifdef GTL2
+  pt[0] = ptStart;
+  pt[1] = ptEnd;
+  #else
   pt[0].x = ptStart.x;
   pt[0].y = ptStart.y;
   pt[1].x = ptEnd.x;
   pt[1].y = ptEnd.y;
+  #endif
   
   //increment on smallest variance
   if(abs(ptStart.x - ptEnd.x) < abs(ptStart.y - ptEnd.y)){
+    #ifdef GTL2
+    pt[0].x -= Offset;
+    pt[1].x -= Offset;
+    #endif
     for (i = 0; i < width; i++){
       pt[0].x += 1;
       pt[1].x += 1;     
       _Polyline(hdc, pt, 2, rc);
     }   
   } else {
+    #ifdef GTL2
+    pt[0].y -= Offset;
+    pt[1].y -= Offset;
+    #endif
     for (i = 0; i < width; i++){
       pt[0].y += 1;
       pt[1].y += 1;     
@@ -143,3 +162,15 @@ void MapWindow::DrawDashLine(HDC hdc, const int width,
 } 
 
 
+
+#ifdef GTL2
+void MapWindow::DrawDashPoly(HDC hdc, const int width, const COLORREF color,
+                             POINT* pt, const int npoints, const RECT rc)
+{
+  int Segment;
+
+  for (Segment = 1; Segment < npoints; Segment++) {
+    DrawDashLine(hdc, width, pt[Segment-1], pt[Segment], color, rc);
+  }
+}
+#endif

--- a/Common/Source/Draw/MapWndProc.cpp
+++ b/Common/Source/Draw/MapWndProc.cpp
@@ -82,6 +82,9 @@ HPEN MapWindow::hSnailPens[NUMSNAILCOLORS];
 COLORREF MapWindow::hSnailColours[NUMSNAILCOLORS];
 
 POINT MapWindow::Groundline[NUMTERRAINSWEEPS+1];
+#ifdef GTL2
+POINT MapWindow::Groundline2[NUMTERRAINSWEEPS+1];
+#endif
 
 // 16 is number of airspace types
 int      MapWindow::iAirspaceBrush[AIRSPACECLASSCOUNT] = {2,0,0,0,3,3,3,3,0,3,2,3,3,3,3,3};
@@ -130,6 +133,9 @@ HPEN MapWindow::hpMapScale;
 HPEN MapWindow::hpMapScale2;
 HPEN MapWindow::hpTerrainLine;
 HPEN MapWindow::hpTerrainLineBg;
+#ifdef GTL2
+HPEN MapWindow::hpTerrainLine2Bg;
+#endif
 HPEN MapWindow::hpStartFinishThick;
 HPEN MapWindow::hpStartFinishThin;
 HPEN MapWindow::hpVisualGlideLightBlack; // VENTA3

--- a/Common/Source/Draw/RenderMapWindowBg.cpp
+++ b/Common/Source/Draw/RenderMapWindowBg.cpp
@@ -216,7 +216,12 @@ fastzoom:
 	}
     if (!QUICKDRAW) {
     	// shaded terrain unreachable, aka glide amoeba
+        #ifdef GTL2
+    	if (((FinalGlideTerrain == 2) || (FinalGlideTerrain == 4)) && 
+            DerivedDrawInfo.TerrainValid) {
+        #else
     	if ((FinalGlideTerrain==2) && DerivedDrawInfo.TerrainValid) {
+        #endif
     	  DrawTerrainAbove(hdc, rc);
     	}
     }

--- a/Common/Source/LKObjects.cpp
+++ b/Common/Source/LKObjects.cpp
@@ -186,6 +186,9 @@ void LKObjects_Create() {
   MapWindow::hpFinalGlideAbove = (HPEN)CreatePen(PS_SOLID, NIBLSCALE(1), RGB(0xA0,0xFF,0xA0)); // another light green
   MapWindow::hpTerrainLine = (HPEN)CreatePen(PS_DASH, (1), RGB(0x30,0x30,0x30)); // shade
   MapWindow::hpTerrainLineBg = (HPEN)CreatePen(PS_SOLID, NIBLSCALE(2), RGB_LCDDARKGREEN); // perimeter
+#ifdef GTL2
+  MapWindow::hpTerrainLine2Bg = (HPEN)CreatePen(PS_SOLID, NIBLSCALE(2), RGB_WHITE);
+#endif
   MapWindow::hpVisualGlideLightBlack = (HPEN)CreatePen(PS_DASH, (1), RGB_BLACK);
   MapWindow::hpVisualGlideHeavyBlack = (HPEN)CreatePen(PS_DASH, (2), RGB_BLACK);
   MapWindow::hpVisualGlideLightRed = (HPEN)CreatePen(PS_DASH, (1), RGB_RED);
@@ -294,6 +297,9 @@ void LKObjects_Delete() {
   if (MapWindow::hpFinalGlideAbove) DeleteObject((HPEN)MapWindow::hpFinalGlideAbove);
   if (MapWindow::hpTerrainLine) DeleteObject((HPEN)MapWindow::hpTerrainLine);
   if (MapWindow::hpTerrainLineBg) DeleteObject((HPEN)MapWindow::hpTerrainLineBg);
+#ifdef GTL2
+  if (MapWindow::hpTerrainLine2Bg) DeleteObject((HPEN)MapWindow::hpTerrainLine2Bg);
+#endif
   if (MapWindow::hpVisualGlideLightBlack) DeleteObject((HPEN)MapWindow::hpVisualGlideLightBlack);
   if (MapWindow::hpVisualGlideHeavyBlack) DeleteObject((HPEN)MapWindow::hpVisualGlideHeavyBlack);
   if (MapWindow::hpVisualGlideLightRed) DeleteObject((HPEN)MapWindow::hpVisualGlideLightRed);


### PR DESCRIPTION
This change adds the new feature discussed in this forum topic: http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=6444.  This feature is an optional glide footprint (glide terrain line) around the active waypoint – showing your glide range after reaching that waypoint (at your predicted arrival altitude for that waypoint).  This option is configured using the “Glide Terrain Line” setting in system setup config menu 13 (Map Overlays).  The new “…+NextWP” options there enable this feature.
