### PR TITLE
fix possible buffer overflow if device send NMEA string with exactly 160 char

### DIFF
--- a/Common/Source/Comm/ComPort.cpp
+++ b/Common/Source/Comm/ComPort.cpp
@@ -142,7 +142,9 @@ DWORD ComPort::RxThreadProc(LPVOID prt) {
 }
 
 void ComPort::ProcessChar(char c) {
-    if (pLastNmea >= begin(_NmeaString) && pLastNmea < end(_NmeaString)) {
+    // last char need to be reserved for '\0' for avoid buffer overflow
+    // in theory this should never happen because NMEA sentence can't have more than 82 char and _NmeaString size is 160.
+    if (pLastNmea >= begin(_NmeaString) && (pLastNmea+1) < end(_NmeaString)) {
 
         if (c == '\n' || c == '\r') {
             // abcd\n , now closing the line also with \r


### PR DESCRIPTION
in theory never happen, max string length is 82 char
cf. NMEA standard :

"NMEA 0183 sentences sentence is limited to 79 characters or less. This length limit excludes the $ and the [CR][LF] characters."
