### PR TITLE
fix Wing Loading calculation in paraglider mode

### DIFF
--- a/Common/Data/Dialogs/dlgBasicSettings.xml
+++ b/Common/Data/Dialogs/dlgBasicSettings.xml
@@ -24,7 +24,7 @@
       <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" OnDataAccess="OnAltitudeData" />
     </WndProperty>
     <WndProperty Caption="_@M428_"     X="2" Y="-997"  Width="165" Height="22" CaptionWidth="78" Font="2" Help="_@H305_">
-      <DataField name="" DataType="double" DisplayFormat="%.0fï¿½" EditFormat="%.0f" Min="0" Max="50" Step="1"  OnDataAccess="OnTempData"/>
+      <DataField name="" DataType="double" DisplayFormat="%.0f°" EditFormat="%.0f" Min="0" Max="50" Step="1"  OnDataAccess="OnTempData"/>
     </WndProperty>
   </WndForm>
 </PMML>

--- a/Common/Data/Dialogs/dlgBasicSettings_L.xml
+++ b/Common/Data/Dialogs/dlgBasicSettings_L.xml
@@ -24,7 +24,7 @@
       <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" OnDataAccess="OnAltitudeData" />
     </WndProperty>
     <WndProperty Caption="_@M428_"     X="2" Y="-997"  Width="230" Height="22" CaptionWidth="78" Font="2" Help="_@H305_">
-      <DataField name="" DataType="double" DisplayFormat="%.0fï¿½" EditFormat="%.0f" Min="0" Max="50" Step="1"  OnDataAccess="OnTempData"/>
+      <DataField name="" DataType="double" DisplayFormat="%.0f°" EditFormat="%.0f" Min="0" Max="50" Step="1"  OnDataAccess="OnTempData"/>
     </WndProperty>
   </WndForm>
 </PMML>


### PR DESCRIPTION
if polar have Wing Area, when you edit basic setting, wing load is reseted to 5kg/m²

Bug Sample :
    MassDryGross : 120Kg
    Ballast : 0L
    WingArea : 32m²

max weigth is 120kg, but if you edit basic setting, weight calculated is 160kg

Fix :
change range and step of wing load parameter for allow wing load less than 5kg/m²
