### PR TITLE
disable AAT Time notification for PG optimized Task

### DIFF
--- a/Common/Source/ConditionMonitor.cpp
+++ b/Common/Source/ConditionMonitor.cpp
@@ -256,7 +256,7 @@ public:
 protected:
 
   bool CheckCondition(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {    
-    if (!AATEnabled || !ValidTaskPoint(ActiveWayPoint) 
+    if (DoOptimizeRoute() || !AATEnabled || !ValidTaskPoint(ActiveWayPoint) 
         || !(Calculated->ValidStart && !Calculated->ValidFinish)
         || !Calculated->Flying) {
       return false;


### PR DESCRIPTION
Disable "Expect early task arrival" for paraglider task.
