### PR TITLE
allow non-landable WP definition in WP notes file

### DIFF
--- a/Common/Source/AirfieldDetails.cpp
+++ b/Common/Source/AirfieldDetails.cpp
@@ -15,12 +15,6 @@
 #include "AirfieldDetails.h"
 #include <zzip/lib.h>
 
-// Allow a non-landable waypoint to be designated as the home
-// waypoint in the waypoint notes file.  HG/PG pilots usually
-// can't land back at the takeoff position but might like to
-// start there when in simulator mode.
-#define NOLAND_HOME_WP
-
 ZZIP_FILE* zAirfieldDetails = NULL;
 
 static TCHAR szAirfieldDetailsFile[MAX_PATH] = TEXT("\0");
@@ -73,20 +67,11 @@ void LookupAirfieldDetail(TCHAR *Name, TCHAR *Details) {
   TCHAR NameC[100];
   TCHAR NameD[100];
   TCHAR TmpName[100];
-
-#ifndef NOLAND_HOME_WP
-  bool isHome, isPreferred;
-#else
   bool isHome, isPreferred, isLandable;
-#endif
 
   if (!WayPointList) return;
 
   for(i=NUMRESWP;i<(int)NumberOfWayPoints;i++) {
-
-    #ifndef NOLAND_HOME_WP
-      if (((WayPointList[i].Flags & AIRPORT) == AIRPORT) || ((WayPointList[i].Flags & LANDPOINT) == LANDPOINT)) { 
-    #endif
 
 	_tcscpy(UName, WayPointList[i].Name);
 
@@ -100,31 +85,22 @@ void LookupAirfieldDetail(TCHAR *Name, TCHAR *Details) {
 
 	isHome=false;
 	isPreferred=false;
-    #ifdef NOLAND_HOME_WP
-      isLandable = (((WayPointList[i].Flags & AIRPORT) == AIRPORT) || 
-                   ((WayPointList[i].Flags & LANDPOINT) == LANDPOINT));
-    #endif
+    isLandable = (((WayPointList[i].Flags & AIRPORT) == AIRPORT) || 
+                 ((WayPointList[i].Flags & LANDPOINT) == LANDPOINT));
 
 	_stprintf(TmpName,TEXT("%s=HOME"),UName);
 	if ( (_tcscmp(Name, TmpName)==0) )  isHome=true;
 
-  #ifdef NOLAND_HOME_WP
   // Only bother checking whether it's preferred if it's landable.
   if (isLandable) {
-  #endif
 	_stprintf(TmpName,TEXT("%s=PREF"),UName);
 	if ( (_tcscmp(Name, TmpName)==0) )  isPreferred=true;
 	_stprintf(TmpName,TEXT("%s=PREFERRED"),UName);
 	if ( (_tcscmp(Name, TmpName)==0) )  isPreferred=true;
-  #ifdef NOLAND_HOME_WP
   }
-  #endif
 
 	if ( isHome==true ) {
-    #ifdef NOLAND_HOME_WP
-    if (isLandable)
-    #endif
-	  WayPointCalc[i].Preferred = true;
+      if (isLandable) WayPointCalc[i].Preferred = true;
 	  HomeWaypoint = i;
 	  AirfieldsHomeWaypoint = i; // make it survive a reset..
 	}
@@ -148,11 +124,6 @@ void LookupAirfieldDetail(TCHAR *Name, TCHAR *Details) {
 	    } 
 	    return;
 	  }
-
-    #ifndef NOLAND_HOME_WP // end of "if airport or landpoint" block
-      }
-    #endif
-
     }
 }
 


### PR DESCRIPTION
This just makes permanent the change I made a couple of years ago to allow the definition of the home waypoint in a waypoint notes file.  This issue is discussed in this forum topic: http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=5754.
