### PR TITLE
switchable optimizer mode regarding this discussion

### DIFF
--- a/Common/Data/Language/DEFAULT_MENU.TXT
+++ b/Common/Data/Language/DEFAULT_MENU.TXT
@@ -815,10 +815,9 @@ location=7
 mode=Display2
 type=key
 data=9
-event=Null
-label=$(AC03)
+event=Service OPTIMODE
+label=_@M2251_
 location=8
-
 
 mode=Display2
 type=key

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -1360,6 +1360,10 @@ _@M1293_ "SONAR"
 #1294 REMOVED UNUSED
 _@M1294_ "Sonar OFF"
 _@M1295_ "Sideview"
+_@M1296_ "Optimizer"
+_@M1297_ "FAI Start on turnpoint"
+_@M1298_ "FAI Start on leg"
+_@M1299_ "FAI Mercedes star"
 
 # LK info page headers, try to use the same or less number of chars here,
 # or test it with different screen reolutions and landscape/portrait mode too!
@@ -2168,6 +2172,8 @@ _@M2248_  "No Near Object found!"
 _@M2249_  "DspMode"
 
 _@M2250_ "Ext. Sound"
+_@M2251_  "Optimizer\nmode"
+
 
 # MAX 2500! 
 # (Reserved for custom menus up to 2300!)

--- a/Common/Header/ContestMgr.h
+++ b/Common/Header/ContestMgr.h
@@ -51,6 +51,10 @@ public:
     TYPE_FAI_3_TPS,                               /**< @brief FAI with 3 turnpoints */
     TYPE_FAI_3_TPS_PREDICTED,                     /**< @brief FAI with 3 turnpoints predicted for returning to start */
     TYPE_FAI_TRIANGLE,                            /**< @brief FAI triangle 2 turnpoints predicted for returning to start */
+    TYPE_FAI_TRIANGLE4,                            /**< @brief FAI triangle 3 turnpoints predicted for returning to start "Start On Leg" */
+#ifdef   FIVEPOINT_OPTIMIZER
+    TYPE_FAI_TRIANGLE5,                            /**< @brief FAI triangle 2 turnpoints predicted for returning to start */
+#endif
     TYPE_NUM,                                     /**< @brief Do not use it! */
     TYPE_INVALID = TYPE_NUM
   };
@@ -154,7 +158,7 @@ private:
 
 public:
 
-
+  void RefreshFAIOptimizer(void);
   static CContestMgr &Instance() { return _instance; }
   static const TCHAR *TypeToString(TType type);
   

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -890,6 +890,7 @@ GEXTERN int  Multimap_SizeY[MP_TOP+1];
 // Global, not saved to profile
 GEXTERN bool Flags_DrawTask;
 GEXTERN bool Flags_DrawFAI;
+GEXTERN unsigned int FAI_OptimizerMode;
 
 GEXTERN unsigned int Trip_Moving_Time;
 GEXTERN unsigned int Trip_Steady_Time;

--- a/Common/Header/LKInterface.h
+++ b/Common/Header/LKInterface.h
@@ -98,8 +98,9 @@ typedef enum{
 	ckSonarToggle,
 	ckResetView,
 	ckMapOrient,
-        ckResetComm,
+	ckResetComm,
 	ckDspMode,
+	ckOtimizerPointsToggle,
 	ckTOP,
 } CustomKeyMode_t;
 

--- a/Common/Header/options.h
+++ b/Common/Header/options.h
@@ -138,7 +138,9 @@
   #define OWN_FLARM_TRACES
 //  #define FLARM_MS    // not implemented inside Multiselect dialog.
   #define OUTLINE_2ND		// double outline airspaces
+//  #define FIVEPOINT_OPTIMIZER
 #endif
+
 
 /*
  * MULTISELECT OPTIONS 

--- a/Common/Source/Calc/ContestMgr.cpp
+++ b/Common/Source/Calc/ContestMgr.cpp
@@ -35,11 +35,18 @@ const TCHAR *CContestMgr::TypeToString(TType type)
     _T("OLC-League"),
     _T("FAI 3 TPs"),
     _T("FAI 3 TPs (P)"),
-    _T("FAI triangle (P)"),
+ //   _T("FAI start on turnpoint (P)"),
+ //   _T("FAI start on leg (P)"),
+ //   _T("FAI mercedes star (P)"),
+    MsgToken(1297) ,   //    _@M1297_ "FAI Start on turnpoint"
+    MsgToken(1298)  ,  //    _@M1298_ "FAI Start on leg"
+    MsgToken(1299)  ,  //    _@M1299_ "FAI Mercedes star"
+    _T("FAI Mercedes star (P)"),
     _T("[invalid]") 
   };
   return typeStr[type];
 }
+
 
 
 
@@ -286,6 +293,18 @@ void CContestMgr::PointsResult(TType type, const CTrace &traceResult)
 }
 
 
+void CContestMgr::RefreshFAIOptimizer(void)
+{
+      CCriticalSection::CGuard guard(_mainCS);
+      {
+        CCriticalSection::CGuard Traceguard(_traceCS);
+        _trace->Compress();
+      }
+    SolvePoints(*_trace, false, true);
+    SolveOLCPlus(true);
+
+}
+
 /** 
  * @brief Solve point based contest
  * 
@@ -372,7 +391,7 @@ else*/
 
     PointsResult(predicted ? TYPE_FAI_3_TPS_PREDICTED : TYPE_FAI_3_TPS, traceResult);
 
