### PR TITLE
Fix Freetype TextSize

### DIFF
--- a/Common/Source/Draw/LKDrawLook8000.cpp
+++ b/Common/Source/Draw/LKDrawLook8000.cpp
@@ -503,19 +503,18 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
 
                 // Req. Speed For reach Gate
                 if (LKFormatValue(LK_START_SPEED, false, BufferValue, BufferUnit, BufferTitle)) {
-                    Surface.SelectObject(LK8OverlayBigFont);
+                    Surface.SelectObject(LK8TargetFont);
                     Surface.GetTextSize(BufferUnit, _tcslen(BufferUnit), &TextSize);
                     rcx -= TextSize.cx;
-                    Surface.SelectObject(LK8TargetFont);
                     Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
                     rcx -= (TextSize.cx + NIBLSCALE(2));
                     rcy += TextSize.cy-NIBLSCALE(2);
 
-                    LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                    LKWriteText(Surface, BufferValue, rcx, rcy + (TextSize.cy / 3), 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
 
-                    Surface.SelectObject(LK8OverlayBigFont);
                     LKWriteText(Surface, BufferUnit, rcx + TextSize.cx + NIBLSCALE(2), rcy + (TextSize.cy / 3), 0,
                             WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                    Surface.SelectObject(LK8OverlayBigFont);
                 }
             }
 

--- a/Common/Source/Screen/LKSurface.cpp
+++ b/Common/Source/Screen/LKSurface.cpp
@@ -576,7 +576,7 @@ void LKSurface::DrawText(int X, int Y, const TCHAR* lpString, UINT cbCount, RECT
         if(ClipRect) {
             _pCanvas->DrawClippedText(X, Y, *ClipRect, lpString);
         } else {
-            _pCanvas->DrawText(X, Y, lpString, cbCount);
+            _pCanvas->DrawText(X, Y, lpString);
         }
     }    
 #endif    

--- a/Common/Source/xcs/Screen/FreeType/Font.cpp
+++ b/Common/Source/xcs/Screen/FreeType/Font.cpp
@@ -359,11 +359,15 @@ Font::TextSize(const TCHAR *text) const
   }
 
   if(glyph) {
-      // fix width for last glyph
-      x -= glyph->advance.x;
-      x += glyph->metrics.horiBearingX + glyph->metrics.width;
+      /* fix width for last glyph, horiBearingX+Width can be greater than advance, in most case for Oblique font.
+       * this fix need to be done only if advance is lower than horiBearingX+Width, otherwise, we broke right aligned text.
+       */
+      const FT_Pos offset = glyph->metrics.horiBearingX + glyph->metrics.width - glyph->advance.x;
+      if(offset > 0) {
+        x += offset;
+      }
   }
-  
+
   if(demibold) {
       // glyph are embolben by 32 (0.5 px), so for avoid rouding artefact, we need to had 1px to width;
       x += (1<<6);


### PR DESCRIPTION
horiBearingX+Width can be greater than advance, in most case for Oblique font.
this fix need to be done only if advance is lower than horiBearingX+Width, otherwise, we broke right aligned text.

append to commit eb3dfc1b499dca639558dd23bd56a9938c325b87