### PR TITLE
fix Optimized Route config-runtime setting problem

### DIFF
--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -204,6 +204,9 @@ GEXTERN int LKVarioBar;
 GEXTERN int LKVarioVal;
 
 GEXTERN bool PGOptimizeRoute;
+#ifdef PGOPT_FIX
+GEXTERN bool PGOptimizeRoute_Config;
+#endif
 
 GEXTERN short OverlaySize;
 GEXTERN short BarOpacity;

--- a/Common/Header/options.h
+++ b/Common/Header/options.h
@@ -79,7 +79,13 @@
 // Activate FastZoom and QUICKDRAW conditions, for fast paint of map the first time after zoom request
 #define USEBIGZOOM	1	
 
-
+// Fix "Optimized Route" config setting.  There WAS only one variable that was being
+// use for both saved config and runtime use.  This fix adds a second (PGOptimizeRoute_Config)
+// and changes the code where needed to use the appropriate one of the two.  For example,
+// this fix makes it so that toggling this setting with a custom key only changes the runtime
+// variable, not the saved config setting.
+// Eric Carden, February 11, 2014
+#define PGOPT_FIX
 
 
 

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -2997,7 +2997,11 @@ static void setVariables(void) {
 	// LKTOKEN  _@M259_ = "Enabled" 
     dfe->addEnumText(gettext(TEXT("_@M259_")));
     dfe = (DataFieldEnum*)wp->GetDataField();
+    #ifdef PGOPT_FIX
+    dfe->Set(PGOptimizeRoute_Config);
+    #else
     dfe->Set(PGOptimizeRoute);
+    #endif
     wp->RefreshDisplay();
   }
 
@@ -4397,8 +4401,17 @@ int ival;
   }
   wp = (WndProperty*)wf->FindByName(TEXT("prpPGOptimizeRoute"));
   if (wp) {
+    #ifdef PGOPT_FIX
+    if (PGOptimizeRoute_Config != (wp->GetDataField()->GetAsInteger())) {
+    #else
     if (PGOptimizeRoute != (wp->GetDataField()->GetAsInteger())) {
+    #endif
+      #ifdef PGOPT_FIX
+      PGOptimizeRoute_Config = (wp->GetDataField()->GetAsInteger());
+      PGOptimizeRoute = PGOptimizeRoute_Config;
+      #else
       PGOptimizeRoute = (wp->GetDataField()->GetAsInteger());
+      #endif
 
       if (ISPARAGLIDER) {
 	    if(PGOptimizeRoute) {

--- a/Common/Source/Globals.cpp
+++ b/Common/Source/Globals.cpp
@@ -272,7 +272,9 @@ void Globals_Init(void) {
   McOverlay=true;
   TrackBar=false;
   PGOptimizeRoute=true;
-
+  #ifdef PGOPT_FIX
+  PGOptimizeRoute_Config=true;
+  #endif
   WindCalcSpeed=0;
   WindCalcTime=WCALC_TIMEBACK;
   RepeatWindCalc=false;

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -509,7 +509,11 @@ void LKParseProfileString(const TCHAR *sname, const TCHAR *svalue) {
  // PREAD(sname,svalue,szRegistryPGNumberOfGates,&PGNumberOfGates);
  // PREAD(sname,svalue,szRegistryPGOpenTimeH,&PGOpenTimeH);
  // PREAD(sname,svalue,szRegistryPGOpenTimeM,&PGOpenTimeM);
+  #ifdef PGOPT_FIX
+  PREAD(sname,svalue,szRegistryPGOptimizeRoute,&PGOptimizeRoute_Config);
+  #else
   PREAD(sname,svalue,szRegistryPGOptimizeRoute,&PGOptimizeRoute);
+  #endif
  // PREAD(sname,svalue,szRegistryPGStartOut,&PGStartOut);
   PREAD(sname,svalue,szRegistryPilotName,&*PilotName_Config);
   PREAD(sname,svalue,szRegistryLiveTrackersrv,&*LiveTrackersrv_Config);

--- a/Common/Source/LKProfileResetDefault.cpp
+++ b/Common/Source/LKProfileResetDefault.cpp
@@ -236,6 +236,9 @@ void LKProfileResetDefault(void) {
   TrackBar=1;
 
   PGOptimizeRoute=true;
+  #ifdef PGOPT_FIX
+  PGOptimizeRoute_Config = true;
+  #endif
 
   GlideBarMode = (GlideBarMode_t)gbDisabled;
 

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -253,7 +253,11 @@ void LKProfileSave(const TCHAR *szFile)
   rprintf(szRegistryPGAutoZoomThreshold,PGAutoZoomThreshold);
   rprintf(szRegistryPGClimbZoom,PGClimbZoom);
   rprintf(szRegistryPGCruiseZoom,PGCruiseZoom);
+  #ifdef PGOPT_FIX
+  rprintf(szRegistryPGOptimizeRoute,PGOptimizeRoute_Config);
+  #else
   rprintf(szRegistryPGOptimizeRoute,PGOptimizeRoute);
+  #endif
 // >> Moved to PilotFile <<
 //  rprintf(szRegistryPilotName,PilotName_Config);
 //  >> Moved to AircraftFile <<

--- a/Common/Source/SaveLoadTask/ClearTask.cpp
+++ b/Common/Source/SaveLoadTask/ClearTask.cpp
@@ -18,6 +18,9 @@ void ClearTask(void) {
   LockTaskData();
   TaskModified = true; 
   TargetModified = true;
+  #ifdef PGOPT_FIX
+  if (ISPARAGLIDER) PGOptimizeRoute = PGOptimizeRoute_Config;
+  #endif
   LastTaskFileName[0] = _T('\0');
   ActiveWayPoint = -1;
 


### PR DESCRIPTION
This change fixes a problem I recently noticed – that the “Optimized Route” runtime and saved configuration settings used the same variable.  This fix adds a new PGOptimizedRoute_Config variable (to the existing PGOptimizedRoute variable) and changes code in a few places to use the appropriate one of the two variables for this setting.  For example, using a custom key to toggle this setting in flight no longer changes the setting as saved to the profile.  And when the task is cleared, the runtime setting is set to match the saved configuration setting.  This change makes LK more consistent in the behavior of on/off settings that both exist in a config menu and can be assigned to a custom key.
