### PR TITLE
Convert the numeric keyboard to a better layout

### DIFF
--- a/Common/Data/Dialogs/dlgNumEntry_Keyboard_L.xml
+++ b/Common/Data/Dialogs/dlgNumEntry_Keyboard_L.xml
@@ -7,16 +7,16 @@
     <WndButton   Caption="1"    X="1"   Y="-1"   Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
     <WndButton   Caption="2"    X="80"  Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
     <WndButton   Caption="3"    X="159" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
-    <WndButton   Caption="4"    X="238" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="0"    X="238" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
 
-    <WndButton   Caption="5"    X="1"   Y="-1"   Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
-    <WndButton   Caption="6"    X="80"  Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
-    <WndButton   Caption="7"    X="159" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
-    <WndButton   Caption="8"    X="238" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="4"    X="1"   Y="-1"   Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="5"    X="80"  Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="6"    X="159" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="-"    X="238" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
 
-    <WndButton   Caption="-"    X="1"   Y="-1"   Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
-    <WndButton   Caption="9"    X="80"  Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
-    <WndButton   Caption="0"    X="159" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="7"    X="1"   Y="-1"   Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="8"    X="80"  Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Caption="9"    X="159" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
     <WndButton   Caption="."    X="238" Y="-999" Width="78"  Height="52" Font="2" OnClickNotify="OnKey"/>
 
     <WndButton  Name="cmdHelp"  Caption="_@M336_" X="1" Y="-1" Width="70"  Height="34" Font="2" OnClickNotify="OnHelpClicked"/>


### PR DESCRIPTION
Since the current layout is far from intuitive, I changed the numeric keyboard to look like telephone keypad (except with 0, '-' and '.' on the right)

![Image of the keyboard](http://puu.sh/3Dofb.png)