-    traceResult.Compress(3);
+    traceResult.Compress(FAI_OptimizerMode);
     if(predicted)
     {
       // do it just in a case if predicted trace is worst than the current one

--- a/Common/Source/Dialogs/AddCustomKeyList.cpp
+++ b/Common/Source/Dialogs/AddCustomKeyList.cpp
@@ -102,7 +102,8 @@ void AddCustomKeyList( DataFieldEnum* dfe) {
     dfe->addEnumTextNoLF(MsgToken(2038)); // Map Orient
     dfe->addEnumTextNoLF(MsgToken(928)); //Restarting Comm Ports
     dfe->addEnumTextNoLF(MsgToken(2249)); // DspMode , not to be translated
-
+    dfe->addEnumTextNoLF(MsgToken(2251)); // Optimizer Mode
+    
     dfe->Sort(0);
 
 }

--- a/Common/Source/Dialogs/Analysis/RenderContest.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderContest.cpp
@@ -18,8 +18,15 @@ CContestMgr::TType contestType = CContestMgr::TYPE_OLC_CLASSIC;
  ****************************************************************/
 void Statistics::RenderContest(LKSurface& Surface, const RECT& rc)
 {
-if(contestType == CContestMgr::TYPE_FAI_TRIANGLE)
-   RenderFAIOptimizer(Surface, rc);
+if((contestType == CContestMgr::TYPE_FAI_TRIANGLE)
+   || (contestType == CContestMgr::TYPE_FAI_TRIANGLE4)
+#ifdef  FIVEPOINT_OPTIMIZER
+   || (contestType == CContestMgr::TYPE_FAI_TRIANGLE5)
+#endif
+  )
+{
+    RenderFAIOptimizer(Surface, rc);
+}
 else
 {
   unsigned int ui;
@@ -203,9 +210,9 @@ double fTotalPercent = 1.0;
 ResetScale();
 
 
-  CContestMgr::CResult result = CContestMgr::Instance().Result(contestType, true);
+  CContestMgr::CResult result = CContestMgr::Instance().Result( CContestMgr::TYPE_FAI_TRIANGLE, true);
   const CPointGPSArray &points = result.PointArray();
-  if(contestType == CContestMgr::TYPE_FAI_TRIANGLE)
+//  if(contestType == CContestMgr::TYPE_FAI_TRIANGLE)
      fXY_Scale = 1.5;
 
   // find center
@@ -252,7 +259,7 @@ ResetScale();
 
   ScaleMakeSquare(rc);
 
-  if(result.Type() == contestType)
+  if(result.Type() ==  CContestMgr::TYPE_FAI_TRIANGLE)
   {
     for(ui=0; ui<points.size()-1; ui++)
     {

--- a/Common/Source/Dialogs/Analysis/Update.cpp
+++ b/Common/Source/Dialogs/Analysis/Update.cpp
@@ -225,7 +225,7 @@ void UpdateAnalysis(void){
     } 
     waInfo->SetCaption(sTmp);
     break;
-  case ANALYSIS_PAGE_CONTEST:
+case ANALYSIS_PAGE_CONTEST:
     _stprintf(sTmp, TEXT("%s: %s - %s"), 
               // LKTOKEN  _@M93_ = "Analysis" 
               gettext(TEXT("_@M93_")),
@@ -235,11 +235,30 @@ void UpdateAnalysis(void){
     wfa->SetCaption(sTmp);
     
     {
+      bool typeFAITriangle = false;
+
       CContestMgr::CResult result = CContestMgr::Instance().Result(contestType, false);
-      if(result.Type() == contestType) {
+
+      switch (contestType)
+      {
+        case CContestMgr::TYPE_FAI_TRIANGLE:  typeFAITriangle = true; FAI_OptimizerMode =3; break;
+        case CContestMgr::TYPE_FAI_TRIANGLE4: typeFAITriangle = true; FAI_OptimizerMode =4; break;
+#ifdef  FIVEPOINT_OPTIMIZER
+        case CContestMgr::TYPE_FAI_TRIANGLE5: typeFAITriangle = true; FAI_OptimizerMode =5;	break;
+#endif
+        default: break;
+      }
+
+      if(typeFAITriangle)
+	  {
+		 result = CContestMgr::Instance().Result(CContestMgr::TYPE_FAI_TRIANGLE, false);
+		 CContestMgr::Instance().RefreshFAIOptimizer();
+	  }
+      if ((result.Type() == contestType) || typeFAITriangle)
+      {
         BOOL bFAI = CContestMgr::Instance().FAI();
         double  fDist     = result.Distance();
-        if(!bFAI && (result.Type() == CContestMgr::TYPE_FAI_TRIANGLE))  // was only !bFAI
+        if(!bFAI && ( typeFAITriangle))  // was only !bFAI
         	fDist /=2.0;
         double  fCPDist   = CContestMgr::Instance().GetClosingPointDist();
         double  fB_CPDist = CContestMgr::Instance().GetBestClosingPointDist();
@@ -249,12 +268,12 @@ void UpdateAnalysis(void){
 
 
         TCHAR distStr[50];  TCHAR speedStr[50];
-        if((result.Type() == CContestMgr::TYPE_FAI_TRIANGLE) && bFAI)
+        if(typeFAITriangle && bFAI)
           _stprintf(distStr, _T("%.1f %s FAI\r\n"), DISTANCEMODIFY * fDist, Units::GetDistanceName());
         else
           _stprintf(distStr, _T("%.1f %s\r\n"), DISTANCEMODIFY * fDist, Units::GetDistanceName());
 
-        if((result.Type() == CContestMgr::TYPE_FAI_TRIANGLE) && bFAI )
+        if(typeFAITriangle && bFAI )
           _stprintf(speedStr, _T("%s%-.1f %s\r\n(%.1f %%)\r\n"),gettext(TEXT("_@M1508_")),  DISTANCEMODIFY * fCPDist, Units::GetDistanceName(),fCPDist/fDist*100.0);
         else
           _stprintf(speedStr, TEXT("%.1f %s\r\n"),TASKSPEEDMODIFY * result.Speed(), Units::GetTaskSpeedName());
@@ -262,7 +281,7 @@ void UpdateAnalysis(void){
         Units::TimeToText(timeTempStr, result.Duration());
         TCHAR timeStr[50];
 
-        if( (result.Type() == CContestMgr::TYPE_FAI_TRIANGLE) && bFAI && ISPARAGLIDER)
+        if( typeFAITriangle && bFAI && ISPARAGLIDER)
           _stprintf(timeStr, _T("\r\n%s%-.1f %s\r\n(%.1f %%)\r\n"),gettext(TEXT("_@M1511_")), DISTANCEMODIFY * fB_CPDist, Units::GetDistanceName(), fB_CPDist/fDist*100.0); //_@M1511_ = "B:"
         else
           _stprintf(timeStr, _T("%s\r\n"), timeTempStr);
@@ -270,6 +289,10 @@ void UpdateAnalysis(void){
         TCHAR scoreStr[50] = _T("");
         if(result.Type() != CContestMgr::TYPE_FAI_3_TPS &&
            result.Type() != CContestMgr::TYPE_FAI_TRIANGLE &&
+           result.Type() != CContestMgr::TYPE_FAI_TRIANGLE4 &&
+#ifdef  FIVEPOINT_OPTIMIZER
+           result.Type() != CContestMgr::TYPE_FAI_TRIANGLE5 &&
+#endif
            result.Type() != CContestMgr::TYPE_FAI_3_TPS_PREDICTED)
           _stprintf(scoreStr, TEXT("%.2f pt\r\n"), result.Score());
         

--- a/Common/Source/Dialogs/Analysis/dlgStatistics.cpp
+++ b/Common/Source/Dialogs/Analysis/dlgStatistics.cpp
@@ -230,9 +230,25 @@ static void OnCalcClicked(WndButton* pWnd){
     case CContestMgr::TYPE_OLC_CLASSIC:
       contestType = CContestMgr::TYPE_FAI_TRIANGLE;
       break;
+      
     case CContestMgr::TYPE_FAI_TRIANGLE:
+      contestType = CContestMgr::TYPE_FAI_TRIANGLE4;
+      FAI_OptimizerMode = 4;
+      CContestMgr::Instance().RefreshFAIOptimizer();
+      break;
+    case CContestMgr::TYPE_FAI_TRIANGLE4:
+#ifdef  FIVEPOINT_OPTIMIZER
+      contestType = CContestMgr::TYPE_FAI_TRIANGLE5;
+      FAI_OptimizerMode = 5;
+
+      CContestMgr::Instance().RefreshFAIOptimizer();
+      break;
+
+    case CContestMgr::TYPE_FAI_TRIANGLE5:
+#endif
       contestType = CContestMgr::TYPE_OLC_FAI;
       break;
+      
     case CContestMgr::TYPE_OLC_FAI:
       contestType = CContestMgr::TYPE_OLC_CLASSIC_PREDICTED;
       break;

--- a/Common/Source/InputEvents.cpp
+++ b/Common/Source/InputEvents.cpp
@@ -2249,6 +2249,13 @@ void InputEvents::eventService(const TCHAR *misc) {
 	ToggleDrawTaskFAI();
 	return;
   }
+  
+  if (_tcscmp(misc, TEXT("OPTIMODE")) == 0) {
+	  CustomKeyHandler(ckOtimizerPointsToggle+1000); // passthrough mode
+	return;
+  }
+
+  
   if (_tcscmp(misc, TEXT("SONAR")) == 0) {
 	CustomKeyHandler(ckSonarToggle+1000); // passthrough mode
 	return;

--- a/Common/Source/LKInterface/LKCustomKeyHandler.cpp
+++ b/Common/Source/LKInterface/LKCustomKeyHandler.cpp
@@ -386,6 +386,42 @@ passthrough:
         else
             LKSound(TEXT("LK_TONEDOWN.WAV"));
 		return true;
+	case ckOtimizerPointsToggle:
+		FAI_OptimizerMode++;
+#ifdef FIVEPOINT_OPTIMIZER
+		if(FAI_OptimizerMode > 5)
+#else
+		if(FAI_OptimizerMode > 4)
+#endif
+			FAI_OptimizerMode = 3;
+		TCHAR Optimizermsg[60];
+
+		switch(FAI_OptimizerMode)
+		{
+		  case 5:
+		   _stprintf(Optimizermsg,_T("%s: %s"),MsgToken(1296),MsgToken(1299)); // _@M1296_ "FAI Optimizer"  _@M1299_ "Mercedes star"
+		  break;
+		  case 4:
+		   _stprintf(Optimizermsg,_T("%s: %s"),MsgToken(1296),MsgToken(1298)); // _@M1296_ "FAI Optimizer"  "Start on leg"
+		  break;
+		  case 3:
+		  default:
+		   _stprintf(Optimizermsg,_T("%s: %s"),MsgToken(1296),MsgToken(1297)); // _@M1296_ "FAI Optimizer"  "Start on turnpoint"
+		   break;
+		}
+
+
+		 CContestMgr::Instance().RefreshFAIOptimizer();
+
+		DoStatusMessage(Optimizermsg,NULL,false);
+
+		if (EnableSoundModes) {
+			if (FAI_OptimizerMode == 5)
+				LKSound(TEXT("LK_TONEUP.WAV"));
+			else
+				LKSound(TEXT("LK_TONEDOWN.WAV"));
+		}
+		return true;                
 	case ckResetView:
 		ModeType[LKMODE_MAP]    =       MP_MOVING;
 		ModeType[LKMODE_INFOMODE]=      IM_CRUISE;
@@ -516,6 +552,7 @@ CustomKeyLabel[57]=2246;	// Reset view
 CustomKeyLabel[58]=2038;	// Map Orientation
 CustomKeyLabel[59]=928;		// Restarting Comm Ports
 CustomKeyLabel[60]=2249;	// DspMode
+CustomKeyLabel[61]=2251;	// Optimizer Mode
 
 static_assert(60 < array_size(CustomKeyLabel), "invalid CustomKeyLabel array size");
 }

--- a/Common/Source/LKProfileResetDefault.cpp
+++ b/Common/Source/LKProfileResetDefault.cpp
@@ -342,7 +342,7 @@ void LKProfileResetDefault(void) {
   OverlayClock = 0;
   UseTwoLines = 0;
   SonarWarning_Config = 1; // sonar enabled by default on reset
-
+  FAI_OptimizerMode = 5;
   // default BB and IP is all ON
   ConfBB0 = 0; // TRM is off by default on v4
   ConfBB1 = 1;


### PR DESCRIPTION
http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=7234
Display2/3 -> Optimizer mode
switches between
"Start on turnpoint"
an 
"Start on Leg"
optimisation
Also added this to custom key and custom Menu respectively
Not only for paragliders very interesting

Here we can see the difference:
The standard "Start on turnpoint" is useless in this case.
![turn1](https://cloud.githubusercontent.com/assets/1188401/11425280/0cf5c6b2-9454-11e5-8f38-c9184b36339b.png)

Here we see that "Start on Leg" already finds a FAI triangle in the same situation
![leg](https://cloud.githubusercontent.com/assets/1188401/11425291/2e454356-9454-11e5-94b8-e34db04ea542.png)




