### PR TITLE
Target dialog for AAT sector fixed

### DIFF
--- a/Common/Source/Library/NavFunctions.cpp
+++ b/Common/Source/Library/NavFunctions.cpp
@@ -298,7 +298,7 @@ void xXY_Brg_Rng(double X_1, double Y_1, double X_2, double Y_2, double *Bearing
   double y = (X_2 - X_1);
   double x = (Y_2 - Y_1);
 
-  if (fabs(x)>0.00000001 && fabs(y)>0.00000001){
+  if (fabs(x)>0.00000001 || fabs(y)>0.00000001){
     Rad_Bearing = atan2(y, x);
   } else {
     Rad_Bearing = 0;


### PR DESCRIPTION
Before the change a Target dialog for narrow AAT sector (like 90o - 180o) was
centered at the center of the circle used to draw the sector and zoomed
to view 2x its radius. Because of that sector was really hard to manage in
AAT tasks. Now the same sector is centered on the screen and stretched on full
screen.

Old:
![AAT_sector_old](https://f.cloud.github.com/assets/506260/206543/4b419e24-81d2-11e2-8f14-dfbf771fa841.png)

New:
![AAT_sector_new](https://f.cloud.github.com/assets/506260/206544/55acfc8c-81d2-11e2-96c9-c9dc13c23328.png)
