### PR TITLE
GA Task: start at departure, remove start-end popups, draw WP lines

### DIFF
--- a/Common/Source/Calc/Task/CheckStartRestartFinish.cpp
+++ b/Common/Source/Calc/Task/CheckStartRestartFinish.cpp
@@ -142,6 +142,13 @@ StartupStore(_T("... CheckStart Timenow=%d OpenTime=%d CloseTime=%d ActiveGate=%
 	StartupStore(_T("... CheckStart: start crossed and valid gate!\n"));
 	#endif
 	
+	if(ISGAAIRCRAFT) {
+		Calculated->ValidStart = true;
+		ActiveWayPoint=0; // enforce this since it may be 1
+		StartTask(Basic,Calculated, true, false);
+		return;
+	}
+
     // ToLo: Check weather speed and height are within the rules or not (zero margin)
     if(!IsFinalWaypoint() && ValidStartSpeed(Basic, Calculated) && InsideStartHeight(Basic, Calculated)) {
 
@@ -226,7 +233,7 @@ void CheckFinish(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
                          ActiveWayPoint);
     if (!Calculated->ValidFinish) {
       Calculated->ValidFinish = true;
-      AnnounceWayPointSwitch(Calculated, false);
+      if(!ISGAAIRCRAFT) AnnounceWayPointSwitch(Calculated, false);
 
       // JMWX save calculated data at finish
       memcpy(&Finish_Derived_Info, Calculated, sizeof(DERIVED_INFO));

--- a/Common/Source/Calc/Task/InStartSector.cpp
+++ b/Common/Source/Calc/Task/InStartSector.cpp
@@ -70,10 +70,23 @@ bool InStartSector(NMEA_INFO *Basic, DERIVED_INFO *Calculated, int &index, BOOL 
   static bool LastInSector = false;
   static int EntryStartSector = index;
 
+  if(ISGAAIRCRAFT) { //Detect start for GA aircraft
+  	if(!ValidTaskPoint(ActiveWayPoint) || !ValidTaskPoint(0)) return false;
+  	if(ActiveWayPoint==0) { //if the next WP is the departure
+  		LockTaskData();
+  		double departureRadius=1000; //1 Km default departure radius
+  		if(WayPointList[Task[0].Index].RunwayLen>0) departureRadius=WayPointList[Task[0].Index].RunwayLen/2; // if we have runaway length available
+  		if(Calculated->WaypointDistance<=departureRadius) *CrossedStart=true; //consider in departure as reached
+  		else *CrossedStart=false;
+  		UnlockTaskData();
+  		if(*CrossedStart) return true;
+  	} else return false;
+  }
+
   bool isInSector= false;
   bool retval=false;
 
-  if (!Calculated->Flying || !ValidTaskPoint(ActiveWayPoint) || !ValidTaskPoint(0)) 
+  if (!Calculated->Flying || !ValidTaskPoint(ActiveWayPoint) || !ValidTaskPoint(0))
 	return false;
 
   LockTaskData();

--- a/Common/Source/Draw/DrawTask.cpp
+++ b/Common/Source/Draw/DrawTask.cpp
@@ -225,7 +225,17 @@ DoInit[MDI_DRAWTASK]=false;
                     break;
                 case LINE:
                     if (!AATEnabled) { // this Type exist only if not AAT task
-                        _DrawLine(hdc, PS_SOLID, NIBLSCALE(3), Task[i].Start, Task[i].End, taskcolor, rc);
+                    	if(ISGAAIRCRAFT) {
+                    		POINT start,end;
+                    		double rotation=AngleLimit360(Task[i].Bisector-DisplayAngle);
+                    		int length=14*ScreenScale; //Make intermediate WP lines always of the same size independent by zoom level
+                    		start.x=WayPointList[Task[i].Index].Screen.x+(long)(length*fastsine(rotation));
+                    		start.y=WayPointList[Task[i].Index].Screen.y-(long)(length*fastcosine(rotation));
+                    		rotation=Reciprocal(rotation);
+                    		end.x=WayPointList[Task[i].Index].Screen.x+(long)(length*fastsine(rotation));
+                    		end.y=WayPointList[Task[i].Index].Screen.y-(long)(length*fastcosine(rotation));
+                    		_DrawLine(hdc, PS_SOLID, NIBLSCALE(3), start, end, taskcolor, rc);
+                    	} else _DrawLine(hdc, PS_SOLID, NIBLSCALE(3), Task[i].Start, Task[i].End, taskcolor, rc);
                     }
                     break;
                 case CONE:

--- a/Common/Source/SaveLoadTask/LoadGpxTask.cpp
+++ b/Common/Source/SaveLoadTask/LoadGpxTask.cpp
@@ -119,16 +119,24 @@ bool LoadGpxTask(LPCTSTR szFileName) {
 		free(szXML);
 	} //if(stream)
 
-	//Set options for GA aircraft
+	if(ISGAAIRCRAFT) { //Set options for GA aircraft
+		StartLine=1; //Line
+		StartRadius=1000;
+		SectorType=LINE;
+		SectorRadius=1000;
+		FinishLine=0; //Circle
+		FinishRadius=500;
+	} else {
+		StartLine=2; //Sector
+		StartRadius=1500;
+		SectorType=CIRCLE;
+		SectorRadius=2000;
+		FinishLine=0; //Circle
+		FinishRadius=3000;
+	}
 	AutoAdvance=1; //Auto
 	AATEnabled=false;
 	PGOptimizeRoute=false;
-	StartLine=2; //Sector
-	StartRadius=1500;
-	SectorType=LINE;
-	SectorRadius=2000;
-	FinishLine=0; //Circle
-	FinishRadius=1000;
 	StartHeightRef=1; //ASL
 	RefreshTask();
 	TaskModified = false;


### PR DESCRIPTION
For General Aviation: if close to the departure airport consider departure WP already reached and task started, don't display start and finish popups. GA pilots are using the task as their flight plan so first and last WP are the departure and destination airports and they are usually not doing a competition. If we are at departure airport we can consider start line already crossed. And to avoid to display start and and end task popups while beeping during the delicate take off and landing procedures is better for GA.

For GA the intermediate waypoints are usually of type LINE, and doesn't matter where we cross the line (bisector) to switch to the next WP, the field "sector radius" is not used. So here with this change only for GA the intermediate WPs as LINE are drawn always of the same size independently by zoom level. This because in case of more WPs close to each other (for example the WPs defining a circuit pattern) with high level of zoom the lines (if related to a distance on the ground) can cross each other resulting in an ugly and confusing aspect.

LoadGpxTask.cpp is now considering by default intermediate WPs of type LINE only for GA and of type CIRCLE for other categories.
