### PR TITLE
Added information about landable waypoint on Task Edit screen

### DIFF
--- a/Common/Source/Dialogs/dlgTaskOverview.cpp
+++ b/Common/Source/Dialogs/dlgTaskOverview.cpp
@@ -77,6 +77,10 @@ static void OnTaskPaintListItem(WindowControl * Sender, HDC hDC){
   (void)Sender;
   int n = UpLimit - LowLimit;
   TCHAR sTmp[120];
+  TCHAR wpName[120];
+  TCHAR landableStr[5] = TEXT(" [X]");
+  // LKTOKEN _@M1238_ "L"
+  landableStr[2] = gettext(TEXT("_@M1238_"))[0];
   LockTaskData();
 
   int w0 = Sender->GetWidth()-1;
@@ -90,19 +94,20 @@ static void OnTaskPaintListItem(WindowControl * Sender, HDC hDC){
     int i = LowLimit + DrawListIndex;
 
     if (Task[i].Index>=0) {
+      _stprintf(wpName, TEXT("%s%s"),
+                WayPointList[Task[i].Index].Name,
+                (WayPointList[Task[i].Index].Flags & LANDPOINT) ? landableStr : TEXT(""));
+      
       if (AATEnabled && ValidTaskPoint(i+1) && (i>0)) {
         if (Task[i].AATType==0) {
           _stprintf(sTmp, TEXT("%s %.1f"), 
-                    WayPointList[Task[i].Index].Name,
-                    Task[i].AATCircleRadius*DISTANCEMODIFY);
+                    wpName, Task[i].AATCircleRadius*DISTANCEMODIFY);
         } else {
           _stprintf(sTmp, TEXT("%s %.1f"), 
-                    WayPointList[Task[i].Index].Name,
-                    Task[i].AATSectorRadius*DISTANCEMODIFY);
+                    wpName, Task[i].AATSectorRadius*DISTANCEMODIFY);
         }
       } else {
-        _stprintf(sTmp, TEXT("%s"), 
-                  WayPointList[Task[i].Index].Name);
+        _stprintf(sTmp, TEXT("%s"), wpName);
       }
 
       ExtTextOutClip(hDC, 2*ScreenScale, 2*ScreenScale,

--- a/Common/Source/Dialogs/dlgTaskWaypoint.cpp
+++ b/Common/Source/Dialogs/dlgTaskWaypoint.cpp
@@ -43,8 +43,14 @@ static void UpdateCaption(void) {
       _stprintf(title, gettext(TEXT("_@M299_")));
       break;
     };
-    _stprintf(sTmp, TEXT("%s: %s"), title,
-              WayPointList[Task[twItemIndex].Index].Name);
+
+    TCHAR landableStr[5] = TEXT(" [X]");
+    // LKTOKEN _@M1238_ "L"
+    landableStr[2] = gettext(TEXT("_@M1238_"))[0];
+    
+    _stprintf(sTmp, TEXT("%s: %s%s"), title,
+              WayPointList[Task[twItemIndex].Index].Name,
+              (WayPointList[Task[twItemIndex].Index].Flags & LANDPOINT) ? landableStr : TEXT(""));
     wf->SetCaption(sTmp);
   } else {
 	// LKTOKEN  _@M9_ = "(invalid)" 


### PR DESCRIPTION
It is really important to be aware during task planning that we are
dealing with landable waypoint. If we miss that for example finish for
AAT task is a landable we can have big problems to complete task safe or in
good time.
