### PR TITLE
Corrected calculating flaps speed in turn

### DIFF
--- a/Common/Source/Calc/Flaps.cpp
+++ b/Common/Source/Calc/Flaps.cpp
@@ -19,6 +19,7 @@ void Flaps(NMEA_INFO *Basic, DERIVED_INFO *Calculated)
 		speed = (int)(Calculated->IndicatedAirspeedEstimated);
 	}
 
+	// correcting speed for calculated bank angle
 	speed = speed/sqrt(1/cos(Calculated->BankAngle*DEG_TO_RAD));
 
 	LKASSERT(GlidePolar::FlapsMass!=0);


### PR DESCRIPTION
Speed for determining flaps in turn should be corrected for bank angle. It behaves the same like for example minimum speed rising.
