### PR TITLE
Fix crash :  CTrace::Compres()

### DIFF
--- a/Common/Source/Calc/Trace.cpp
+++ b/Common/Source/Calc/Trace.cpp
@@ -140,6 +140,12 @@ void CTrace::Compress(unsigned maxSize /* = 0 */)
   while(_size > _maxSize) {
     // get the worst point
     CPointCostSet::iterator worstIt = _compressionCostSet.begin();
+	if(worstIt == _compressionCostSet.end()) {
+#ifndef TEST_CONTEST
+		StartupStore(_T("%s:%u - ERROR: _compressionCostSet is empty !!\n"), _T(__FILE__), __LINE__);
+#endif
+		return;
+	}
     CPoint *worst = *worstIt;
     
     // remove the worst point from optimization pool


### PR DESCRIPTION
i don't know why, but  _compressionCostSet can be empty with _size > 0, in this case crash ...
