### PR TITLE
fix McCready Speed calculation :

### DIFF
--- a/Common/Source/Calc/McReady.cpp
+++ b/Common/Source/Calc/McReady.cpp
@@ -79,7 +79,7 @@ void GlidePolar::SetBallast() {
   if ((SAFTEYSPEED<1)||(SAFTEYSPEED>=MAXSAFETYSPEED)) {
     SAFTEYSPEED=MAXSAFETYSPEED-1;
   }
-  iSAFETYSPEED=(int)SAFTEYSPEED;
+  iSAFETYSPEED=iround(SAFTEYSPEED);
 
   // sinkratecache is an array for m/s values!! i is the speed in m/s
   for(i=4;i<=MAXSPEED;i++)
@@ -213,7 +213,7 @@ double GlidePolar::MacCreadyAltitude_internal(double emcready,
   bool SpeedFound = false;
   #endif
 
-  for(i=Vminsink;i<iSAFETYSPEED;i++) {
+  for(i=Vminsink;i<=iSAFETYSPEED;i++) {
     double vtrack_real = ((double)i); // actual airspeed
     double vtrack = vtrack_real*cruise_efficiency; 
     // TAS along bearing in cruise
@@ -509,7 +509,7 @@ double GlidePolar::FindSpeedForSinkRate(double w) {
   // find the highest speed that provides a sink rate less than
   // the specified sink rate
   double vbest= Vminsink;
-  for (int v=Vminsink; v<iSAFETYSPEED; v++) {
+  for (int v=Vminsink; v<=iSAFETYSPEED; v++) {
     double wthis = _SinkRateFast(0, v);
     if (wthis>w) {
       vbest = v;


### PR DESCRIPTION
  wrong max speed to integer convertion and wrong exit loop condition

before this change, McSpeed max value is "absolute value of MaxSpeed (in m/s)" - 1m/s

it's critical bug for paragliders : error > 10% of max speed (3.6km/h to 7.8km/h)

TODO : use less speed step for MC Speed, for now we use 1m/s (3.6km/h)
  it's to huge for paraglider, common PG wing have only 10 to 15 km/h speed range.
