### PR TITLE
VSI: Vertical Situation Indicator

### DIFF
--- a/Common/Source/Draw/DrawHSI.cpp
+++ b/Common/Source/Draw/DrawHSI.cpp
@@ -15,6 +15,7 @@
 #include "LKObjects.h"
 #include "RGB.h"
 #include "DoInits.h"
+#include "LKStyle.h"
 
 #ifndef __MINGW32__
 #define DEG "\xB0"
@@ -166,7 +167,7 @@ HSIreturnStruct MapWindow::DrawHSI(HDC hDC, const RECT rc) {
         VSIlabelX=VSIleftBorder+(ScreenLandscape?(NIBLSCALE(2)):(-NIBLSCALE(5)));
         VSIlabelUpY=VSItopBorder-NIBLSCALE(5);
         VSIlabelDwY=VSIbottomBorder+NIBLSCALE(5);
-        VSImarkerBaseX=VSIrightBorder+NIBLSCALE((ScreenSize==ss800x480 || ScreenSize==ss480x272)?5:3);
+        VSImarkerBaseX=VSIrightBorder+NIBLSCALE((ScreenSize==ss800x480 || ScreenSize==ss480x272)?5:2);
         vsiOOSdwMarkerUp=VSIbottomBorder-NIBLSCALE(1);
         vsiOOSdwMarkerMid=VSIbottomBorder+NIBLSCALE(2);
         vsiOOSdwMarkerDw=VSIbottomBorder+NIBLSCALE(5);
@@ -220,6 +221,7 @@ HSIreturnStruct MapWindow::DrawHSI(HDC hDC, const RECT rc) {
     bool validActiveWP=false, validPreviousWP=false;
     int currentWP=0, finalWP=0, RunwayLen=0, QFU=0;
     double WPaltitude=0, prevWPaltitude=0, WPleg=0;
+    short WPstyle;
 
     //Critical section: copy the needed data from Task and WayPoint list
     LockTaskData(); // protect Task & WayPointList
@@ -228,6 +230,7 @@ HSIreturnStruct MapWindow::DrawHSI(HDC hDC, const RECT rc) {
             validActiveWP=true;
             currentWP=ActiveWayPoint;
             finalWP=getFinalWaypoint();
+            WPstyle=WayPointList[Task[ActiveWayPoint].Index].Style;
             RunwayLen=WayPointList[Task[ActiveWayPoint].Index].RunwayLen;
             WPaltitude= WayPointList[Task[ActiveWayPoint].Index].Altitude;
             QFU=WayPointList[Task[ActiveWayPoint].Index].RunwayDir; //get runaway orientation
@@ -260,8 +263,7 @@ HSIreturnStruct MapWindow::DrawHSI(HDC hDC, const RECT rc) {
             _stprintf(Buffer,TEXT("FPM")); //measure unit
             SelectObject(hDC, LK8PanelUnitFont);
             LKWriteText(hDC,Buffer,VertSpeedX,VertSpeedUnitY,0, WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
-
-            if(DerivedDrawInfo.WaypointDistance<fiveNauticalMiles) { //if we are close to the destination
+            if(DerivedDrawInfo.WaypointDistance<fiveNauticalMiles && WPstyle>=STYLE_AIRFIELDGRASS && WPstyle<=STYLE_AIRFIELDSOLID) { //if we are close to the destination airport
                 if(DerivedDrawInfo.WaypointDistance<1500) returnStruct.landing=true; //if at less than 1.5 Km don't show glide slope bar
                 else { //Build glide slope bar
                     //Calculate glide slope inclination to reach the destination runaway

--- a/Common/Source/Draw/LKDrawInfoPage.cpp
+++ b/Common/Source/Draw/LKDrawInfoPage.cpp
@@ -962,7 +962,12 @@ label_HSI:
 			_stprintf(BufferUnit,_T(""));
 			WriteInfo(hdc, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
 			LKFormatValue(LK_FIN_DIST, true, BufferValue, BufferUnit, BufferTitle);
-			WriteInfo(hdc, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[15], &qcolumn[15],&qrow[7],&qrow[8],&qrow[6]);
+			if(ScreenSize==ss800x480 || ScreenSize==ss480x272)
+				WriteInfo(hdc, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[15], &qcolumn[15],&qrow[7],&qrow[8],&qrow[6]);
+			else {
+				_stprintf(BufferUnit,_T(""));
+				WriteInfo(hdc, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[7],&qrow[8],&qrow[6]);
+			}
 			LKFormatValue(LK_FIN_ETA, true, BufferValue, BufferUnit, BufferTitle);
 			_stprintf(BufferUnit,_T(""));
 			WriteInfo(hdc, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);


### PR DESCRIPTION
GA pilots are often planning the altitude to keep between all the WPs in their route, for example:
![altitudegraph](https://f.cloud.github.com/assets/3354240/2304405/03a11502-a21c-11e3-953d-da36a56fb6fe.png)

This change allows to compare our current altitude with the one planned in the flight plan giving intuitive indications on a bar displayed in the HSI screen:
![lk8000-vsi](https://f.cloud.github.com/assets/3354240/2304406/0eec81b2-a21c-11e3-8a80-0aeffe54dd12.png)

In this example the VSI (Vertical Situation Indicator) bar it is telling that we are under our planned route of more than 300 ft and that the ground is just at 300 ft (100 m) below us.

VSI bar is displayed only if we have a task loaded and if the glide slope bar is not already shown.
