### PR TITLE
fixed the NMEA checksum switch

### DIFF
--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -403,8 +403,10 @@ BOOL devParseNMEA(int portNum, TCHAR *String, NMEA_INFO *pGPS){
   }
 
   // intercept device specific parser routines 
-  if (d != NULL){
-
+  if (d != NULL) {
+	  if (!NMEAParser::NMEAChecksum(String)){
+	    return FALSE;
+	  }
     if (d->pDevPipeTo && d->pDevPipeTo->Com) {
 	// stream pipe, pass nmea to other device (NmeaOut)
 	// TODO code: check TX buffer usage and skip it if buffer is full (outbaudrate < inbaudrate)

--- a/Common/Source/Devices/devLX.cpp
+++ b/Common/Source/Devices/devLX.cpp
@@ -175,14 +175,16 @@ bool DevLX::LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* pGPS)
  // ParToDouble(sentence, 1, &MACCREADY);
 //	$LXWP1,LX5000IGC-2,15862,11.1 ,2.0*4A
 #ifdef DEVICE_SERIAL
-  TCHAR ctemp[80];
-  static int NoMsg;
-  static int oldSerial;
-  if((( pGPS->SerialNumber == 0) && (NoMsg <10)) || ( pGPS->SerialNumber != oldSerial))
+TCHAR ctemp[180];
+static int NoMsg=0;
+static int oldSerial=0;
+if(_tcslen(String) < 180)
+  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
-    NMEAParser::ExtractParameter(String,d->Name,0);
-
+    NMEAParser::ExtractParameter(String,ctemp,0);
+    if(_tcslen(ctemp) < DEVNAMESIZE)
+	  _stprintf(d->Name, _T("%s"),ctemp);
     StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);

--- a/Common/Source/Devices/devLX16xx.cpp
+++ b/Common/Source/Devices/devLX16xx.cpp
@@ -386,13 +386,16 @@ bool DevLX16xx::LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* pGP
  // ParToDouble(sentence, 1, &MACCREADY);
 //	$LXWP1,LX5000IGC-2,15862,11.1 ,2.0*4A
 #ifdef DEVICE_SERIAL
-  TCHAR ctemp[80];
-  static int NoMsg;
-  static int oldSerial;
-  if((( pGPS->SerialNumber == 0) && (NoMsg <10)) || ( pGPS->SerialNumber != oldSerial))
+TCHAR ctemp[180];
+static int NoMsg=0;
+static int oldSerial=0;
+if(_tcslen(String) < 180)
+  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
-    NMEAParser::ExtractParameter(String,d->Name,0);
+    NMEAParser::ExtractParameter(String,ctemp,0);
+    if(_tcslen(ctemp) < DEVNAMESIZE)
+	  _stprintf(d->Name, _T("%s"),ctemp);
 
     StartupStore(_T(". %s\n"),ctemp);
 

--- a/Common/Source/Devices/devLXV7.cpp
+++ b/Common/Source/Devices/devLXV7.cpp
@@ -466,13 +466,16 @@ bool DevLXV7::LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* pGPS)
  // ParToDouble(sentence, 1, &MACCREADY);
 //	$LXWP1,LX5000IGC-2,15862,11.1 ,2.0*4A
 #ifdef DEVICE_SERIAL
-  TCHAR ctemp[80];
-  static int NoMsg;
-  static int oldSerial;
-  if((( pGPS->SerialNumber == 0) && (NoMsg <10)) || ( pGPS->SerialNumber != oldSerial))
+  TCHAR ctemp[180];
+  static int NoMsg=0;
+  static int oldSerial=0;
+if(_tcslen(String) < 180)
+  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
-    NMEAParser::ExtractParameter(String,d->Name,0);
+    NMEAParser::ExtractParameter(String,ctemp,0);
+    if(_tcslen(ctemp) < DEVNAMESIZE)
+	  _stprintf(d->Name, _T("%s"),ctemp);
 
     StartupStore(_T(". %s\n"),ctemp);
 

--- a/Common/Source/Devices/devLXV7_EXP.cpp
+++ b/Common/Source/Devices/devLXV7_EXP.cpp
@@ -629,14 +629,16 @@ bool DevLXV7_EXP::LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* p
  // ParToDouble(sentence, 1, &MACCREADY);
 //	$LXWP1,LX5000IGC-2,15862,11.1 ,2.0*4A
 #ifdef DEVICE_SERIAL
-  TCHAR ctemp[80];
-  static int NoMsg;
-  static int oldSerial;
-  if((( pGPS->SerialNumber == 0) && (NoMsg <10)) || ( pGPS->SerialNumber != oldSerial))
+TCHAR ctemp[180];
+static int NoMsg=0;
+static int oldSerial=0;
+if(_tcslen(String) < 180)
+  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
-    NMEAParser::ExtractParameter(String,d->Name,0);
-
+    NMEAParser::ExtractParameter(String,ctemp,0);
+    if(_tcslen(ctemp) < DEVNAMESIZE)
+	  _stprintf(d->Name, _T("%s"),ctemp);
     StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);

--- a/Common/Source/Devices/devWesterboer.cpp
+++ b/Common/Source/Devices/devWesterboer.cpp
@@ -209,7 +209,7 @@ static BOOL PWES0(PDeviceDescriptor_t d, TCHAR *String, NMEA_INFO *pGPS)
 
 */
 
-  TCHAR ctemp[80];
+  TCHAR ctemp[180];
   double vtas, vias;
   double altqne, altqnh;
   static bool initqnh=true;
@@ -219,7 +219,8 @@ static BOOL PWES0(PDeviceDescriptor_t d, TCHAR *String, NMEA_INFO *pGPS)
 
 
 
-  if( (NoMsg <10) && ( pGPS->SerialNumber != oldSerial))
+if(_tcslen(String) < 180)
+  if(((pGPS->SerialNumber == 0) || (oldSerial != SerialNumber)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -462,9 +463,11 @@ static BOOL PWES2(PDeviceDescriptor_t d, TCHAR *String, NMEA_INFO *pGPS)
 //	FFFF Firmware * 100 100 .. 9999 101 = 1.01
 //	$PWES2,60,1234,12,3210*22
 #ifdef DEVICE_SERIAL
-  TCHAR ctemp[80];
-  static int NoMsg;
-  if((pGPS->SerialNumber == 0) && (NoMsg <10))
+TCHAR ctemp[180];
+static int NoMsg=0;
+
+if(_tcslen(String) < 180)
+  if(((pGPS->SerialNumber == 0) || (oldSerial	!= SerialNumber)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -497,7 +500,7 @@ static BOOL PWES2(PDeviceDescriptor_t d, TCHAR *String, NMEA_INFO *pGPS)
     _stprintf(ctemp, _T("SW Ver:%3.2f  HW Ver:%i "),  pGPS->SoftwareVer, Year);
     DoStatusMessage(ctemp);
 	StartupStore(_T(". %s\n"),ctemp);
-
+	oldSerial	=SerialNumber;
   }
   // nothing to do
 #endif


### PR DESCRIPTION
better string safety in device drivers for serial number and device name.
limit Serial number messages to max. 5 instead of 10. for each device
no toggle if 2. devices involved
