### PR TITLE
In sim mode with wind, allow only AutoWind=Manual

### DIFF
--- a/Common/Data/Dialogs/dlgWindSettings.xml
+++ b/Common/Data/Dialogs/dlgWindSettings.xml
@@ -9,7 +9,7 @@
     <WndProperty Name="prpDirection" Caption="_@M237_" X="10" Y="-997"  Width="210" Height="40" CaptionWidth="74" Font="1" Help="_@H611_" Keyboard="1">
       <DataField Name="" DataType="double" DisplayFormat="%.0f°" EditFormat="%.0f" Min="0" Max="355" Step="1" OnDataAccess="OnWindDirectionData"/>
     </WndProperty>
-    <WndProperty Name="prpAutoWind" Caption="_@M114_" X="10" Y="-997" Width="210" Height="25" CaptionWidth="74" Font="2" Help="_@H612_">
+    <WndProperty Name="prpAutoWind" Caption="_@M114_" X="10" Y="-997" Width="210" Height="25" CaptionWidth="74" Font="2" Help="_@H139_">
       <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
     </WndProperty>
     <WndProperty Name="prpTrailDrift" Caption="_@M739_" X="10" Y="-1"  Width="210" Height="25" CaptionWidth="74" Font="2" Help="_@H613_">

--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -175,12 +175,13 @@ and when your best alternate option is changing. Warnings will not happen below 
 This determines whether the configuration settings dialog is accessible during flight. 
 
 @139
-This allows switching on or off the automatic wind algorithm.  When the algorithm is switched off, 
-the pilot is responsible for setting the wind estimate.
-[Circling] Requires only a GPS source
-[ZigZag] requires an intelligent vario with airspeed output.
-[Both] Use ZigZag and circling.
-[External] Use only wind calculated by external instrument (like CAI, LX, ZANDER etc.)
+This controls if and how the wind speed and direction are automatically calculated.
+[Manual] Pilot manually enters wind info.
+[Circling] Requires only a GPS source.
+[ZigZag] Requires an intelligent vario with airspeed output.
+[Both] ZigZag and Circling.
+[External] Wind is calculated by an external instrument (like CAI, LX, Zander, etc.) or Condor.
+In simulator mode, Manual is the only option.
 
 @140
 This is the INDICATED AIR SPEED to hold in straight flight before asking for TrueWind calculation. 
@@ -880,14 +881,6 @@ Manual adjustment of wind speed.
 
 @611
 Manual adjustment of wind direction.
-
-@612
-This allows switching on or off the automatic wind algorithm.  
-When the algorithm is switched off, the pilot is responsible for setting the wind estimate.
-[Circling] Requires only a GPS source
-[ZigZag] requires an intelligent vario with airspeed output.
-[Both] Use ZigZag and circling.
-[External] Use only wind calculated by external instrument (like CAI, LX, ZANDER etc.)
 
 @613
 Determines whether the snail trail is drifted with the wind when displayed in circling mode.

--- a/Common/Data/Language/ToDo.TXT
+++ b/Common/Data/Language/ToDo.TXT
@@ -34,6 +34,8 @@ Things to be fixed in LK languages files/tokens:
 - New H1213 pg autozoom threshold
 - New help 916 -> 924
 - New help 505 field "Line" 
+- Removed H612.  It was a duplicate of H139.
+- Changed H139.
 
   NEW MSG TOKENS
   --------------

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -32,6 +32,10 @@
 #include "BtHandler.h"
 #include <functional>
 
+#define SIM_MANUAL_WIND // In sim mode, only allow Auto Wind to be "Manual"
+// There's an identical #define in dlgWindSettings.cpp, where there are
+// related changes.
+
 
 extern void UpdateAircraftConfig(void);
 extern void dlgCustomMenuShowModal(void);
@@ -3976,7 +3980,13 @@ int ival;
   if (wp) {
     if (AutoWindMode_Config != wp->GetDataField()->GetAsInteger()) {
       AutoWindMode_Config = wp->GetDataField()->GetAsInteger();
+      #ifdef SIM_MANUAL_WIND
+      
+      // In sim mode, auto wind is always "Manual".
+      if (!SIMMODE) AutoWindMode = AutoWindMode_Config;
+      #else
       AutoWindMode = AutoWindMode_Config;
+      #endif
     }
   }
 

--- a/Common/Source/Dialogs/dlgWindSettings.cpp
+++ b/Common/Source/Dialogs/dlgWindSettings.cpp
@@ -10,6 +10,10 @@
 #include "LKProfiles.h"
 #include "Dialogs.h"
 
+#define SIM_MANUAL_WIND // In sim mode, only allow Auto Wind to be "Manual"
+// There's an identical #define in dlgConfiguration.cpp, where there are
+// related changes.
+
 extern HWND   hWndMainWindow;
 static WndForm *wf=NULL;
 
@@ -121,12 +125,23 @@ void dlgWindSettingsShowModal(void){
       dfe = (DataFieldEnum*)wp->GetDataField();
 	// LKTOKEN  _@M418_ = "Manual" 
       dfe->addEnumText(gettext(TEXT("_@M418_")));
+      
+      #ifdef SIM_MANUAL_WIND
+      // In sim mode, Manual is the only option.
+      if (!SIMMODE) {
+        dfe->addEnumText(MsgToken(175)); // "Circling"
+        dfe->addEnumText(gettext(TEXT("ZigZag")));
+        dfe->addEnumText(MsgToken(149)); // "Both"
+        dfe->addEnumText(MsgToken(1793)); // "External"
+      }
+      #else
 	// LKTOKEN  _@M175_ = "Circling" 
       dfe->addEnumText(gettext(TEXT("_@M175_")));
       dfe->addEnumText(gettext(TEXT("ZigZag")));
 	// LKTOKEN  _@M149_ = "Both" 
       dfe->addEnumText(gettext(TEXT("_@M149_")));
       dfe->addEnumText(MsgToken(1793)); // External
+      #endif
 
       wp->GetDataField()->Set(AutoWindMode);
       wp->RefreshDisplay();


### PR DESCRIPTION
This is a fix to a minor sim mode issue.  The problem is that if one circles in sim mode with AutoWind=Circling, after a couple of circles, the wind is reset to zero.  This fix makes it so that if the user creates wind in sim mode, AutoWind=Manual (by allowing only this option in the wind settings dialog).  While I was at it, I found and eliminated a duplicate help message for AutoWind.  I updated the help message to reflect this change and rewrote it a little.
