### PR TITLE
fix OpenAir Altitude parsing error

### DIFF
--- a/Common/Source/LKAirspace.cpp
+++ b/Common/Source/LKAirspace.cpp
@@ -1500,12 +1500,18 @@ void CAirspaceManager::ReadAltitude(const TCHAR *Text, AIRSPACE_ALT *Alt) const
       }
     }
 
-    else if (_tcscmp(pToken, TEXT("SFC")) == 0) {
+    else if ((_tcscmp(pToken, TEXT("SFC")) == 0) 
+             || (_tcscmp(pToken, TEXT("ASFC")) == 0)) {
       Alt->Base = abAGL;
-      Alt->FL = 0;
-      Alt->Altitude = 0;
-      Alt->AGL = -1;
-      fHasUnit = true;
+      if (Alt->Altitude>0) {
+        Alt->AGL = Alt->Altitude;
+        Alt->Altitude = 0;
+      } else {      
+        Alt->FL = 0;
+        Alt->Altitude = 0;
+        Alt->AGL = -1;
+        fHasUnit = true;
+      }
     }
 
     else if (_tcsstr(pToken, TEXT("FL")) == pToken){ 
@@ -1524,7 +1530,8 @@ void CAirspaceManager::ReadAltitude(const TCHAR *Text, AIRSPACE_ALT *Alt) const
       fHasUnit = true;
     }
 
-    else if (_tcscmp(pToken, TEXT("MSL")) == 0){
+    else if ((_tcscmp(pToken, TEXT("MSL")) == 0)
+             || (_tcscmp(pToken, TEXT("AMSL")) == 0)){
       Alt->Base = abMSL;
     }
 


### PR DESCRIPTION
```
 2000M ASFC -> 2000M MSL
 2000FT SFC -> SFC
 2000M SFC -> SFC
```

---
-                                                                              *
-                         Special Use Airspace for tests                       *
-                                                                              *
  ********************************************************************************

AC CTR
AN CTR Test 1
AH UNL
AL SFC
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 2
AH FL115
AL GND
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 3 (Pieds)
AH 2000FT AGL
AL 1000F AGL
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 3 (Metres)
AH 2000M AGL
AL 1000M AGL
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 4 (Pieds)
AH 2000FT AMSL
AL 1000F AMSL
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 4 (Metres)
AH 2000M AMSL
AL 1000M AMSL
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 5 (Pieds)
AH 2000FT ASFC
AL 1000F ASFC
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 5 (Metres)
AH 2000M ASFC
AL 1000M ASFC
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 6 (Pieds)
AH 2000FT SFC
AL 1000F SFC
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 6 (Metres)
AH 2000M SFC
AL 1000M SFC
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 7 (Pieds)
AH 2000FT
AL 1000F
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 7 (Metres)
AH 2000M
AL 1000M
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

AC CTR
AN CTR Test 8 (Error)
AH 2000
AL 1000
DP 49:35:09 N 001:11:45 E
DP 49:31:10 N 001:22:43 E
DP 49:23:00 N 001:27:30 E
DP 49:16:58 N 001:13:09 E
DP 49:15:08 N 001:05:47 E
DP 49:22:11 N 000:53:40 E

---
