### PR TITLE
Task for GA fixes

### DIFF
--- a/Common/Source/Calc/Task/CheckStartRestartFinish.cpp
+++ b/Common/Source/Calc/Task/CheckStartRestartFinish.cpp
@@ -142,6 +142,13 @@ StartupStore(_T("... CheckStart Timenow=%d OpenTime=%d CloseTime=%d ActiveGate=%
 	StartupStore(_T("... CheckStart: start crossed and valid gate!\n"));
 	#endif
 	
+	if(ISGAAIRCRAFT) {
+		Calculated->ValidStart = true;
+		ActiveWayPoint=0; // enforce this since it may be 1
+		StartTask(Basic,Calculated, true, false);
+		return;
+	}
+
     // ToLo: Check weather speed and height are within the rules or not (zero margin)
     if(!IsFinalWaypoint() && ValidStartSpeed(Basic, Calculated) && InsideStartHeight(Basic, Calculated)) {
 
@@ -226,7 +233,7 @@ void CheckFinish(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
                          ActiveWayPoint);
     if (!Calculated->ValidFinish) {
       Calculated->ValidFinish = true;
-      AnnounceWayPointSwitch(Calculated, false);
+      if(!ISGAAIRCRAFT) AnnounceWayPointSwitch(Calculated, false);
 
       // JMWX save calculated data at finish
       memcpy(&Finish_Derived_Info, Calculated, sizeof(DERIVED_INFO));

--- a/Common/Source/SaveLoadTask/LoadGpxTask.cpp
+++ b/Common/Source/SaveLoadTask/LoadGpxTask.cpp
@@ -119,16 +119,24 @@ bool LoadGpxTask(LPCTSTR szFileName) {
 		free(szXML);
 	} //if(stream)
 
-	//Set options for GA aircraft
+	if(ISGAAIRCRAFT) { //Set options for GA aircraft
+		StartLine=1; //Line
+		StartRadius=1000;
+		SectorType=LINE;
+		SectorRadius=1000;
+		FinishLine=0; //Circle
+		FinishRadius=500;
+	} else {
+		StartLine=2; //Sector
+		StartRadius=1500;
+		SectorType=CIRCLE;
+		SectorRadius=2000;
+		FinishLine=0; //Circle
+		FinishRadius=3000;
+	}
 	AutoAdvance=1; //Auto
 	AATEnabled=false;
 	PGOptimizeRoute=false;
-	StartLine=2; //Sector
-	StartRadius=1500;
-	SectorType=LINE;
-	SectorRadius=2000;
-	FinishLine=0; //Circle
-	FinishRadius=1000;
 	StartHeightRef=1; //ASL
 	RefreshTask();
 	TaskModified = false;


### PR DESCRIPTION
Only for General Aviation: if close to the departure airport consider departure WP already reached and task started, don't display start and finish popups. GA pilots are using the task as their flight plan so first and last WP are the departure and destination airports and they are usually not doing a competition. If we are at departure airport we can consider start line already crossed. And to avoid to display start and and end task popups while beeping during the delicate take off and landing procedures is better for GA.
Other smaller improvements to: LoadGpxTask.cpp and InTurnSector.cpp
