### PR TITLE
Y-Grid in MM3 did not exclude SeaLevel indicator

### DIFF
--- a/Common/Source/Draw/Multimaps/RenderNearAirspace.cpp
+++ b/Common/Source/Draw/Multimaps/RenderNearAirspace.cpp
@@ -438,6 +438,8 @@ if(bValid)
 	 ytick = ytick * FEET_FACTOR;
 
   _stprintf(text, TEXT("%s"),Units::GetUnitName(Units::GetUserAltitudeUnit()));
+  if(sDia.fYMin < GC_SEA_LEVEL_TOLERANCE)
+	  rc.bottom -= SV_BORDER_Y; /* scale witout sea  */
   DrawYGrid(hdc, rc, ytick/ALTITUDEMODIFY,ytick, 0,TEXT_UNDER_RIGHT ,Sideview_TextColor,  &sDia, text);
 
 


### PR DESCRIPTION
Bug reported here:
http://www.postfrontal.com/forum/topic.asp?whichpage=1&TOPIC_ID=7515&#64645
