### PR TITLE
Fix text Clipping.

### DIFF
--- a/Common/Header/MapWindow.h
+++ b/Common/Header/MapWindow.h
@@ -474,8 +474,8 @@ class MapWindow {
   static void SuspendDrawingThread(void);
   static void ResumeDrawingThread(void);
   
-  static void LKWriteText(LKSurface& Surface, const TCHAR* wText, int x, int y, int maxsize, const bool mode, const short align, const LKColor& rgb_tex, bool invertable, RECT* ClipRect = nullptr);
-  static void LKWriteBoxedText(LKSurface& Surface, const RECT& clipRect, const TCHAR* wText, int x, int y, int maxsize, const short align, const LKColor& rgb_dir, const LKColor& rgb_inv );
+  static void LKWriteText(LKSurface& Surface, const TCHAR* wText, int x, int y, const bool mode, const short align, const LKColor& rgb_tex, bool invertable, RECT* ClipRect = nullptr);
+  static void LKWriteBoxedText(LKSurface& Surface, const RECT& clipRect, const TCHAR* wText, int x, int y, const short align, const LKColor& rgb_dir, const LKColor& rgb_inv );
 
   static bool LKFormatValue(const short fvindex, const bool longtitle, TCHAR *BufferValue, TCHAR *BufferUnit, TCHAR *BufferTitle);
   static void LKFormatBrgDiff(const int wpindex, const bool wpvirtual, TCHAR *BufferValue, TCHAR *BufferUnit);
@@ -632,7 +632,7 @@ private:
 
   static void DoSonar(void);
 
-  static bool TextInBox(LKSurface& Surface, const RECT *area, const TCHAR* Value, int x, int y, int size, TextInBoxMode_t *Mode, bool noOverlap=false);
+  static bool TextInBox(LKSurface& Surface, const RECT *area, const TCHAR* Value, int x, int y, TextInBoxMode_t *Mode, bool noOverlap=false);
   static void VGTextInBox(LKSurface& Surface, const unsigned short nslot, const short numlines, const TCHAR* wText1, const TCHAR *wText2, const TCHAR *wText3, int x, int y, const LKColor& trgb, const LKBrush& bbrush);
   static void ToggleFullScreenStart();
   static bool WaypointInTask(int ind);

--- a/Common/Source/Dialogs/Analysis/DrawOtherFunctions.cpp
+++ b/Common/Source/Dialogs/Analysis/DrawOtherFunctions.cpp
@@ -13,15 +13,14 @@ void Statistics::DrawLabel(LKSurface& Surface, const RECT& rc, const TCHAR *text
 			   const double xv, const double yv) {
 
   SIZE tsize;
-  Surface.GetTextSize(text, _tcslen(text), &tsize);
+  Surface.GetTextSize(text, &tsize);
   int x = (int)((xv-x_min)*xscale)+rc.left-tsize.cx/2+BORDER_X;
   int y = (int)((y_max-yv)*yscale)+rc.top-tsize.cy/2;
-//  SetBkMode(hdc, OPAQUE);
   if(INVERTCOLORS)
     Surface.SelectObject(LK_BLACK_PEN);
 
 
-  Surface.DrawText(x, y, text, _tcslen(text));
+  Surface.DrawText(x, y, text);
   Surface.SetBackgroundTransparent();
 }
 
@@ -32,13 +31,13 @@ void Statistics::DrawNoData(LKSurface& Surface, const RECT& rc) {
   TCHAR text[80];
 	// LKTOKEN  _@M470_ = "No data" 
   _stprintf(text,TEXT("%s"), gettext(TEXT("_@M470_")));
-  Surface.GetTextSize(text, _tcslen(text), &tsize);
+  Surface.GetTextSize(text, &tsize);
   int x = (int)(rc.left+rc.right-tsize.cx)/2;
   int y = (int)(rc.top+rc.bottom-tsize.cy)/2;
   #if (WINDOWSPC>0)
   Surface.SetBackgroundOpaque();
   #endif
-  Surface.DrawText(x, y, text, _tcslen(text));
+  Surface.DrawText(x, y, text);
   Surface.SetBackgroundTransparent();
 }
 
@@ -47,13 +46,13 @@ void Statistics::DrawNoData(LKSurface& Surface, const RECT& rc) {
 void Statistics::DrawXLabel(LKSurface& Surface, const RECT& rc, const TCHAR *text) {
   SIZE tsize;
   const auto hfOld = Surface.SelectObject(LK8GenericVar03Font);
-  Surface.GetTextSize(text, _tcslen(text), &tsize);
+  Surface.GetTextSize(text, &tsize);
   int x = rc.right-tsize.cx-IBLSCALE(3);
   int y = rc.bottom-tsize.cy;
   if(INVERTCOLORS)
     Surface.SelectObject(LK_BLACK_PEN);
 
-  Surface.DrawText(x, y, text, _tcslen(text));
+  Surface.DrawText(x, y, text);
   Surface.SelectObject(hfOld);
 }
 
@@ -61,14 +60,14 @@ void Statistics::DrawXLabel(LKSurface& Surface, const RECT& rc, const TCHAR *tex
 void Statistics::DrawYLabel(LKSurface& Surface, const RECT& rc, const TCHAR *text) {
   SIZE tsize;
   const auto hfOld = Surface.SelectObject(LK8GenericVar03Font);
-  Surface.GetTextSize(text, _tcslen(text), &tsize);
+  Surface.GetTextSize(text, &tsize);
   int x = max(2,(int)rc.left-(int)tsize.cx);
   int y = rc.top;
   if(INVERTCOLORS)
     Surface.SelectObject(LK_BLACK_PEN);
 
 
-  Surface.DrawText(x, y, text, _tcslen(text));
+  Surface.DrawText(x, y, text);
   Surface.SelectObject(hfOld);
 }
 

--- a/Common/Source/Dialogs/Analysis/DrawXYGrid.cpp
+++ b/Common/Source/Dialogs/Analysis/DrawXYGrid.cpp
@@ -51,8 +51,8 @@ void Statistics::DrawXGrid(LKSurface& Surface, const RECT& rc,
 	FormatTicText(unit_text, xval*unit_step/tic_step, unit_step);
 
 //	SetBkMode(hdc, OPAQUE);
-	Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
-	Surface.DrawText(xmin-tsize.cx/2, ymax-tsize.cy, unit_text, _tcslen(unit_text));
+	Surface.GetTextSize(unit_text, &tsize);
+	Surface.DrawText(xmin-tsize.cx/2, ymax-tsize.cy, unit_text);
 	Surface.SetBackgroundTransparent();
       }
     }
@@ -81,8 +81,8 @@ void Statistics::DrawXGrid(LKSurface& Surface, const RECT& rc,
 	TCHAR unit_text[MAX_PATH];
 	FormatTicText(unit_text, xval*unit_step/tic_step, unit_step);
 //	SetBkMode(hdc, OPAQUE);
-	Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
-	Surface.DrawText(xmin-tsize.cx/2, ymax-tsize.cy, unit_text, _tcslen(unit_text));
+	Surface.GetTextSize(unit_text, &tsize);
+	Surface.DrawText(xmin-tsize.cx/2, ymax-tsize.cy, unit_text);
 	Surface.SetBackgroundTransparent();
       }
     }
@@ -132,8 +132,8 @@ void Statistics::DrawYGrid(LKSurface& Surface, const RECT& rc,
 	TCHAR unit_text[MAX_PATH];
 	FormatTicText(unit_text, yval*unit_step/tic_step, unit_step);
 //	SetBkMode(hdc, OPAQUE);
-	Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
-	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text, _tcslen(unit_text));
+	Surface.GetTextSize(unit_text, &tsize);
+	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text);
 //	SetBkMode(hdc, TRANSPARENT);
       }
     }
@@ -160,8 +160,8 @@ void Statistics::DrawYGrid(LKSurface& Surface, const RECT& rc,
 	TCHAR unit_text[MAX_PATH];
 	FormatTicText(unit_text, yval*unit_step/tic_step, unit_step);
 //	SetBkMode(hdc, OPAQUE);
-	Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
-	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text, _tcslen(unit_text));
+	Surface.GetTextSize(unit_text, &tsize);
+	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text);
 //	SetBkMode(hdc, TRANSPARENT);
       }
     }
@@ -210,8 +210,8 @@ void Statistics::DrawYGrid_cor(LKSurface& Surface, const RECT& rc,
 	TCHAR unit_text[MAX_PATH];
 	FormatTicText(unit_text, yval*unit_step/tic_step, unit_step);
 //	SetBkMode(hdc, OPAQUE);
-	Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
-	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text, _tcslen(unit_text));
+	Surface.GetTextSize(unit_text, &tsize);
+	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text);
 //	SetBkMode(hdc, TRANSPARENT);
       }
     }
@@ -238,8 +238,8 @@ void Statistics::DrawYGrid_cor(LKSurface& Surface, const RECT& rc,
 	TCHAR unit_text[MAX_PATH];
 	FormatTicText(unit_text, yval*unit_step/tic_step, unit_step);
 //	SetBkMode(hdc, OPAQUE);
-	Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
-	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text, _tcslen(unit_text));
+	Surface.GetTextSize(unit_text, &tsize);
+	Surface.DrawText(xmin, ymin-tsize.cy/2, unit_text);
 //	SetBkMode(hdc, TRANSPARENT);
       }
     }

--- a/Common/Source/Dialogs/Analysis/RenderContest.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderContest.cpp
@@ -348,13 +348,13 @@ ResetScale();
 		  SIZE tsize;
 		  fTotalPercent -= fDist/result.Distance();
 		  _stprintf(text, TEXT("%3.1f%%"), (fDist/result.Distance()*100.0));
-		  Surface.GetTextSize(text, _tcslen(text), &tsize);
+		  Surface.GetTextSize(text, &tsize);
                   #ifndef UNDITHER
 		  Surface.SetTextColor(RGB_BLUE);
                   #else
 		  Surface.SetTextColor(RGB_BLACK);
                   #endif
-	      Surface.DrawText(ScaleX(rc, x1 +( x2-x1)/2)-tsize.cx/2,   ScaleY(rc,y1 + (y2-y1)/2), text, _tcslen(text));
+	      Surface.DrawText(ScaleX(rc, x1 +( x2-x1)/2)-tsize.cx/2,   ScaleY(rc,y1 + (y2-y1)/2), text);
 	    }
 	#endif
 
@@ -394,13 +394,13 @@ ResetScale();
 	    TCHAR text[180];
 	    SIZE tsize;
 	    _stprintf(text, TEXT("%3.1f%%"), (fTotalPercent*100.0));
-	    Surface.GetTextSize(text, _tcslen(text), &tsize);
+	    Surface.GetTextSize(text, &tsize);
             #ifndef UNDITHER
 	    Surface.SetTextColor(RGB_LIGHTBLUE);
             #else
 	    Surface.SetTextColor(RGB_RED);
             #endif
-	    Surface.DrawText(ScaleX(rc, x1 +( x2-x1)/2)-tsize.cx/2,   ScaleY(rc,y1 + (y2-y1)/2), text, _tcslen(text));
+	    Surface.DrawText(ScaleX(rc, x1 +( x2-x1)/2)-tsize.cx/2,   ScaleY(rc,y1 + (y2-y1)/2), text);
 #endif
 
 	    lat0 = CContestMgr::Instance().GetClosingPoint().Latitude();

--- a/Common/Source/Dialogs/Analysis/RenderFAISector.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderFAISector.cpp
@@ -465,7 +465,7 @@ int iCnt = 0;
     else
       _stprintf(text, TEXT("%i"), (int)(fDistTri*DISTANCEMODIFY));
     bFirstUnit = false;
-    Surface.GetTextSize(text, _tcslen(text), &tsize);
+    Surface.GetTextSize(text, &tsize);
     #ifndef UNDITHER
     Surface.SetTextColor(RGB_GREY);
     #else
@@ -524,7 +524,7 @@ int iCnt = 0;
 
       if(j==0)
       {
-        Surface.DrawText(line[0].x, line[0].y, text, _tcslen(text));
+        Surface.DrawText(line[0].x, line[0].y, text);
         j=1;
 
       }

--- a/Common/Source/Dialogs/Analysis/RenderGlidePolar.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderGlidePolar.cpp
@@ -128,11 +128,11 @@ void Statistics::RenderGlidePolar(LKSurface& Surface, const RECT& rc)
 
       for(unsigned i = 0; i<array_size(text); ++i) {
         SIZE sizeTmp;
-        Surface.GetTextSize(text[i], _tcslen(text[i]), &sizeTmp);
+        Surface.GetTextSize(text[i], &sizeTmp);
         tsize.cx = std::max(tsize.cx, sizeTmp.cx);
         tsize.cy = std::max(tsize.cy, sizeTmp.cy);
 
-        Surface.GetTextSize(value[i], _tcslen(value[i]), &sizeTmp);
+        Surface.GetTextSize(value[i], &sizeTmp);
         vsize.cx = std::max(vsize.cx, sizeTmp.cx);
         vsize.cy = std::max(vsize.cy, sizeTmp.cy);
 
@@ -148,8 +148,8 @@ void Statistics::RenderGlidePolar(LKSurface& Surface, const RECT& rc)
       Surface.FillRect(&blockR, INVERTCOLORS?LKBrush_White:LKBrush_Black);
 
       for(unsigned i = 0; i<array_size(text); ++i) {
-        Surface.DrawText(blockR.left, blockR.top+tsize.cy*i, text[i], _tcslen(text[i]), NULL);
-        Surface.DrawText(blockR.left+tsize.cx, rc.top+tsize.cy*i, value[i], _tcslen(value[i]), NULL);
+        Surface.DrawText(blockR.left, blockR.top+tsize.cy*i, text[i]);
+        Surface.DrawText(blockR.left+tsize.cx, rc.top+tsize.cy*i, value[i]);
       }
       Surface.SelectObject(hfOldU);
     }
@@ -181,14 +181,14 @@ void Statistics::RenderGlidePolar(LKSurface& Surface, const RECT& rc)
     _stprintf(text,TEXT("%s %.1f kg/m2"),
 	             gettext(TEXT("_@M821_")), // Wing load
 	             GlidePolar::WingLoading);
-    Surface.DrawText(rc.left+IBLSCALE(30), rc.bottom-IBLSCALE(90), text, _tcslen(text), NULL);
+    Surface.DrawText(rc.left+IBLSCALE(30), rc.bottom-IBLSCALE(90), text);
   }
   _stprintf(text, TEXT("%s: %3.1f  @ %3.0f %s"),
 		MsgToken(140), // Best LD
                   GlidePolar::bestld,
                   GlidePolar::Vbestld()*SPEEDMODIFY,
                   Units::GetHorizontalSpeedName());
-  Surface.DrawText(rc.left+IBLSCALE(30), rc.bottom-IBLSCALE(70), text, _tcslen(text));
+  Surface.DrawText(rc.left+IBLSCALE(30), rc.bottom-IBLSCALE(70), text);
 
   _stprintf(text, TEXT("%s: %3.2f %s @ %3.0f %s"),
 		MsgToken(437), // Min sink
@@ -196,7 +196,7 @@ void Statistics::RenderGlidePolar(LKSurface& Surface, const RECT& rc)
                   Units::GetVerticalSpeedName(),
                   GlidePolar::Vminsink()*SPEEDMODIFY,
                   Units::GetHorizontalSpeedName());
-  Surface.DrawText(rc.left+IBLSCALE(30), rc.bottom-IBLSCALE(50), text, _tcslen(text));
+  Surface.DrawText(rc.left+IBLSCALE(30), rc.bottom-IBLSCALE(50), text);
 
   Surface.SelectObject(hfOldU);
   Surface.SetBackgroundTransparent();

--- a/Common/Source/Dialogs/dlgAirspace.cpp
+++ b/Common/Source/Dialogs/dlgAirspace.cpp
@@ -73,12 +73,12 @@ static void OnAirspacePaintListItem(WindowControl * Sender, LKSurface& Surface){
       if (iswarn) {
 	// LKTOKEN  _@M789_ = "Warn" 
         _tcscpy(label, gettext(TEXT("_@M789_")));
-        Surface.DrawText(w0-w1-w2, 2*ScreenScale, label, _tcslen(label));
+        Surface.DrawText(w0-w1-w2, 2*ScreenScale, label);
       }
       if (isdisplay) {
 	// LKTOKEN  _@M241_ = "Display" 
         _tcscpy(label, gettext(TEXT("_@M241_")));
-        Surface.DrawText(w0-w2, 2*ScreenScale, label, _tcslen(label));
+        Surface.DrawText(w0-w2, 2*ScreenScale, label);
       }
 
     }

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -523,19 +523,19 @@ static void OnPaintListItem(WindowControl * Sender, LKSurface& Surface){
 	  LK_tcsncpy(sTmp, CAirspaceManager::Instance().GetAirspaceTypeShortText(AirspaceSelectInfo[i].Type), 4);
       // left justified
      
-      Surface.DrawText(x1, 2*ScreenScale, sTmp, _tcslen(sTmp));
+      Surface.DrawText(x1, 2*ScreenScale, sTmp);
 
       // right justified after airspace type
       _stprintf(sTmp, TEXT("%.0f%s"), 
                 AirspaceSelectInfo[i].Distance,
                 Units::GetDistanceName());
       x2 = w0-w3-Surface.GetTextWidth(sTmp);
-      Surface.DrawText(x2, 2*ScreenScale, sTmp, _tcslen(sTmp));
+      Surface.DrawText(x2, 2*ScreenScale, sTmp);
       
       // right justified after distance
       _stprintf(sTmp, TEXT("%d%s"),  iround(AirspaceSelectInfo[i].Direction), gettext(_T("_@M2179_")));
       x3 = w0-Surface.GetTextWidth(sTmp);
-      Surface.DrawText(x3, 2*ScreenScale, sTmp, _tcslen(sTmp));
+      Surface.DrawText(x3, 2*ScreenScale, sTmp);
     } else {
       // should never get here!
     }
@@ -543,7 +543,7 @@ static void OnPaintListItem(WindowControl * Sender, LKSurface& Surface){
     if (DrawListIndex == 0){
 	// LKTOKEN  _@M466_ = "No Match!" 
       _stprintf(sTmp, TEXT("%s"), gettext(TEXT("_@M466_")));
-      Surface.DrawText(2*ScreenScale, 2*ScreenScale, sTmp, _tcslen(sTmp));
+      Surface.DrawText(2*ScreenScale, 2*ScreenScale, sTmp);
     }
   }
 }

--- a/Common/Source/Dialogs/dlgChecklist.cpp
+++ b/Common/Source/Dialogs/dlgChecklist.cpp
@@ -114,7 +114,7 @@ static void OnPaintDetailsListItem(WindowControl * Sender, LKSurface& Surface){
       LKASSERT(DrawListIndex>=0);
       const TCHAR* szText = aTextLine[DrawListIndex];
       Surface.SetTextColor(RGB_BLACK);
-      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText, _tcslen(szText));
+      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText);
   }
 }
 

--- a/Common/Source/Dialogs/dlgHelp.cpp
+++ b/Common/Source/Dialogs/dlgHelp.cpp
@@ -44,7 +44,7 @@ static void OnPaintDetailsListItem(WindowControl * Sender, LKSurface& Surface){
       LKASSERT(DrawListIndex>=0);
       const TCHAR* szText = aTextLine[DrawListIndex];
       Surface.SetTextColor(RGB_BLACK);
-      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText, _tcslen(szText));
+      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText);
   }
 }
 

--- a/Common/Source/Dialogs/dlgMultiSelectList.cpp
+++ b/Common/Source/Dialogs/dlgMultiSelectList.cpp
@@ -417,12 +417,12 @@ static void OnMultiSelectListPaintListItem(WindowControl * Sender, LKSurface& Su
         int iLen = _tcslen(text1);
         if (iLen > 100)
             iLen = 100;
-        Surface.DrawText((int) (PICTO_WIDTH * 1.1) * ScreenScale, 2 * ScreenScale, text1, iLen);
+        Surface.DrawText((int) (PICTO_WIDTH * 1.1) * ScreenScale, 2 * ScreenScale, text1);
         Surface.SetTextColor(RGB_DARKBLUE);
         iLen = _tcslen(text2);
         if (iLen > 100)
             iLen = 100;
-        Surface.DrawText((int) (PICTO_WIDTH * 1.1) * ScreenScale, 15 * ScreenScale, text2, iLen);
+        Surface.DrawText((int) (PICTO_WIDTH * 1.1) * ScreenScale, 15 * ScreenScale, text2);
 
     }
 }

--- a/Common/Source/Dialogs/dlgProgress.cpp
+++ b/Common/Source/Dialogs/dlgProgress.cpp
@@ -51,7 +51,7 @@ static void OnProgressPaint(WindowControl * Sender, LKSurface& Surface) {
   InflateRect(&PrintAreaR, -NIBLSCALE(2), -NIBLSCALE(2));
   
   const TCHAR* text = Sender->GetCaption();
-  Surface.DrawText(text,_tcslen(text), &PrintAreaR, DT_VCENTER|DT_SINGLELINE);
+  Surface.DrawText(text, &PrintAreaR, DT_VCENTER|DT_SINGLELINE);
 
   Surface.SelectObject(ohB);
   Surface.SelectObject(ohP);

--- a/Common/Source/Dialogs/dlgStartPoint.cpp
+++ b/Common/Source/Dialogs/dlgStartPoint.cpp
@@ -51,7 +51,7 @@ static void OnStartPointPaintListItem(WindowControl * Sender, LKSurface& Surface
       }
     }
     Surface.SetTextColor(RGB_BLACK);
-    Surface.DrawText(2*ScreenScale, 2*ScreenScale, label, _tcslen(label));
+    Surface.DrawText(2*ScreenScale, 2*ScreenScale, label);
   }
 }
 

--- a/Common/Source/Dialogs/dlgStartup.cpp
+++ b/Common/Source/Dialogs/dlgStartup.cpp
@@ -72,10 +72,10 @@ void RawWrite(LKSurface& Surface, const TCHAR *text, int line, short fsize, cons
     }
     Surface.SetBackgroundTransparent();
     SIZE tsize;
-    Surface.GetTextSize(text, _tcslen(text), &tsize);
+    Surface.GetTextSize(text, &tsize);
     const int y = tsize.cy * (line - 1) + (tsize.cy / 2);
 
-    MapWindow::LKWriteText(Surface, text, ScreenSizeX / 2, y, 0, wtmode, WTALIGN_CENTER, rgbcolor, false);
+    MapWindow::LKWriteText(Surface, text, ScreenSizeX / 2, y, wtmode, WTALIGN_CENTER, rgbcolor, false);
     Surface.SelectObject(oldfont);
 }
 

--- a/Common/Source/Dialogs/dlgTaskOverview.cpp
+++ b/Common/Source/Dialogs/dlgTaskOverview.cpp
@@ -127,10 +127,10 @@ static void OnTaskPaintListItem(WindowControl * Sender, LKSurface& Surface){
       _stprintf(sTmp, TEXT("%.0f %s"), 
 		Task[i].Leg*DISTANCEMODIFY,
 		Units::GetDistanceName());
-      Surface.DrawText(Sender->GetHeight()+p1+w1-Surface.GetTextWidth(sTmp), TextMargin, sTmp, _tcslen(sTmp));
+      Surface.DrawText(Sender->GetHeight()+p1+w1-Surface.GetTextWidth(sTmp), TextMargin, sTmp);
 
       _stprintf(sTmp, TEXT("%d%s"),  iround(Task[i].InBound),gettext(_T("_@M2179_")));
-      Surface.DrawText(Sender->GetHeight()+p2+w2-Surface.GetTextWidth(sTmp), TextMargin, sTmp, _tcslen(sTmp));
+      Surface.DrawText(Sender->GetHeight()+p2+w2-Surface.GetTextWidth(sTmp), TextMargin, sTmp);
       
     }
 
@@ -143,13 +143,13 @@ static void OnTaskPaintListItem(WindowControl * Sender, LKSurface& Surface){
 
 	// LKTOKEN  _@M832_ = "add waypoint" 
       _stprintf(sTmp, TEXT("  (%s)"), gettext(TEXT("_@M832_")));
-      Surface.DrawText(Sender->GetHeight()+2*ScreenScale, TextMargin, sTmp, _tcslen(sTmp));
+      Surface.DrawText(Sender->GetHeight()+2*ScreenScale, TextMargin, sTmp);
     } else if ((DrawListIndex==n+1) && ValidTaskPoint(0)) {
 
       if (!AATEnabled || ISPARAGLIDER) {
 	// LKTOKEN  _@M735_ = "Total:" 
 	_tcscpy(sTmp, gettext(TEXT("_@M735_")));
-	Surface.DrawText(Sender->GetHeight()+2*ScreenScale, TextMargin, sTmp, _tcslen(sTmp));
+	Surface.DrawText(Sender->GetHeight()+2*ScreenScale, TextMargin, sTmp);
       
 	if (fai_ok) {
 	  _stprintf(sTmp, TEXT("%.0f %s FAI"), lengthtotal*DISTANCEMODIFY,
@@ -158,7 +158,7 @@ static void OnTaskPaintListItem(WindowControl * Sender, LKSurface& Surface){
 	  _stprintf(sTmp, TEXT("%.0f %s"), lengthtotal*DISTANCEMODIFY,
 		    Units::GetDistanceName());
 	}
-	Surface.DrawText(Sender->GetHeight()+p1+w1-Surface.GetTextWidth(sTmp), TextMargin, sTmp, _tcslen(sTmp));
+	Surface.DrawText(Sender->GetHeight()+p1+w1-Surface.GetTextWidth(sTmp), TextMargin, sTmp);
 
       } else {
 
@@ -178,7 +178,7 @@ static void OnTaskPaintListItem(WindowControl * Sender, LKSurface& Surface){
 		  DISTANCEMODIFY*lengthtotal,
 		  DISTANCEMODIFY*d1,
 		  Units::GetDistanceName());
-	Surface.DrawText(Sender->GetHeight()+2*ScreenScale, TextMargin, sTmp, _tcslen(sTmp));
+	Surface.DrawText(Sender->GetHeight()+2*ScreenScale, TextMargin, sTmp);
       } 
     }
   }

--- a/Common/Source/Dialogs/dlgTerminal.cpp
+++ b/Common/Source/Dialogs/dlgTerminal.cpp
@@ -51,13 +51,13 @@ static void OnPaintListItem(WindowControl * Sender, LKSurface& Surface){
 
   _stprintf(tmps,_T("[ Rx=%ld ErrRx=%ld Tx=%ld ErrTx=%ld ]"),
       ComPortRx[active],ComPortErrRx[active],ComPortTx[active],ComPortErrTx[active]);
-  Surface.DrawText(0, 0, tmps, _tcslen(tmps));
+  Surface.DrawText(0, 0, tmps);
   y+=hline;
 
 
   if (ComCheck_Reset>=0 || (ComCheck_LastLine==0 && ComCheck_BufferFull==false)) {
       _stprintf(tmps,_T("%s"),MsgToken(1872)); // NO DATA RECEIVED
-      Surface.DrawText(0, y, tmps, _tcslen(tmps));
+      Surface.DrawText(0, y, tmps);
       return;
   }
 

--- a/Common/Source/Dialogs/dlgWayPointDetails.cpp
+++ b/Common/Source/Dialogs/dlgWayPointDetails.cpp
@@ -114,7 +114,7 @@ static void OnPaintDetailsListItem(WindowControl * Sender, LKSurface& Surface){
       LKASSERT(DetailDrawListIndex>=0);
       const TCHAR* szText = aDetailTextLine[DetailDrawListIndex];
       Surface.SetTextColor(RGB_BLACK);
-      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText, _tcslen(szText));
+      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText);
   }
 }
 
@@ -137,7 +137,7 @@ static void OnPaintWpCommentListItem(WindowControl * Sender, LKSurface& Surface)
       LKASSERT(CommentDrawListIndex>=0);
       const TCHAR* szText = aCommentTextLine[CommentDrawListIndex];
       Surface.SetTextColor(RGB_BLACK);
-      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText, _tcslen(szText));
+      Surface.DrawText(2*ScreenScale, 2*ScreenScale, szText);
   }
 }
 

--- a/Common/Source/Dialogs/dlgWayPointSelect.cpp
+++ b/Common/Source/Dialogs/dlgWayPointSelect.cpp
@@ -705,17 +705,17 @@ static void OnPaintListItem(WindowControl * Sender, LKSurface& Surface) {
         // Draw Distance : right justified after waypoint Name
         _stprintf(sTmp, TEXT("%.0f%s"), WayPointSelectInfo[i].Distance, Units::GetDistanceName());
         const int x2 = width - w3 - Surface.GetTextWidth(sTmp);
-        Surface.DrawText(x2, TextPos, sTmp, _tcslen(sTmp));
+        Surface.DrawText(x2, TextPos, sTmp);
 
         // Draw Bearing right justified after distance
         _stprintf(sTmp, TEXT("%d%s"), iround(WayPointSelectInfo[i].Direction), gettext(_T("_@M2179_")));
         const int x3 = width - Surface.GetTextWidth(sTmp);
-        Surface.DrawText(x3, TextPos, sTmp, _tcslen(sTmp));
+        Surface.DrawText(x3, TextPos, sTmp);
     } else {
         if (DrawListIndex == 0) {
             // LKTOKEN  _@M466_ = "No Match!" 
             _stprintf(sTmp, TEXT("%s"), gettext(TEXT("_@M466_")));
-            Surface.DrawText(IBLSCALE(2), TextPos, sTmp, _tcslen(sTmp));
+            Surface.DrawText(IBLSCALE(2), TextPos, sTmp);
         }
     }
 }

--- a/Common/Source/Draw/DrawAirspaceLabels.cpp
+++ b/Common/Source/Draw/DrawAirspaceLabels.cpp
@@ -70,7 +70,7 @@ void MapWindow::DrawAirspaceLabels(LKSurface& Surface, const RECT& rc, const Scr
                      TextDisplayMode.WhiteBold = 1; // outlined  
               }
 
-              hlabel_draws = TextInBox(Surface, &rc, hbuf, sc.x, sc.y+NIBLSCALE(15), 0, &TextDisplayMode, true);
+              hlabel_draws = TextInBox(Surface, &rc, hbuf, sc.x, sc.y+NIBLSCALE(15), &TextDisplayMode, true);
            }
            
           // Vertical warning point
@@ -105,7 +105,7 @@ void MapWindow::DrawAirspaceLabels(LKSurface& Surface, const RECT& rc, const Scr
                      TextDisplayMode.WhiteBold = 1; // outlined  
               }
 
-              vlabel_draws = TextInBox(Surface, &rc, hbuf, Orig_Aircraft.x, Orig_Aircraft.y+NIBLSCALE(15), 0, &TextDisplayMode, true);
+              vlabel_draws = TextInBox(Surface, &rc, hbuf, Orig_Aircraft.x, Orig_Aircraft.y+NIBLSCALE(15), &TextDisplayMode, true);
            }
            if (!label_sequencing_divider) CAirspaceManager::Instance().AirspaceWarningLabelPrinted(**it, hlabel_draws || vlabel_draws);
            

--- a/Common/Source/Draw/DrawFAIOpti.cpp
+++ b/Common/Source/Draw/DrawFAIOpti.cpp
@@ -589,7 +589,7 @@ int iCnt = 0;
         else
           _stprintf(text, TEXT("%i"), (int)(fDistTri*DISTANCEMODIFY));
         bFirstUnit = false;
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
 
         int j=0;
 
@@ -642,7 +642,7 @@ int iCnt = 0;
 
       if(j==0)
       {
-        Surface.DrawText(line[0].x, line[0].y, text, _tcslen(text));
+        Surface.DrawText(line[0].x, line[0].y, text);
         j=1;
 
       }
@@ -652,17 +652,17 @@ int iCnt = 0;
         _stprintf(text, TEXT("%i%s"), (int)(fDistTri*DISTANCEMODIFY), Units::GetUnitName(Units::GetUserDistanceUnit()));
       else
         _stprintf(text, TEXT("%i"), (int)(fDistTri*DISTANCEMODIFY));
-      Surface.GetTextSize(text, _tcslen(text), &tsize);
+      Surface.GetTextSize(text, &tsize);
       if(i == 0)
-        Surface.DrawText(line[0].x, line[0].y, text, _tcslen(text));
+        Surface.DrawText(line[0].x, line[0].y, text);
 
       if(iCnt > 1)
         if(i == FAI_SECTOR_STEPS-1)
-          Surface.DrawText(line[0].x, line[0].y, text, _tcslen(text));
+          Surface.DrawText(line[0].x, line[0].y, text);
 
       if(iCnt > 2)
         if((i== (FAI_SECTOR_STEPS/2)))
-          Surface.DrawText(line[0].x, line[0].y, text, _tcslen(text));
+          Surface.DrawText(line[0].x, line[0].y, text);
 
       line[1] =  line[0];
 

--- a/Common/Source/Draw/DrawFinalGlideBar.cpp
+++ b/Common/Source/Draw/DrawFinalGlideBar.cpp
@@ -299,14 +299,14 @@ _skipout:
         GlideBarOffset -= LKVarioSize;
 
         LKSurface::OldFont hfOld = Surface.SelectObject(MapWaypointBoldFont);
-        Surface.GetTextSize(Value, _tcslen(Value), &TextSize);
+        Surface.GetTextSize(Value, &TextSize);
         GlideBarOffset = std::max<int>(GlideBarOffset, TextSize.cx+NIBLSCALE(1))+1; 
 
         TextInBoxMode_t TextInBoxMode = {0};
         TextInBoxMode.Border = true; //={1|8};
         TextInBoxMode.Reachable = false;
         TextInBoxMode.NoSetFont = true;
-        TextInBox(Surface, &rc, Value, lkVarioOffset , (int) Offset, 0, &TextInBoxMode);
+        TextInBox(Surface, &rc, Value, lkVarioOffset , (int) Offset, &TextInBoxMode);
 
         Surface.SelectObject(hfOld);
         Surface.SelectObject(hbOld);

--- a/Common/Source/Draw/DrawFlarmRadar.cpp
+++ b/Common/Source/Draw/DrawFlarmRadar.cpp
@@ -140,7 +140,7 @@ void MapWindow::DrawXGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
 	   FormatTicText(unit_text, xval*unit_step/ticstep, unit_step);
 
 
-	   Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
+	   Surface.GetTextSize(unit_text, &tsize);
 	   switch(iTextAling)
 	   {
 	     case TEXT_ABOVE_LEFT    : xoff = -tsize.cx  ; yoff= -tsize.cy  ; break;
@@ -155,11 +155,11 @@ void MapWindow::DrawXGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
 	     case TEXT_MIDDLE_CENTER : xoff = -tsize.cx/2; yoff= -tsize.cy/2; break;
 	   }
 
-	   Surface.DrawText(xmin+xoff, ymax+yoff, unit_text, _tcslen(unit_text));
+	   Surface.DrawText(xmin+xoff, ymax+yoff, unit_text);
 
 	   if(pLable != NULL)
 		if((xval+ticstep) > x_max)
-		  Surface.DrawText(xmin, ymax+yoff, pLable, _tcslen(pLable));
+		  Surface.DrawText(xmin, ymax+yoff, pLable);
 	}
 
   }
@@ -187,7 +187,7 @@ void MapWindow::DrawXGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
     {
 
        FormatTicText(unit_text, xval*unit_step/ticstep, unit_step);
-       Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
+       Surface.GetTextSize(unit_text, &tsize);
 	   switch(iTextAling)
 	   {
 	     case TEXT_ABOVE_LEFT    : xoff = -tsize.cx   ; yoff= -tsize.cy  ; break;
@@ -202,7 +202,7 @@ void MapWindow::DrawXGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
 	     case TEXT_MIDDLE_CENTER : xoff = -tsize.cx/2 ; yoff= -tsize.cy/2; break;
 	   }
 
-       Surface.DrawText(xmin+xoff, ymax+yoff, unit_text, _tcslen(unit_text));
+       Surface.DrawText(xmin+xoff, ymax+yoff, unit_text);
     }
   }
 }
@@ -251,7 +251,7 @@ void MapWindow::DrawYGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
 	  if(pUnit != NULL)
             if(yval+ticstep >y_max)
               _stprintf(unit_text + _tcslen(unit_text), TEXT("%s"), pUnit);
-	  Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
+	  Surface.GetTextSize(unit_text, &tsize);
 	  switch(iTextAling)
 	  {
 	    case TEXT_ABOVE_LEFT    : xoff = -tsize.cx  ; yoff= -tsize.cy-2  ; break;
@@ -265,7 +265,7 @@ void MapWindow::DrawYGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
 	    case TEXT_MIDDLE_RIGHT  : xoff = 1          ; yoff= -tsize.cy/2-1; break;
 	    case TEXT_MIDDLE_CENTER : xoff = -tsize.cx/2; yoff= -tsize.cy/2-1; break;
 	  }
-	  Surface.DrawText(xmin+xoff, ymin+yoff, unit_text, _tcslen(unit_text));
+	  Surface.DrawText(xmin+xoff, ymin+yoff, unit_text);
     }
   }
 
@@ -292,7 +292,7 @@ void MapWindow::DrawYGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
     {
 	  TCHAR unit_text[MAX_PATH];
 	  FormatTicText(unit_text, yval*unit_step/ticstep, unit_step);
-	  Surface.GetTextSize(unit_text, _tcslen(unit_text), &tsize);
+	  Surface.GetTextSize(unit_text, &tsize);
 	  switch(iTextAling)
 	  {
 	    case TEXT_ABOVE_LEFT    : xoff = -tsize.cx  ; yoff= -tsize.cy  ; break;
@@ -306,7 +306,7 @@ void MapWindow::DrawYGrid(LKSurface& Surface, const RECT& rc, double ticstep,dou
 	    case TEXT_MIDDLE_RIGHT  : xoff = 0          ; yoff= -tsize.cy/2; break;
 	    case TEXT_MIDDLE_CENTER : xoff = -tsize.cx/2; yoff= -tsize.cy/2; break;
 	  }
-	  Surface.DrawText(xmin+xoff, ymin+yoff, unit_text, _tcslen(unit_text));
+	  Surface.DrawText(xmin+xoff, ymin+yoff, unit_text);
     }
   }
 
@@ -1077,12 +1077,12 @@ if(SPLITSCREEN_FACTOR >0)
 		     *************************************************************************/
 		   _stprintf(lbuffer,_T("%3.1f"),LIFTMODIFY*LKTraffic[i].Average30s);
 
-		    SIZE tsize;
 		    Surface.SetBackgroundTransparent();
-		    Surface.GetTextSize(lbuffer, _tcslen(lbuffer), &tsize);
-		    if (_tcslen(lbuffer)>0)
-			  TextInBox(Surface, &rct, lbuffer,x+tscaler, y+tsize.cy/4, 0, &displaymode, false);
-
+		    if (_tcslen(lbuffer)>0) {
+		      SIZE tsize;
+              Surface.GetTextSize(lbuffer, &tsize);
+			  TextInBox(Surface, &rct, lbuffer,x+tscaler, y+tsize.cy/4, &displaymode, false);
+            }
 			break;
 	      }
 	    /*********************************************
@@ -1255,9 +1255,9 @@ if(bSideview)
 
 	  SIZE tsize;
 	  Surface.SetBackgroundTransparent();
-	  Surface.GetTextSize(lbuffer,  _tcslen(lbuffer), &tsize);
+	  Surface.GetTextSize(lbuffer, &tsize);
 	  if (_tcslen(lbuffer)>0)
-		TextInBox(Surface, &rc, lbuffer, x+tscaler,  hy+tsize.cy/4, 0, &displaymode, false);
+		TextInBox(Surface, &rc, lbuffer, x+tscaler,  hy+tsize.cy/4, &displaymode, false);
 	  /*********************************************
 	   * draw lines to target if target selected
 	   */

--- a/Common/Source/Draw/DrawGPSStatus.cpp
+++ b/Common/Source/Draw/DrawGPSStatus.cpp
@@ -37,24 +37,24 @@ void MapWindow::DrawGPSStatus(LKSurface& Surface, const RECT& rc)
     TextInBoxMode.WhiteBorder = 1;
     TextInBoxMode.Border = 1;
     if (ComPortStatus[0]==CPS_OPENKO) {
-      TextInBox(Surface, &rc, gettext(_T("_@M971_")), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode); // No ComPort
+      TextInBox(Surface, &rc, gettext(_T("_@M971_")), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode); // No ComPort
     } else {
     	if (ComPortStatus[0]==CPS_OPENOK) {
 		if ((ComPortRx[0]>0) && !firstrun) {
 			// GPS IS MISSING
-			TextInBox(Surface, &rc, MsgToken(973), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode);
+			TextInBox(Surface, &rc, MsgToken(973), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode);
 			firstrun=false; 
 		} else {
 			// NO DATA RX
-			TextInBox(Surface, &rc, MsgToken(972), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode);
+			TextInBox(Surface, &rc, MsgToken(972), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode);
 		}
 	} else  {
 		if (ComPortStatus[0]==CPS_EFRAME)  {
 			// DATA ERROR
-			TextInBox(Surface, &rc, MsgToken(975), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode);
+			TextInBox(Surface, &rc, MsgToken(975), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode);
 		} else {
 			// GPS NOT CONNECTED
-			TextInBox(Surface, &rc, MsgToken(974), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode);
+			TextInBox(Surface, &rc, MsgToken(974), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode);
 		}
 	}
 
@@ -71,7 +71,7 @@ void MapWindow::DrawGPSStatus(LKSurface& Surface, const RECT& rc)
     TextInBoxMode.WhiteBorder = 1;
     TextInBoxMode.Border = 1;
     // NO VALID FIX
-    TextInBox(Surface, &rc, MsgToken(970), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode);
+    TextInBox(Surface, &rc, MsgToken(970), (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode);
 
     }
 
@@ -89,10 +89,10 @@ goto_DrawLockModeStatus:
     TextInBoxModeL.WhiteBorder = 1;
     TextInBoxModeL.Border = 1;
     if (ISPARAGLIDER){
-        TextInBox(Surface, &rc,gettext(_T("_@M962_")), (rc.right-rc.left)/2, rc.bottom-((rc.bottom-rc.top)/3), 0, &TextInBoxModeL);
+        TextInBox(Surface, &rc,gettext(_T("_@M962_")), (rc.right-rc.left)/2, rc.bottom-((rc.bottom-rc.top)/3), &TextInBoxModeL);
     }
     Surface.SelectObject(LK8MapFont);
-    TextInBox(Surface, &rc, gettext(_T("_@M1601_")), (rc.right-rc.left)/2, rc.bottom-((rc.bottom-rc.top)/5), 0, &TextInBoxModeL);
+    TextInBox(Surface, &rc, gettext(_T("_@M1601_")), (rc.right-rc.left)/2, rc.bottom-((rc.bottom-rc.top)/5), &TextInBoxModeL);
   }
 
   Surface.SelectObject(oldfont);

--- a/Common/Source/Draw/DrawGlideThroughTerrain.cpp
+++ b/Common/Source/Draw/DrawGlideThroughTerrain.cpp
@@ -117,7 +117,7 @@ void MapWindow::DrawGlideThroughTerrain(LKSurface& Surface, const RECT& rc, cons
 
 			if (DerivedDrawInfo.FarObstacle_AltArriv <=-50 ||  DerivedDrawInfo.FarObstacle_Dist<5000 ) {
 				_stprintf(hbuf,_T(" %.0f"),ALTITUDEMODIFY*DerivedDrawInfo.FarObstacle_AltArriv);
-				TextInBox(Surface,&rc,hbuf,sc.x+NIBLSCALE(15), sc.y, 0, &tmode,false); 
+				TextInBox(Surface,&rc,hbuf,sc.x+NIBLSCALE(15), sc.y, &tmode,false); 
 				wrotevalue=true;
 			}
 		} // visible far obstacle
@@ -144,7 +144,7 @@ void MapWindow::DrawGlideThroughTerrain(LKSurface& Surface, const RECT& rc, cons
 					// and there is a significant difference in the numbers, then paint value also for nearest
 					if (  fabs(DerivedDrawInfo.ObstacleAltArriv - DerivedDrawInfo.FarObstacle_AltArriv) >100 ) {
 						_stprintf(hbuf,_T(" %.0f"),ALTITUDEMODIFY*DerivedDrawInfo.ObstacleAltArriv);
-						TextInBox(Surface,&rc,hbuf,sc.x+NIBLSCALE(15), sc.y, 0, &tmode,false); 
+						TextInBox(Surface,&rc,hbuf,sc.x+NIBLSCALE(15), sc.y, &tmode,false); 
 					}
 				}
 			} else {
@@ -156,7 +156,7 @@ void MapWindow::DrawGlideThroughTerrain(LKSurface& Surface, const RECT& rc, cons
 				 ((DerivedDrawInfo.ObstacleAltArriv<0) && (DerivedDrawInfo.ObstacleDistance<5000)) ) {
 
 					_stprintf(hbuf,_T(" %.0f"),ALTITUDEMODIFY*DerivedDrawInfo.ObstacleAltArriv);
-					TextInBox(Surface,&rc,hbuf,sc.x+NIBLSCALE(15), sc.y, 0, &tmode,false); 
+					TextInBox(Surface,&rc,hbuf,sc.x+NIBLSCALE(15), sc.y, &tmode,false); 
 				}
 			}
 #endif

--- a/Common/Source/Draw/DrawHSI.cpp
+++ b/Common/Source/Draw/DrawHSI.cpp
@@ -201,7 +201,7 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
     Surface.SelectObject(LK8TitleFont);
     for(int i=0;i<12;i++) {
         int deg=i*30+angle;
-        LKWriteText(Surface,label[i],centerX+(int)(labelsRadius*fastsine(deg)),centerY-(int)(labelsRadius*fastcosine(deg)),0, WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
+        LKWriteText(Surface,label[i],centerX+(int)(labelsRadius*fastsine(deg)),centerY-(int)(labelsRadius*fastcosine(deg)),WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
     }
 
     //Draw true heading mark on the top of the compass rose
@@ -219,9 +219,9 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
     Surface.SelectObject(LK8InfoSmallFont);
     _stprintf(Buffer, TEXT("%03d%s"),(int)round(DrawInfo.TrackBearing),gettext(_T("_@M2179_")));
     #ifndef UNDITHER
-    LKWriteText(Surface,Buffer,posTRKx,posTRKy,0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_RED,false);
+    LKWriteText(Surface,Buffer,posTRKx,posTRKy,WTMODE_NORMAL,WTALIGN_CENTER,RGB_RED,false);
     #else
-    LKWriteText(Surface,Buffer,posTRKx,posTRKy,0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
+    LKWriteText(Surface,Buffer,posTRKx,posTRKy,WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
     #endif
 
     //Copies of the data needed from Task and WayPointList
@@ -263,17 +263,17 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
             _tcscpy(Buffer,gettext(TEXT("_@M784_"))); //"Vario"
             Surface.SelectObject(LK8PanelSmallFont);
             #ifndef UNDITHER
-            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedLabelY,0, WTMODE_NORMAL,WTALIGN_RIGHT,RGB_LIGHTGREEN,false);
+            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedLabelY,WTMODE_NORMAL,WTALIGN_RIGHT,RGB_LIGHTGREEN,false);
             #else
-            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedLabelY,0, WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
+            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedLabelY,WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
             #endif
             _stprintf(Buffer, TEXT("%+.0f"),varioFtMin); //print the value
             if(!ScreenLandscape || (ScreenSize!=ss800x480 && ScreenSize!=ss480x272)) Surface.SelectObject(LK8PanelMediumFont);
             else Surface.SelectObject(LK8PanelBigFont);
-            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedValueY,0, WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
+            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedValueY,WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
             _stprintf(Buffer,TEXT("FPM")); //measure unit
             Surface.SelectObject(LK8PanelUnitFont);
-            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedUnitY,0, WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
+            LKWriteText(Surface,Buffer,VertSpeedX,VertSpeedUnitY,WTMODE_NORMAL,WTALIGN_RIGHT,RGB_WHITE,false);
             if(DerivedDrawInfo.WaypointDistance<fiveNauticalMiles && WPstyle>=STYLE_AIRFIELDGRASS && WPstyle<=STYLE_AIRFIELDSOLID) { //if we are close to the destination airport
                 if(DerivedDrawInfo.WaypointDistance<1500) returnStruct.landing=true; //if at less than 1.5 Km don't show glide slope bar
                 else { //Build glide slope bar
@@ -341,22 +341,22 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
                         for(int i=0;i<=6;i++) {
                             _stprintf(Buffer, TEXT("%d"),i);
                             #ifndef UNDITHER
-                            LKWriteText(Surface,Buffer,gssLabelX,gssStart+gssIncrementX2*i,0, WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_LIGHTRED:RGB_WHITE,false);
+                            LKWriteText(Surface,Buffer,gssLabelX,gssStart+gssIncrementX2*i,WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_LIGHTRED:RGB_WHITE,false);
                             #else
-                            LKWriteText(Surface,Buffer,gssLabelX,gssStart+gssIncrementX2*i,0, WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_WHITE:RGB_WHITE,false);
+                            LKWriteText(Surface,Buffer,gssLabelX,gssStart+gssIncrementX2*i,WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_WHITE:RGB_WHITE,false);
                             #endif
                         }
                     } else {
                         #ifndef UNDITHER
                         _stprintf(Buffer, TEXT("0"));
-                        LKWriteText(Surface,Buffer,gssLabelX,gssStart,0, WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_LIGHTRED:RGB_WHITE,false);
+                        LKWriteText(Surface,Buffer,gssLabelX,gssStart,WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_LIGHTRED:RGB_WHITE,false);
                         _stprintf(Buffer, TEXT("6"));
-                        LKWriteText(Surface,Buffer,gssLabelX,gssEnd,0, WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_LIGHTRED:RGB_WHITE,false);
+                        LKWriteText(Surface,Buffer,gssLabelX,gssEnd,WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_LIGHTRED:RGB_WHITE,false);
                         #else
                         _stprintf(Buffer, TEXT("0"));
-                        LKWriteText(Surface,Buffer,gssLabelX,gssStart,0, WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_WHITE:RGB_WHITE,false);
+                        LKWriteText(Surface,Buffer,gssLabelX,gssStart,WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_WHITE:RGB_WHITE,false);
                         _stprintf(Buffer, TEXT("6"));
-                        LKWriteText(Surface,Buffer,gssLabelX,gssEnd,0, WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_WHITE:RGB_WHITE,false);
+                        LKWriteText(Surface,Buffer,gssLabelX,gssEnd,WTMODE_NORMAL,WTALIGN_CENTER,isOutOfScale?RGB_WHITE:RGB_WHITE,false);
                         #endif
                     }
                 } //end of glide slope bar
@@ -376,9 +376,9 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
         Surface.SelectObject(LK8InfoSmallFont);
         _stprintf(Buffer, TEXT("%03d%s"),(int)round(course),gettext(_T("_@M2179_")));
         #ifndef UNDITHER
-        LKWriteText(Surface,Buffer,posDTKx,posTRKy,0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_GREEN,false);
+        LKWriteText(Surface,Buffer,posDTKx,posTRKy,WTMODE_NORMAL,WTALIGN_CENTER,RGB_GREEN,false);
         #else
-        LKWriteText(Surface,Buffer,posDTKx,posTRKy,0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
+        LKWriteText(Surface,Buffer,posDTKx,posTRKy,WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
         #endif
 
         //Calculate rotation angle
@@ -497,9 +497,9 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
                 else _stprintf(Buffer,TEXT("%d %s"),(int)round(xtk),Units::GetDistanceName());
             }
             #ifndef UNDITHER
-            LKWriteText(Surface,Buffer,posXTKx,posXTKy+NIBLSCALE(2),0,WTMODE_NORMAL,WTALIGN_CENTER,cdiColor,false);
+            LKWriteText(Surface,Buffer,posXTKx,posXTKy+NIBLSCALE(2),WTMODE_NORMAL,WTALIGN_CENTER,cdiColor,false);
             #else
-            LKWriteText(Surface,Buffer,posXTKx,posXTKy+NIBLSCALE(2),0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
+            LKWriteText(Surface,Buffer,posXTKx,posXTKy+NIBLSCALE(2),WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
             #endif
 
             //Draw bearing pointer to next waypoint
@@ -537,9 +537,9 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
             Surface.SelectObject(LK8InfoSmallFont);
             _stprintf(Buffer, TEXT("%03d%s"),(int)round(DerivedDrawInfo.WaypointBearing),gettext(_T("_@M2179_")));
             #ifndef UNDITHER
-            LKWriteText(Surface,Buffer,posDTKx,posBRGy+NIBLSCALE(2),0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_MAGENTA,false);
+            LKWriteText(Surface,Buffer,posDTKx,posBRGy+NIBLSCALE(2),WTMODE_NORMAL,WTALIGN_CENTER,RGB_MAGENTA,false);
             #else
-            LKWriteText(Surface,Buffer,posDTKx,posBRGy+NIBLSCALE(2),0,WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
+            LKWriteText(Surface,Buffer,posDTKx,posBRGy+NIBLSCALE(2),WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE,false);
             #endif
         } else { //flying to the departure or a direct GOTO without information for landing: don't draw CDI
             //Draw anyway the CDI scale in grey (disabled)
@@ -649,15 +649,15 @@ HSIreturnStruct MapWindow::DrawHSI(LKSurface& Surface, const RECT& rc) {
         if(scale<10000) _stprintf(Buffer, TEXT("+%.0fft"),scale);
         else _stprintf(Buffer, TEXT("+%.0ff"),scale);
         #ifndef UNDITHER
-        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelUpY,0, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_LIGHTRED:RGB_WHITE,false);
+        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelUpY, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_LIGHTRED:RGB_WHITE,false);
         if(scale<10000) _stprintf(Buffer, TEXT("-%.0fft"),scale);
         else _stprintf(Buffer, TEXT("-%.0ff"),scale);
-        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelDwY,0, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_LIGHTRED:RGB_WHITE,false);
+        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelDwY, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_LIGHTRED:RGB_WHITE,false);
         #else
-        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelUpY,0, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_WHITE:RGB_WHITE,false);
+        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelUpY, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_WHITE:RGB_WHITE,false);
         if(scale<10000) _stprintf(Buffer, TEXT("-%.0fft"),scale);
         else _stprintf(Buffer, TEXT("-%.0ff"),scale);
-        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelDwY,0, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_WHITE:RGB_WHITE,false);
+        LKWriteText(Surface,Buffer,VSIlabelX,VSIlabelDwY, WTMODE_NORMAL,WTALIGN_CENTER,outOfScale?RGB_WHITE:RGB_WHITE,false);
         #endif
 
         //Draw expected in route altitude marker

--- a/Common/Source/Draw/DrawLKAlarms.cpp
+++ b/Common/Source/Draw/DrawLKAlarms.cpp
@@ -82,7 +82,7 @@ void MapWindow::DrawLKAlarms(LKSurface& Surface, const RECT& rc) {
 	TextInBoxMode.Border = 1;
 
 	// same position for gps warnings: if navwarning, then no alarms. So no overlapping.
-        TextInBox(Surface, &rc, textalarm , (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, 0, &TextInBoxMode);
+        TextInBox(Surface, &rc, textalarm , (rc.right-rc.left)/2, (rc.bottom-rc.top)/3, &TextInBoxMode);
 
 	Surface.SelectObject(oldfont);
   }

--- a/Common/Source/Draw/DrawMapScale.cpp
+++ b/Common/Source/Draw/DrawMapScale.cpp
@@ -84,7 +84,7 @@ void MapWindow::DrawMapScale(LKSurface& Surface, const RECT& rc /* the Map Rect*
         
         SIZE tsize;
         Surface.SelectObject(MapScaleFont);
-        Surface.GetTextSize(_T("M"),1,&tsize);
+        Surface.GetTextSize(_T("M"),&tsize);
         int ofs=(MAPSCALE_VSIZE - (tsize.cy + tsize.cy))/2;
         ytext=ScaleLine[0].y+ofs;
 
@@ -263,20 +263,20 @@ _skip2:
     const auto oldPen = Surface.SelectObject(LK_BLACK_PEN);
     const auto oldBrush = Surface.SelectObject(LKBrush_Black);
 
-    Surface.GetTextSize(Scale, _tcslen(Scale), &tsize);
+    Surface.GetTextSize(Scale, &tsize);
 
     LKColor mapscalecolor = OverColorRef;
     if (OverColorRef==RGB_SBLACK) mapscalecolor=RGB_WHITE;
 
-    LKWriteText(Surface, Scale, rc.right-NIBLSCALE(7)-tsize.cx, ytext, 0, WTMODE_OUTLINED, WTALIGN_LEFT, mapscalecolor, true);
+    LKWriteText(Surface, Scale, rc.right-NIBLSCALE(7)-tsize.cx, ytext, WTMODE_OUTLINED, WTALIGN_LEFT, mapscalecolor, true);
 
-    Surface.GetTextSize(Scale2, _tcslen(Scale2), &tsize);
+    Surface.GetTextSize(Scale2, &tsize);
 
     if (!DerivedDrawInfo.TerrainValid) {
 	if (terrainwarning>0 && terrainwarning<120) mapscalecolor=RGB_RED;
     }
 
-    LKWriteText(Surface, Scale2, rc.right-NIBLSCALE(7)-tsize.cx, ytext+tsize.cy, 0, WTMODE_OUTLINED, WTALIGN_LEFT, mapscalecolor, true);
+    LKWriteText(Surface, Scale2, rc.right-NIBLSCALE(7)-tsize.cx, ytext+tsize.cy, WTMODE_OUTLINED, WTALIGN_LEFT, mapscalecolor, true);
 
     Surface.SelectObject(oldPen);
     Surface.SelectObject(oldBrush);

--- a/Common/Source/Draw/DrawRunway.cpp
+++ b/Common/Source/Draw/DrawRunway.cpp
@@ -295,7 +295,7 @@ void MapWindow::DrawRunway(LKSurface& Surface, const WAYPOINT* wp, const RECT& r
 	unsigned int offset = p + NIBLSCALE(1) ;
 	{
 		if ( _tcslen(wp->Freq)>0 ) {
-			MapWindow::LKWriteBoxedText(Surface,rc,wp->Freq, Center_x- offset, Center_y -offset, 0, WTALIGN_RIGHT, RGB_WHITE, RGB_BLACK);
+			MapWindow::LKWriteBoxedText(Surface,rc,wp->Freq, Center_x- offset, Center_y -offset, WTALIGN_RIGHT, RGB_WHITE, RGB_BLACK);
 		}
 
 		//
@@ -303,13 +303,13 @@ void MapWindow::DrawRunway(LKSurface& Surface, const WAYPOINT* wp, const RECT& r
 		//
 		if (MapWindow::zoom.RealScale() <=scale_fullinfos) {
 			if ( _tcslen(wp->Code)==4 ) {
-				MapWindow::LKWriteBoxedText(Surface,rc,wp->Code,Center_x + offset, Center_y - offset, 0, WTALIGN_LEFT, RGB_WHITE,RGB_BLACK);
+				MapWindow::LKWriteBoxedText(Surface,rc,wp->Code,Center_x + offset, Center_y - offset, WTALIGN_LEFT, RGB_WHITE,RGB_BLACK);
 			}
 
 			if (wp->Altitude >0) {
 				TCHAR tAlt[20];
 				_stprintf(tAlt,_T("%.0f %s"),wp->Altitude*ALTITUDEMODIFY,Units::GetUnitName(Units::GetUserAltitudeUnit()));
-				MapWindow::LKWriteBoxedText(Surface,rc,tAlt, Center_x + offset, Center_y + offset, 0, WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
+				MapWindow::LKWriteBoxedText(Surface,rc,tAlt, Center_x + offset, Center_y + offset, WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
 			}
 
 		}

--- a/Common/Source/Draw/DrawTRI.cpp
+++ b/Common/Source/Draw/DrawTRI.cpp
@@ -242,7 +242,7 @@ void MapWindow::DrawTRI(LKSurface& Surface, const RECT& rc) {
   else
 	_tcscpy(Buffer, TEXT("--"));
 
-  LKWriteText(Surface, Buffer, Start.x , bankindy, 0, WTMODE_NORMAL, WTALIGN_CENTER, RGB_BLUE, false);
+  LKWriteText(Surface, Buffer, Start.x , bankindy, WTMODE_NORMAL, WTALIGN_CENTER, RGB_BLUE, false);
 
 //  MapDirty = true;
 //  if (!disabled) MapWindow::RefreshMap();
@@ -611,7 +611,7 @@ double vscale = 0.25;
   else
 	_tcscpy(Buffer, TEXT("--"));
 
-  LKWriteText(Surface, Buffer, Start.x , bankindy, 0, WTMODE_NORMAL, WTALIGN_CENTER, RGB_BLUE, false);
+  LKWriteText(Surface, Buffer, Start.x , bankindy, WTMODE_NORMAL, WTALIGN_CENTER, RGB_BLUE, false);
 
 //  MapDirty = true;
 //  if (!disabled) MapWindow::RefreshMap();

--- a/Common/Source/Draw/DrawWind.cpp
+++ b/Common/Source/Draw/DrawWind.cpp
@@ -22,7 +22,7 @@ void MapWindow::DrawWindAtAircraft2(LKSurface& Surface, const POINT& Orig, const
   if (tsize.cx == 0){
 
     const auto oldFont = Surface.SelectObject(MapWindowBoldFont);
-    Surface.GetTextSize(TEXT("99"), 2, &tsize);
+    Surface.GetTextSize(TEXT("99"), &tsize);
     Surface.SelectObject(oldFont);
     tsize.cx = tsize.cx/2;
   }
@@ -69,9 +69,9 @@ void MapWindow::DrawWindAtAircraft2(LKSurface& Surface, const POINT& Orig, const
     TextInBoxMode.AlligneCenter = true;   // { 16 | 32 }; // JMW test {2 | 16};
     TextInBoxMode.WhiteBorder = true;
     if (Arrow[5].y>=Arrow[6].y) {
-      TextInBox(Surface, &rc, sTmp, Arrow[5].x-kx, Arrow[5].y, 0, &TextInBoxMode);
+      TextInBox(Surface, &rc, sTmp, Arrow[5].x-kx, Arrow[5].y, &TextInBoxMode);
     } else {
-      TextInBox(Surface, &rc, sTmp, Arrow[6].x-kx, Arrow[6].y, 0, &TextInBoxMode);
+      TextInBox(Surface, &rc, sTmp, Arrow[6].x-kx, Arrow[6].y, &TextInBoxMode);
     }
   }
   const auto hpOld = Surface.SelectObject(LKPen_Black_N2);

--- a/Common/Source/Draw/LKDrawBottomBar.cpp
+++ b/Common/Source/Draw/LKDrawBottomBar.cpp
@@ -61,17 +61,17 @@ void MapWindow::DrawBottomBar(LKSurface& Surface, const RECT& rc )
 	OldBottomMode=BM_FIRST;
 
 	Surface.SelectObject(LK8BottomBarTitleFont);
-	Surface.GetTextSize(_T("M"), 1, &TextSize);
+	Surface.GetTextSize(_T("M"), &TextSize);
 	int syTitle = TextSize.cy;
 
 	Surface.SelectObject(LK8BottomBarUnitFont);
 	// m for meters unit, f is shorter anyway
-	Surface.GetTextSize(_T("m"), 1, &TextSize); 
+	Surface.GetTextSize(_T("m"), &TextSize); 
 	int sxUnit = TextSize.cx;
 
 	Surface.SelectObject(LK8BottomBarValueFont);
         // we need to be able to print 12345f with no problems
-	Surface.GetTextSize(_T("12345"), 5, &TextSize);
+	Surface.GetTextSize(_T("12345"), &TextSize);
 	int syValue = TextSize.cy;
 	int sxValue = TextSize.cx + NIBLSCALE(2) + (HideUnits ? 0 : sxUnit);
 
@@ -249,7 +249,7 @@ _afterautotrm:
   } else {
 	#include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   SECOND VALUE
@@ -332,7 +332,7 @@ _afterautotrm:
   } else {
 	#include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   THIRD VALUE
@@ -440,7 +440,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   FOURTH VALUE
@@ -531,7 +531,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(7), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   FIFTH VALUE
@@ -648,7 +648,7 @@ _afterautotrm:
       #include "LKMW3include_navbox2.cpp"
   }
 
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   SIXTH VALUE
@@ -723,7 +723,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
 
   /*
@@ -795,7 +795,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
 
   /*
@@ -864,7 +864,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   NINTH VALUE
@@ -884,7 +884,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *   TENTH VALUE
@@ -904,7 +904,7 @@ _afterautotrm:
   } else {
       #include "LKMW3include_navbox2.cpp"
   }
-  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+  LKWriteText(Surface, BufferTitle, rcx+NIBLSCALE(3), rcy, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
 
   /*
    *    CLEAN UP 

--- a/Common/Source/Draw/LKDrawFLARMTraffic.cpp
+++ b/Common/Source/Draw/LKDrawFLARMTraffic.cpp
@@ -135,7 +135,7 @@ static int	iRectangleSize = 4;
 		displaymode.Border=1;
 
 		if (_tcslen(lbuffer)>0)
-		TextInBox(Surface, &rc, lbuffer, sc.x+tscaler, sc.y+tscaler, 0, &displaymode, false);
+		TextInBox(Surface, &rc, lbuffer, sc.x+tscaler, sc.y+tscaler, &displaymode, false);
 
 		// red circle
 		if ((DrawInfo.FLARM_Traffic[i].AlarmLevel>0) && (DrawInfo.FLARM_Traffic[i].AlarmLevel<4)) {

--- a/Common/Source/Draw/LKDrawInfoPage.cpp
+++ b/Common/Source/Draw/LKDrawInfoPage.cpp
@@ -217,7 +217,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			_stprintf(Buffer,_T("error"));
 			break;
 	}
-        LKWriteText(Surface, Buffer, qcolumn[0],qrow[0], 0, WTMODE_NORMAL, WTALIGN_LEFT,
+        LKWriteText(Surface, Buffer, qcolumn[0],qrow[0], WTMODE_NORMAL, WTALIGN_LEFT,
             #ifndef UNDITHER
             RGB_LIGHTGREEN, false);
             #else
@@ -287,7 +287,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			icolor=AMBERCOLOR;
 			break;
 	}
-        LKWriteText(Surface, Buffer, qcolumn[8],qrow[1], 0, WTMODE_NORMAL, WTALIGN_CENTER, icolor, false);
+        LKWriteText(Surface, Buffer, qcolumn[8],qrow[1], WTMODE_NORMAL, WTALIGN_CENTER, icolor, false);
 
 	// R0 C2	= time of day
 	if ( (curtype == (IM_TOP+IM_TRF)) || (curtype == (IM_TOP+IM_TARGET)) ) {
@@ -309,15 +309,15 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 					_stprintf(Buffer,_T("??? %s\""),tpas);
 					break;
 			}
-        		LKWriteText(Surface, Buffer, qcolumn[16],qrow[0], 0, WTMODE_NORMAL, WTALIGN_RIGHT, icolor, false);
+        		LKWriteText(Surface, Buffer, qcolumn[16],qrow[0], WTMODE_NORMAL, WTALIGN_RIGHT, icolor, false);
 		} else {
 			LKFormatValue(LK_TIME_LOCALSEC, false, BufferValue, BufferUnit, BufferTitle); // 091219
-        		LKWriteText(Surface, BufferValue, qcolumn[16],qrow[0], 0, WTMODE_NORMAL, WTALIGN_RIGHT, RGB_WHITE, false);
+        		LKWriteText(Surface, BufferValue, qcolumn[16],qrow[0], WTMODE_NORMAL, WTALIGN_RIGHT, RGB_WHITE, false);
 		}
 		if ( curtype == (IM_TOP+IM_TARGET) ) goto label_Target;
 	} else {
 		LKFormatValue(LK_TIME_LOCALSEC, false, BufferValue, BufferUnit, BufferTitle); // 091219
-        	LKWriteText(Surface, BufferValue, qcolumn[16],qrow[0], 0, WTMODE_NORMAL, WTALIGN_RIGHT, RGB_WHITE, false);
+        	LKWriteText(Surface, BufferValue, qcolumn[16],qrow[0], WTMODE_NORMAL, WTALIGN_RIGHT, RGB_WHITE, false);
 	}
 
 	if (curtype == IM_TRI) goto label_TRI;
@@ -905,7 +905,7 @@ label_TRI:
 #endif
 	_tcscpy(BufferTitle, gettext(TEXT("_@M915_"))); // NOT FOR IFR USAGE
 	Surface.SelectObject(LK8PanelSmallFont);
-	LKWriteText(Surface,  BufferTitle, qcolumn[8],qrow[12], 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_ORANGE, false);
+	LKWriteText(Surface,  BufferTitle, qcolumn[8],qrow[12], WTMODE_OUTLINED, WTALIGN_CENTER, RGB_ORANGE, false);
 #endif // not in LKCOMPETITION 
 	goto label_End; // End of TRI
 
@@ -956,7 +956,7 @@ label_HSI:
 		}
 	}
 	Surface.SelectObject(LK8PanelMediumFont);
-	LKWriteText(Surface,  Buffer, qcolumn[8],qrow[1], 0, WTMODE_NORMAL, WTALIGN_CENTER, icolor, false);
+	LKWriteText(Surface,  Buffer, qcolumn[8],qrow[1], WTMODE_NORMAL, WTALIGN_CENTER, icolor, false);
 	showunit=true;
 	if (ScreenLandscape) {
 		LKFormatValue(LK_NEXT_ETE, true, BufferValue, BufferUnit, BufferTitle);
@@ -1139,19 +1139,19 @@ void MapWindow::WriteInfo(LKSurface& Surface, bool *showunit, TCHAR *BufferValue
 
   Surface.SelectObject(LK8PanelBigFont);
   if (*showunit)
-	LKWriteText(Surface, BufferValue, *columnvalue,*row1, 0, WTMODE_NORMAL,WTALIGN_RIGHT, RGB_WHITE, false);
+	LKWriteText(Surface, BufferValue, *columnvalue,*row1, WTMODE_NORMAL,WTALIGN_RIGHT, RGB_WHITE, false);
   else
-	LKWriteText(Surface, BufferValue, *columnvalue,*row1, 0, WTMODE_NORMAL,WTALIGN_RIGHT, AMBERCOLOR, false);
+	LKWriteText(Surface, BufferValue, *columnvalue,*row1, WTMODE_NORMAL,WTALIGN_RIGHT, AMBERCOLOR, false);
 
   if (*showunit==true && !HideUnits) {
        	Surface.SelectObject(LK8PanelUnitFont); // 091230
-        LKWriteText(Surface, BufferUnit, *columnvalue,*row2+unitrowoffset, 0, WTMODE_NORMAL, WTALIGN_LEFT, RGB_WHITE, false);
+        LKWriteText(Surface, BufferUnit, *columnvalue,*row2+unitrowoffset, WTMODE_NORMAL, WTALIGN_LEFT, RGB_WHITE, false);
   }
   Surface.SelectObject(LK8PanelSmallFont);
   #ifndef UNDITHER
-  LKWriteText(Surface, BufferTitle, *columntitle,*row3, 0, WTMODE_NORMAL, WTALIGN_RIGHT, RGB_LIGHTGREEN, false);
+  LKWriteText(Surface, BufferTitle, *columntitle,*row3, WTMODE_NORMAL, WTALIGN_RIGHT, RGB_LIGHTGREEN, false);
   #else
-  LKWriteText(Surface, BufferTitle, *columntitle,*row3, 0, WTMODE_NORMAL, WTALIGN_RIGHT, RGB_WHITE, false);
+  LKWriteText(Surface, BufferTitle, *columntitle,*row3, WTMODE_NORMAL, WTALIGN_RIGHT, RGB_WHITE, false);
   #endif
 
 }

--- a/Common/Source/Draw/LKDrawLook8000.cpp
+++ b/Common/Source/Draw/LKDrawLook8000.cpp
@@ -99,22 +99,22 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
 
         TCHAR Tdummy[] = _T("E");
         Surface.SelectObject(LK8OverlayBigFont);
-        Surface.GetTextSize(Tdummy, _tcslen(Tdummy), &SizeBigFont);
+        Surface.GetTextSize(Tdummy, &SizeBigFont);
 
         Surface.SelectObject(LK8OverlayMediumFont);
-        Surface.GetTextSize(Tdummy, _tcslen(Tdummy), &SizeMediumFont);
+        Surface.GetTextSize(Tdummy, &SizeMediumFont);
 
         Surface.SelectObject(LK8OverlaySmallFont);
-        Surface.GetTextSize(Tdummy, _tcslen(Tdummy), &SizeSmallFont);
+        Surface.GetTextSize(Tdummy, &SizeSmallFont);
 
         Surface.SelectObject(LK8OverlayMcModeFont);
-        Surface.GetTextSize(Tdummy, _tcslen(Tdummy), &SizeMcModeFont);
+        Surface.GetTextSize(Tdummy, &SizeMcModeFont);
 
         Surface.SelectObject(LK8OverlayGatesFont);
-        Surface.GetTextSize(Tdummy, _tcslen(Tdummy), &SizeGatesFont);
+        Surface.GetTextSize(Tdummy, &SizeGatesFont);
 
         Surface.SelectObject(MapScaleFont);
-        Surface.GetTextSize(Tdummy, _tcslen(Tdummy), &SizeUnitFont);
+        Surface.GetTextSize(Tdummy, &SizeUnitFont);
 
         //
         // TIME GATES OFFSETS FOR PARAGLIDERS
@@ -228,12 +228,12 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 _stprintf(Buffer, _T("%s%d/%d"), StartGateName, gateinuse + 1, PGNumberOfGates);
             }
 
-            LKWriteText(Surface, Buffer, rcx , topmargin, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+            LKWriteText(Surface, Buffer, rcx , topmargin, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         } else {
             if (Overlay_TopLeft) {
                 GetOvertargetName(Buffer);
                 RECT ClipRect = { rcx, topmargin, name_xmax, topmargin + SizeMediumFont.cy };
-                LKWriteText(Surface, Buffer, rcx, topmargin, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true, &ClipRect);
+                LKWriteText(Surface, Buffer, rcx, topmargin, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true, &ClipRect);
             }
         }
 
@@ -289,16 +289,14 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
 
         if ( !OverlayClock && ScreenLandscape && (!(ISPARAGLIDER && UseGates()))) {
             _stprintf(BufferValue + _tcslen(BufferValue), _T(" %s"), BufferUnit);
-            LKWriteText(Surface, BufferValue, compass.cx, topmargin, 
-                0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+            LKWriteText(Surface, BufferValue, compass.cx, topmargin, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
         } else {
-            LKWriteText(Surface, BufferValue, rcx , topmargin + SizeMediumFont.cy, 
-                0, WTMODE_OUTLINED, WTALIGN_LEFT, distcolor, true);
+            LKWriteText(Surface, BufferValue, rcx , topmargin + SizeMediumFont.cy, WTMODE_OUTLINED, WTALIGN_LEFT, distcolor, true);
             
             if (!HideUnits) {
-                Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+                Surface.GetTextSize(BufferValue, &TextSize);
                 Surface.SelectObject(MapScaleFont); 
-                LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, yDistUnit, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, yDistUnit, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
             }
 
         }
@@ -346,8 +344,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             }
 
             Surface.SelectObject(LK8OverlayMediumFont); // restore previously selected font
-            LKWriteText(Surface, BufferValue, topbearing.cx,  topbearing.cy, 0,
-                WTMODE_OUTLINED, WTALIGN_CENTER, OverColorRef, true);
+            LKWriteText(Surface, BufferValue, topbearing.cx,  topbearing.cy, WTMODE_OUTLINED, WTALIGN_CENTER, OverColorRef, true);
         }
         _skip_TopMid:
 
@@ -402,7 +399,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             Surface.SelectObject(LK8OverlayBigFont); // use this font for big values
             rcy = yrightoffset - SizeBigFont.cy;
             color=(redwarning&&Overlay_RightMid<OAUX)?AMBERCOLOR:OverColorRef;
-            LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_RIGHT, color, true);
+            LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_RIGHT, color, true);
             
             _skip_glider_RightMid:
 
@@ -447,8 +444,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     break;
             }
             color=(redwarning&&Overlay_RightBottom<OAUX)?AMBERCOLOR:OverColorRef;
-            LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, 0,
-                WTMODE_OUTLINED, WTALIGN_RIGHT, color, true); 
+            LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, WTMODE_OUTLINED, WTALIGN_RIGHT, color, true); 
 
             //
             // (GLIDERS) SAFETY ALTITUDE INDICATOR 
@@ -459,8 +455,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 Surface.SelectObject(LK8OverlaySmallFont);
                 _stprintf(BufferValue, _T(" + %.0f %s "), SAFETYALTITUDEARRIVAL / 10 * ALTITUDEMODIFY,
                         Units::GetUnitName(Units::GetUserAltitudeUnit()));
-                LKWriteBoxedText(Surface, rc, BufferValue, rcx, yAltSafety,
-                    0, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
+                LKWriteBoxedText(Surface, rc, BufferValue, rcx, yAltSafety, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
             }
             _skip_glider_RightBottom: ;
         } // ISGLIDER
@@ -475,7 +470,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             CharUpper(Buffer);
             Surface.SelectObject(LK8OverlayBigFont); // use this font for big values
             RECT ClipRect = { rcx, topmargin, name_xmax, topmargin + SizeBigFont.cy };
-            LKWriteText(Surface, Buffer, rcx, topmargin, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true, &ClipRect);
+            LKWriteText(Surface, Buffer, rcx, topmargin, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true, &ClipRect);
         }
     }
 
@@ -492,28 +487,27 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 Units::TimeToTextDown(BufferValue, gatechrono);
                 rcx= rc.right-RIGHTMARGIN;
                 rcy = yrightoffset - SizeBigFont.cy-NIBLSCALE(6); // 101112
-                LKWriteText(Surface, BufferValue, rcx,rcy, 0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+                LKWriteText(Surface, BufferValue, rcx,rcy, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
 
                 // Gate ETE Diff 
                 Value = WayPointCalc[DoOptimizeRoute() ? RESWP_OPTIMIZED : Task[0].Index].NextETE - gatechrono;
                 Units::TimeToTextDown(BufferValue, (int) Value);
                 rcy += SizeBigFont.cy-NIBLSCALE(2);
                 color=(Value<=0)?AMBERCOLOR:OverColorRef;
-                LKWriteText(Surface, BufferValue, rcx,rcy, 0, WTMODE_OUTLINED,WTALIGN_RIGHT,color, true);
+                LKWriteText(Surface, BufferValue, rcx,rcy, WTMODE_OUTLINED,WTALIGN_RIGHT,color, true);
 
                 // Req. Speed For reach Gate
                 if (LKFormatValue(LK_START_SPEED, false, BufferValue, BufferUnit, BufferTitle)) {
                     Surface.SelectObject(LK8TargetFont);
-                    Surface.GetTextSize(BufferUnit, _tcslen(BufferUnit), &TextSize);
+                    Surface.GetTextSize(BufferUnit, &TextSize);
                     rcx -= TextSize.cx;
-                    Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+                    Surface.GetTextSize(BufferValue, &TextSize);
                     rcx -= (TextSize.cx + NIBLSCALE(2));
                     rcy += TextSize.cy-NIBLSCALE(2);
 
-                    LKWriteText(Surface, BufferValue, rcx, rcy + (TextSize.cy / 3), 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                    LKWriteText(Surface, BufferValue, rcx, rcy + (TextSize.cy / 3), WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
 
-                    LKWriteText(Surface, BufferUnit, rcx + TextSize.cx + NIBLSCALE(2), rcy + (TextSize.cy / 3), 0,
-                            WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                    LKWriteText(Surface, BufferUnit, rcx + TextSize.cx + NIBLSCALE(2), rcy + (TextSize.cy / 3), WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
                     Surface.SelectObject(LK8OverlayBigFont);
                 }
             }
@@ -532,7 +526,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
 
             rcy = yrightoffset - SizeBigFont.cy;
             rcx = rightmargin;
-            LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+            LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
             _skip_para_RightMid:
 
             // Altitude difference with current MC
@@ -573,8 +567,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     break;
             }
             color=(redwarning&&Overlay_RightBottom<OAUX)?AMBERCOLOR:OverColorRef;
-            LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, 0,
-                WTMODE_OUTLINED, WTALIGN_RIGHT,color, true);  
+            LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, WTMODE_OUTLINED, WTALIGN_RIGHT,color, true);  
 
             //
             // SAFETY ALTITUDE INDICATOR (FOR PARAGLIDERS)
@@ -584,8 +577,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 Surface.SelectObject(LK8OverlaySmallFont);
                 _stprintf(BufferValue, _T(" + %.0f %s "), SAFETYALTITUDEARRIVAL / 10 * ALTITUDEMODIFY,
                         Units::GetUnitName(Units::GetUserAltitudeUnit()));
-                LKWriteBoxedText(Surface, rc, BufferValue, rcx, yAltSafety,
-                    0, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
+                LKWriteBoxedText(Surface, rc, BufferValue, rcx, yAltSafety, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
 
             }
             _skip_para_RightBottom: ;
@@ -608,7 +600,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         }
         rcy = yrightoffset - SizeBigFont.cy - (SizeGatesFont.cy * 2);
         rcx = rc.right - RIGHTMARGIN;
-        LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+        LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
 
         // USE THIS SPACE FOR MESSAGES TO THE PILOT
         rcy += SizeGatesFont.cy;
@@ -663,7 +655,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             // LKTOKEN  _@M925_ = "NO TSK START"
             _tcscpy(BufferValue, MsgToken(925));
         }
-        LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_RIGHT, distcolor, true);
+        LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_RIGHT, distcolor, true);
 
     } else 
     if ( (ISGLIDER || ISPARAGLIDER) && Overlay_RightTop) {
@@ -676,7 +668,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             LKFormatValue(GetInfoboxType(1), true, BufferValue, BufferUnit, BufferTitle);
         else
             LKFormatValue(LK_MC, false, BufferValue, BufferUnit, BufferTitle);
-        LKWriteText(Surface, BufferValue, rightmargin, yMcValue, 0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+        LKWriteText(Surface, BufferValue, rightmargin, yMcValue, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
 
         //
         // SAFETY MAC CREADY INDICATOR
@@ -686,7 +678,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             Surface.SelectObject(LK8OverlaySmallFont);
             _stprintf(BufferValue, _T(" %.1f %s "), GlidePolar::SafetyMacCready*LIFTMODIFY,
                 Units::GetUnitName(Units::GetUserVerticalSpeedUnit()));
-            LKWriteBoxedText(Surface, rc, BufferValue, rightmargin, yMcSafety, 0, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
+            LKWriteBoxedText(Surface, rc, BufferValue, rightmargin, yMcSafety, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
         }
 
         //
@@ -719,7 +711,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             Surface.Rectangle( rightmargin, yMcMode, rc.right, yMcMode + SizeMcModeFont.cy);
             LKWriteText(Surface, amcmode, rightmargin + NIBLSCALE(1), yMcMode,
                     // We paint white on black always here, but WriteText can invert them. So we reverse. 
-                    0, WTMODE_NORMAL, WTALIGN_LEFT, INVERTCOLORS?RGB_WHITE:RGB_BLACK, true);
+                    WTMODE_NORMAL, WTALIGN_LEFT, INVERTCOLORS?RGB_WHITE:RGB_BLACK, true);
 
         } // AutoMacCready true AUTO MC INDICATOR
     } // overlay RighTop
@@ -755,12 +747,11 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         // CENTER THE LEFT OVERLAYS
         //
         rcy = yMcValue;
-        LKWriteText(Surface, BufferValue, rcx, rcy+yoffset, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        LKWriteText(Surface, BufferValue, rcx, rcy+yoffset, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         if (!HideUnits) {
-            Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+            Surface.GetTextSize(BufferValue, &TextSize);
             Surface.SelectObject(MapScaleFont); 
-            LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, rcy+yoffset+unitbigoffset, 
-                0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+            LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, rcy+yoffset+unitbigoffset, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
    } // LeftTop
 
@@ -791,11 +782,11 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         Surface.SelectObject(LK8OverlayBigFont);
         rcy = yrightoffset - SizeBigFont.cy +yoffset;
 
-        LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         if (!HideUnits) {
-            Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+            Surface.GetTextSize(BufferValue, &TextSize);
             Surface.SelectObject(MapScaleFont);
-            LKWriteText(Surface, BufferUnit, rcx + TextSize.cx , rcy + unitbigoffset, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+            LKWriteText(Surface, BufferUnit, rcx + TextSize.cx , rcy + unitbigoffset, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
     } // LeftMid
 
@@ -818,12 +809,12 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         }
         Surface.SelectObject(LK8OverlayBigFont);
         rcy=yrightoffset - fixBigInterline+yoffset;
-        LKWriteText(Surface, BufferValue, rcx, rcy, 0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         if (!HideUnits) {
-            Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+            Surface.GetTextSize(BufferValue, &TextSize);
             Surface.SelectObject(MapScaleFont);
             LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, rcy + unitbigoffset, 
-                0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
     }
 
@@ -835,10 +826,10 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         Surface.SelectObject(LK8OverlayMediumFont);
         if (!ScreenLandscape) {
             LKWriteText(Surface, BufferValue, rightmargin, compass.cy,
-                0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
         } else { 
             LKWriteText(Surface, BufferValue, compass.cx, topmargin,
-                0, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
         }
     }
 
@@ -857,13 +848,13 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 LKFormatValue(LK_WIND, false, BufferValue, BufferUnit, BufferTitle);
         }
         LKWriteText(Surface, BufferValue, leftmargin, yLeftWind,
-            0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true); 
+            WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true); 
 
         if (!HideUnits) {
-            Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+            Surface.GetTextSize(BufferValue, &TextSize);
             Surface.SelectObject(MapScaleFont);
             LKWriteText(Surface, BufferUnit, leftmargin + TextSize.cx, yLeftWind + unitmediumoffset, 
-                0, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
     } // LeftDown
 

--- a/Common/Source/Draw/LKDrawMapSpace.cpp
+++ b/Common/Source/Draw/LKDrawMapSpace.cpp
@@ -175,7 +175,7 @@ void MapWindow::DrawMapSpace(LKSurface& Surface,  const RECT& rc) {
     TextDisplayMode.AlligneCenter = 1;
     Surface.SelectObject(LK8TargetFont);
     _stprintf(Buffer,TEXT("MapSpaceMode=%d"),MapSpaceMode);
-    TextInBox(Surface, &rc, Buffer, (rc.right+rc.left)/2, NIBLSCALE(50) , 0, &TextDisplayMode, false);
+    TextInBox(Surface, &rc, Buffer, (rc.right+rc.left)/2, NIBLSCALE(50) , &TextDisplayMode, false);
     break;
   }
 #ifdef DRAWLKSTATUS

--- a/Common/Source/Draw/LKDrawNearest.cpp
+++ b/Common/Source/Draw/LKDrawNearest.cpp
@@ -100,10 +100,10 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
         Surface.SelectObject(bigFont);
 
         // We want an average size of an alphabet letter and number
-        Surface.GetTextSize(_T("ALPHAROMEO"), 10, &InfoTextSize);
+        Surface.GetTextSize(_T("ALPHAROMEO"), &InfoTextSize);
         InfoTextSize.cx /= 10;
 
-        Surface.GetTextSize(_T("0123456789"), 10, &InfoNumberSize);
+        Surface.GetTextSize(_T("0123456789"), &InfoNumberSize);
         InfoNumberSize.cx /= 10;
 
         //
@@ -112,16 +112,16 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
 
 #define LKASP_TYPE_LEN  4
         _stprintf(Buffer, TEXT("CTRA")); // ASP TYPE
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_AIRSPACES]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_AIRSPACES]);
 
         // Flags can be SFE, three chars
         _stprintf(Buffer, TEXT("SFE"));
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_AIRSPACES]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_AIRSPACES]);
 
         // Thermal average
         _stprintf(Buffer, TEXT("+55.5"));
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_THERMALS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_TRAFFIC]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_THERMALS]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_TRAFFIC]);
 
         //
         // COMMON TYPES (Distance, Bearing, Altitude Diff,  Efficiency)
@@ -134,37 +134,38 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
             _tcscat(Buffer, _T(" "));
             _tcscat(Buffer, Units::GetDistanceName());
         }
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_LANDABLE]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_AIRPORTS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_NEARTPS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_COMMON]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_RECENT]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_AIRSPACES]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_THERMALS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K1TextSize[MSM_TRAFFIC]);
+#warning "to much call with same input"
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_LANDABLE]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_AIRPORTS]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_NEARTPS]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_COMMON]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_RECENT]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_AIRSPACES]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_THERMALS]);
+        Surface.GetTextSize(Buffer, &K1TextSize[MSM_TRAFFIC]);
 
 
         // BEARING
         //
         _stprintf(Buffer, TEXT("<325"));
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_LANDABLE]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_AIRPORTS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_NEARTPS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_COMMON]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_RECENT]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_AIRSPACES]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_THERMALS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K2TextSize[MSM_TRAFFIC]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_LANDABLE]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_AIRPORTS]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_NEARTPS]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_COMMON]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_RECENT]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_AIRSPACES]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_THERMALS]);
+        Surface.GetTextSize(Buffer, &K2TextSize[MSM_TRAFFIC]);
 
 
         // REQUIRED EFFICIENCY (max 200)
         //
         _stprintf(Buffer, TEXT("255"));
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_LANDABLE]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_AIRPORTS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_NEARTPS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_COMMON]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K3TextSize[MSM_RECENT]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_LANDABLE]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_AIRPORTS]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_NEARTPS]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_COMMON]);
+        Surface.GetTextSize(Buffer, &K3TextSize[MSM_RECENT]);
 
 
         // REQUIRED ALTITUDE DIFFERENCE
@@ -177,18 +178,18 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
             _tcscat(Buffer, _T(" "));
             _tcscat(Buffer, Units::GetAltitudeName());
         }
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_LANDABLE]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_AIRPORTS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_NEARTPS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_COMMON]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_RECENT]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_THERMALS]);
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &K4TextSize[MSM_TRAFFIC]); // we dont use +-
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_LANDABLE]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_AIRPORTS]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_NEARTPS]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_COMMON]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_RECENT]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_THERMALS]);
+        Surface.GetTextSize(Buffer, &K4TextSize[MSM_TRAFFIC]); // we dont use +-
 
 
         Surface.SelectObject(LK8PanelMediumFont);
         _stprintf(Buffer, TEXT("4.4"));
-        Surface.GetTextSize(Buffer, _tcslen(Buffer), &phdrTextSize);
+        Surface.GetTextSize(Buffer, &phdrTextSize);
 
         // Col0 is where APTS 1/3 can be written, after ModeIndex:Curtype
         Column0[MSM_LANDABLE] = rc.left + phdrTextSize.cx + LEFTLIMITER + NIBLSCALE(5);
@@ -337,7 +338,7 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
         // Vertical alignement
 
         Surface.SelectObject(LK8InfoNearestFont);
-        Surface.GetTextSize(_T("M"), 1, &phdrTextSize);
+        Surface.GetTextSize(_T("M"), &phdrTextSize);
 
         TopSize = rc.top + HEADRAW * 2 + phdrTextSize.cy;
         p1.x = rc.left;
@@ -378,9 +379,9 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
         //
         Surface.SelectObject(LK8InfoNearestFont);
         if (ScreenLandscape)
-            Surface.GetTextSize(_T("MMMM 3/3"), 8, &phdrTextSize);
+            Surface.GetTextSize(_T("MMMM 3/3"), &phdrTextSize);
         else
-            Surface.GetTextSize(_T("MMM 3/3"), 7, &phdrTextSize);
+            Surface.GetTextSize(_T("MMM 3/3"), &phdrTextSize);
 
         s_sortBox[0].left = Column0[MSM_LANDABLE] - NIBLSCALE(1);
         s_sortBox[0].right = Column0[MSM_LANDABLE] + phdrTextSize.cx;
@@ -731,7 +732,7 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
     //
     Surface.SelectObject(LK8PanelMediumFont);
     _stprintf(Buffer, TEXT("%d.%d"), ModeIndex, CURTYPE + 1);
-    LKWriteText(Surface, Buffer, rc.left + LEFTLIMITER, rc.top + TOPLIMITER, 0, WTMODE_NORMAL, WTALIGN_LEFT,
+    LKWriteText(Surface, Buffer, rc.left + LEFTLIMITER, rc.top + TOPLIMITER, WTMODE_NORMAL, WTALIGN_LEFT,
 #ifndef UNDITHER
             RGB_LIGHTGREEN, false);
 #else
@@ -748,24 +749,24 @@ void MapWindow::DrawNearest(LKSurface& Surface, const RECT& rc) {
 #else
     tmpcolor = cursortbox == 0 ? RGB_BLACK : RGB_WHITE;
 #endif
-    LKWriteText(Surface, Buffer, Column0[curmapspace], rc.top + HEADRAW - NIBLSCALE(1), 0, WTMODE_NORMAL, WTALIGN_LEFT, tmpcolor, false);
+    LKWriteText(Surface, Buffer, Column0[curmapspace], rc.top + HEADRAW - NIBLSCALE(1), WTMODE_NORMAL, WTALIGN_LEFT, tmpcolor, false);
     if (cursortbox == 99) cursortbox = 0;
 
     _tcscpy(Buffer, MsgToken(headertoken[1]));
     tmpcolor = cursortbox == 1 ? RGB_BLACK : RGB_WHITE;
-    LKWriteText(Surface, Buffer, hColumn2, rc.top + HEADRAW, 0, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
+    LKWriteText(Surface, Buffer, hColumn2, rc.top + HEADRAW, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
 
     _tcscpy(Buffer, MsgToken(headertoken[2]));
     tmpcolor = cursortbox == 2 ? RGB_BLACK : RGB_WHITE;
-    LKWriteText(Surface, Buffer, hColumn3, rc.top + HEADRAW, 0, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
+    LKWriteText(Surface, Buffer, hColumn3, rc.top + HEADRAW, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
 
     _tcscpy(Buffer, MsgToken(headertoken[3]));
     tmpcolor = cursortbox == 3 ? RGB_BLACK : RGB_WHITE;
-    LKWriteText(Surface, Buffer, hColumn4, rc.top + HEADRAW, 0, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
+    LKWriteText(Surface, Buffer, hColumn4, rc.top + HEADRAW, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
 
     _tcscpy(Buffer, MsgToken(headertoken[4]));
     tmpcolor = cursortbox == 4 ? RGB_BLACK : RGB_WHITE;
-    LKWriteText(Surface, Buffer, hColumn5, rc.top + HEADRAW, 0, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
+    LKWriteText(Surface, Buffer, hColumn5, rc.top + HEADRAW, WTMODE_NORMAL, WTALIGN_RIGHT, tmpcolor, false);
 
     Surface.SelectObject(bigFont); // Text font for Nearest
 
@@ -1210,18 +1211,18 @@ _KeepOldAirspacesValues:
         } // MSMTRAFFIC
 
         if (!usetwolines) {
-            LKWriteText(Surface, Buffer1[i][curpage], Column1[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_LEFT, rcolor, false);
-            LKWriteText(Surface, Buffer2[i][curpage], Column2[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
-            LKWriteText(Surface, Buffer3[i][curpage], Column3[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
-            LKWriteText(Surface, Buffer4[i][curpage], Column4[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
-            LKWriteText(Surface, Buffer5[i][curpage], Column5[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer1[i][curpage], Column1[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_LEFT, rcolor, false);
+            LKWriteText(Surface, Buffer2[i][curpage], Column2[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer3[i][curpage], Column3[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer4[i][curpage], Column4[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer5[i][curpage], Column5[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
         } else {
-            LKWriteText(Surface, Buffer1[i][curpage], Column1[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_LEFT, rcolor, false);
-            LKWriteText(Surface, Buffer2[i][curpage], Column5[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer1[i][curpage], Column1[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_LEFT, rcolor, false);
+            LKWriteText(Surface, Buffer2[i][curpage], Column5[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
             iRaw += s_rawspace;
-            LKWriteText(Surface, Buffer3[i][curpage], Column2[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
-            LKWriteText(Surface, Buffer4[i][curpage], Column3[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
-            LKWriteText(Surface, Buffer5[i][curpage], Column4[curmapspace], iRaw, 0, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer3[i][curpage], Column2[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer4[i][curpage], Column3[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
+            LKWriteText(Surface, Buffer5[i][curpage], Column4[curmapspace], iRaw, WTMODE_NORMAL, WTALIGN_RIGHT, rcolor, false);
         }
 
     } // for loop

--- a/Common/Source/Draw/LKDrawTargetTraffic.cpp
+++ b/Common/Source/Draw/LKDrawTargetTraffic.cpp
@@ -236,13 +236,13 @@ void MapWindow::DrawTarget(LKSurface& Surface, const RECT& rc, int ttop, int tbo
 	Surface.SelectObject(LK8PanelBigFont);
 	switch ( LKTraffic[LKTargetIndex].Status ) {
 		case LKT_GHOST:
-			LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTYELLOW, false);
+			LKWriteText(Surface,  tbear, ncenterx,ncentery, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTYELLOW, false);
 			break;
 		case LKT_ZOMBIE:
-			LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTRED, false);
+			LKWriteText(Surface,  tbear, ncenterx,ncentery, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTRED, false);
 			break;
 		default:
-			LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
+			LKWriteText(Surface,  tbear, ncenterx,ncentery, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
 			break;
 	}
 
@@ -254,7 +254,7 @@ void MapWindow::DrawTarget(LKSurface& Surface, const RECT& rc, int ttop, int tbo
 	} else {
 		_stprintf(tbear, TEXT("0%s"), gettext(_T("_@M2179_")));
 	}
-	LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
+	LKWriteText(Surface,  tbear, ncenterx,ncentery, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
 	#endif
   }
 
@@ -379,19 +379,15 @@ void MapWindow::DrawTarget(LKSurface& Surface, const RECT& rc, int ttop, int tbo
 	} else
 		yposbear=altline_left[5].y;
 
-//	LKWriteText(Surface,  tbear, ncenterx,altline_left[5].y, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
 	switch ( LKTraffic[LKTargetIndex].Status ) {
 		case LKT_GHOST:
-			//LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTYELLOW, false);
-			LKWriteText(Surface,  tbear, ncenterx,yposbear, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTYELLOW, false);
+			LKWriteText(Surface,  tbear, ncenterx,yposbear, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTYELLOW, false);
 			break;
 		case LKT_ZOMBIE:
-			//LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTRED, false);
-			LKWriteText(Surface,  tbear, ncenterx,yposbear, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTRED, false);
+			LKWriteText(Surface,  tbear, ncenterx,yposbear, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_LIGHTRED, false);
 			break;
 		default:
-			//LKWriteText(Surface,  tbear, ncenterx,ncentery, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
-			LKWriteText(Surface,  tbear, ncenterx,yposbear, 0, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
+			LKWriteText(Surface,  tbear, ncenterx,yposbear, WTMODE_OUTLINED, WTALIGN_CENTER, RGB_WHITE, false);
 			break;
 	}
   }

--- a/Common/Source/Draw/LKDrawWaypoints.cpp
+++ b/Common/Source/Draw/LKDrawWaypoints.cpp
@@ -465,7 +465,7 @@ void MapWindow::DrawWaypointsNew(LKSurface& Surface, const RECT& rc)
 	      } // end intask/irange/dowrite
 
     if (MapWindow::zoom.RealScale()<20 && islandable && dowrite) {
-      TextInBox(Surface, &rc, Buffer, WayPointList[i].Screen.x+5, WayPointList[i].Screen.y, 0, &TextDisplayMode, true);
+      TextInBox(Surface, &rc, Buffer, WayPointList[i].Screen.x+5, WayPointList[i].Screen.y, &TextDisplayMode, true);
       dowrite=false; // do not pass it along
     }
 
@@ -522,7 +522,7 @@ void MapWindow::DrawWaypointsNew(LKSurface& Surface, const RECT& rc)
     if ( E->inTask || (E->isLandable && !E->isExcluded) ) { 
     const LKIcon* pWptBmp = NULL;
 
-	TextInBox(Surface, &rc, E->Name, E->Pos.x, E->Pos.y, 0, &(E->Mode), false);
+	TextInBox(Surface, &rc, E->Name, E->Pos.x, E->Pos.y, &(E->Mode), false);
 
 	// At low zoom, dont print the bitmap because drawn task would make it look offsetted
 	if(MapWindow::zoom.RealScale() > 2) continue;
@@ -553,7 +553,7 @@ void MapWindow::DrawWaypointsNew(LKSurface& Surface, const RECT& rc)
     if (!E->inTask && !E->isLandable ) {
       const LKIcon* pWptBmp = NULL;
 
-      if ( TextInBox(Surface, &rc, E->Name, E->Pos.x, E->Pos.y, 0, &(E->Mode), true) == true) {
+      if ( TextInBox(Surface, &rc, E->Name, E->Pos.x, E->Pos.y, &(E->Mode), true) == true) {
 
 	// If we are at low zoom, use a dot for icons, so we dont clutter the screen
 	if(MapWindow::zoom.RealScale() > 4) {

--- a/Common/Source/Draw/LKDrawWelcome.cpp
+++ b/Common/Source/Draw/LKDrawWelcome.cpp
@@ -45,14 +45,14 @@ void MapWindow::DrawWelcome8000(LKSurface& Surface, const RECT& rc) {
   #else
   _stprintf(Buffer,TEXT("%sC v%s.%s %s"),_T(LKFORK),_T(LKVERSION),_T(LKRELEASE),_T(__DATE__));
   #endif
-  Surface.GetTextSize(Buffer, _tcslen(Buffer), &textSize);
+  Surface.GetTextSize(Buffer, &textSize);
   y+=(textSize.cy)/2;
-  LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+  LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
 
   #ifdef LKCOMPETITION
   y+=(textSize.cy);
   _stprintf(Buffer,_T("COMPETITION VERSION"));
-  LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+  LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
   #endif
 
   _tcscpy(Buffer,_T(""));
@@ -71,31 +71,31 @@ void MapWindow::DrawWelcome8000(LKSurface& Surface, const RECT& rc) {
   #endif
   if (_tcslen(Buffer)>0) {
       y+=(textSize.cy);
-      LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+      LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
   }
 
   y+=(textSize.cy)/2; // spacing
 
   _stprintf(Buffer, _T("Waypoints loaded: %u"), (unsigned int)(WayPointList.size()-NUMRESWP));
   y+=(textSize.cy);
-  LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+  LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
 
 
   _stprintf(Buffer, _T("Free RAM: %0.1fM"),freeram);
   y+=(textSize.cy);
-  LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+  LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
 
   y+=(textSize.cy)/2; // spacing
 
   if (GPSAltitudeOffset != 0) {
       _stprintf(Buffer, _T("Reminder: HGPS offset: %+.0f)"), GPSAltitudeOffset/1000*ALTITUDEMODIFY); 
       y+=(textSize.cy);
-      LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+      LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
   }
 
   _stprintf(Buffer,TEXT("Click to continue"));
   y= rc.bottom-BottomSize-textSize.cy-NIBLSCALE(2);
-  LKWriteText(Surface, Buffer, x, y , 0, WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
+  LKWriteText(Surface, Buffer, x, y , WTMODE_NORMAL, WTALIGN_LEFT,RGB_WHITENOREV, false);
 
 
 }

--- a/Common/Source/Draw/LKGeneralAviation.cpp
+++ b/Common/Source/Draw/LKGeneralAviation.cpp
@@ -20,17 +20,17 @@
 ////////////////////////////////////////////////////////////////////////////////////
 void drawOutlineText(LKSurface& Surface,int x,int y,const TCHAR * textBuffer, const LKColor& color )
 {
-	size_t len = _tcslen(textBuffer);
-
-
+#ifdef USE_FREETYPE
+#warning "to slow, rewrite using freetype outline"
+#endif
 	Surface.SetTextColor(RGB_BLACK);
-	Surface.DrawText(x -1, y -1, textBuffer , len);
-	Surface.DrawText(x +1, y +1, textBuffer , len);
-	Surface.DrawText(x -1, y   , textBuffer , len);
-	Surface.DrawText(x   , y +1, textBuffer , len);
+	Surface.DrawText(x -1, y -1, textBuffer);
+	Surface.DrawText(x +1, y +1, textBuffer);
+	Surface.DrawText(x -1, y   , textBuffer);
+	Surface.DrawText(x   , y +1, textBuffer);
 
 	Surface.SetTextColor(color);
-	Surface.DrawText(x , y , textBuffer , len);
+	Surface.DrawText(x , y , textBuffer);
 }
 
 
@@ -116,7 +116,7 @@ int MapWindow::DrawCompassArc(LKSurface& Surface, long x, long y, int radius, co
 					}
 
 					SIZE textSize;
-					Surface.GetTextSize(textBuffer, _tcslen(textBuffer), &textSize);
+					Surface.GetTextSize(textBuffer, &textSize);
 
 					int textX = x + (long) ((radius - (textSize.cy/2)-2) * fastsine(screenAngle) ) - textSize.cx/2;
 					int textY = y - (long) ((radius - (textSize.cy/2)-2) * fastcosine(screenAngle) );
@@ -177,7 +177,7 @@ void MapWindow::DrawHSIarc(LKSurface& Surface, const POINT& Orig, const RECT& rc
 	_stprintf(brgText,_T("%03d"),bearing);
 
 	SIZE brgSize;
-	Surface.GetTextSize(brgText, _tcslen(brgText), &brgSize);
+	Surface.GetTextSize(brgText, &brgSize);
 	drawOutlineText(Surface, rcx -(brgSize.cx/2), 0 ,brgText,RGB_WHITE);
 
 	//Draw pointer

--- a/Common/Source/Draw/LKWriteText.cpp
+++ b/Common/Source/Draw/LKWriteText.cpp
@@ -49,12 +49,11 @@ static const Color2Outline_t ColorOutLine [] = {
 //
 
 void MapWindow::LKWriteText(LKSurface& Surface, const TCHAR* wText, int x, int y,
-        int maxsize, const bool lwmode, const short align, const LKColor& rgb_text, bool invertable, RECT* ClipRect) {
+        const bool lwmode, const short align, const LKColor& rgb_text, bool invertable, RECT* ClipRect) {
 
     SIZE tsize;
-    if (maxsize == 0) maxsize = _tcslen(wText);
 
-    Surface.GetTextSize(wText, maxsize, &tsize);
+    Surface.GetTextSize(wText, &tsize);
     LKColor textColor = rgb_text;
     // by default, LK8000 is white on black, i.e. inverted
     if ((!INVERTCOLORS) || (LKTextBlack && invertable)) {
@@ -109,30 +108,33 @@ void MapWindow::LKWriteText(LKSurface& Surface, const TCHAR* wText, int x, int y
             // Simplified, shadowing better and faster
             // ETO_OPAQUE not necessary since we pass a NULL rect
             //
-            Surface.DrawText(x - 1, y - 1, wText, maxsize, ClipRect);
-            Surface.DrawText(x - 1, y + 1, wText, maxsize, ClipRect);
-            Surface.DrawText(x + 1, y - 1, wText, maxsize, ClipRect);
-            Surface.DrawText(x + 1, y + 1, wText, maxsize, ClipRect);
+#ifdef USE_FREETYPE
+#warning "to slow, rewrite using freetype outline"
+#endif
+            Surface.DrawText(x - 1, y - 1, wText, ClipRect);
+            Surface.DrawText(x - 1, y + 1, wText, ClipRect);
+            Surface.DrawText(x + 1, y - 1, wText, ClipRect);
+            Surface.DrawText(x + 1, y + 1, wText, ClipRect);
 
             // SetTextColor(hDC,RGB_GREY);  // This would give an Emboss effect
             // Surface.DrawText(x, y+2, 0, wText, maxsize);
 
             if (moreoutline) {
-                Surface.DrawText(x - 2, y, wText, maxsize, ClipRect);
-                Surface.DrawText(x + 2, y, wText, maxsize, ClipRect);
-                Surface.DrawText(x, y - 2, wText, maxsize, ClipRect);
-                Surface.DrawText(x, y + 2, wText, maxsize, ClipRect);
+                Surface.DrawText(x - 2, y, wText, ClipRect);
+                Surface.DrawText(x + 2, y, wText, ClipRect);
+                Surface.DrawText(x, y - 2, wText, ClipRect);
+                Surface.DrawText(x, y + 2, wText, ClipRect);
             }
 
             Surface.SetTextColor(textColor);
-            Surface.DrawText(x, y, wText, maxsize, ClipRect);
+            Surface.DrawText(x, y, wText, ClipRect);
             Surface.SetTextColor(RGB_BLACK);
             break;
         }
         case WTMODE_NORMAL:
 
             Surface.SetTextColor(textColor);
-            Surface.DrawText(x, y, wText, maxsize, ClipRect);
+            Surface.DrawText(x, y, wText, ClipRect);
             Surface.SetTextColor(RGB_BLACK);
             break;
 
@@ -150,15 +152,13 @@ void MapWindow::LKWriteText(LKSurface& Surface, const TCHAR* wText, int x, int y
 // A note about DrawRect: in main moving map, DrawRect is the part of screen excluding BottomBar, 
 // when the bottom bar is opaque. So choose carefully.
 //
-void MapWindow::LKWriteBoxedText(LKSurface& Surface, const RECT& clipRect, const TCHAR* wText, int x, int y, int maxsize, const short align ,
+void MapWindow::LKWriteBoxedText(LKSurface& Surface, const RECT& clipRect, const TCHAR* wText, int x, int y, const short align ,
 	const LKColor& dir_rgb, const LKColor& inv_rgb  ) {
 
   LKColor oldTextColor = Surface.SetTextColor(INVERTCOLORS?dir_rgb:inv_rgb);
 
   SIZE tsize;
-  if (maxsize==0) maxsize=_tcslen(wText);
-  
-  Surface.GetTextSize(wText, maxsize, &tsize);
+  Surface.GetTextSize(wText, &tsize);
   short vy;
   switch(align) {
 	case WTALIGN_LEFT:
@@ -193,7 +193,7 @@ void MapWindow::LKWriteBoxedText(LKSurface& Surface, const RECT& clipRect, const
   #endif
 
 
-  Surface.DrawText(x, y, wText, maxsize);
+  Surface.DrawText(x, y, wText);
 
   //SetTextColor(hDC,RGB_BLACK);   THIS WAS FORCED BLACk SO FAR 121005
   Surface.SetTextColor(oldTextColor);

--- a/Common/Source/Draw/Multimaps/DrawMultimap_Example.cpp
+++ b/Common/Source/Draw/Multimaps/DrawMultimap_Example.cpp
@@ -44,7 +44,7 @@ void MapWindow::LKDrawMultimap_Example(HDC hdc, const RECT rc)
   // Duration of key is inside long VKtime, in milliseconds.
   //
 
-  LKWriteBoxedText(hdc, _T("MULTIMAP PAGE EXAMPLE"), 1, 1 , 0, WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
+  LKWriteBoxedText(hdc, _T("MULTIMAP PAGE EXAMPLE"), 1, 1 , WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
 
 
   TCHAR ttext[100];
@@ -134,14 +134,14 @@ void MapWindow::LKDrawMultimap_Example(HDC hdc, const RECT rc)
 		break;
   }
 
-  LKWriteBoxedText(hdc, ttext, 1, 50 , 0, WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
+  LKWriteBoxedText(hdc, ttext, 1, 50 , WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
 
   //
   // Be sure to check that an EVENT was generated, otherwise you are checking even bottombar key presses.
   //
   if (LKevent!=LKEVENT_NONE) {
 	_stprintf(ttext,_T("Last coords: X=%d Y=%d  , duration=%ld ms"),X,Y,VKtime);
-	LKWriteBoxedText(hdc, ttext, 1, 100 , 0, WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
+	LKWriteBoxedText(hdc, ttext, 1, 100 , WTALIGN_LEFT, RGB_WHITE, RGB_BLACK);
   }
 
 

--- a/Common/Source/Draw/Multimaps/DrawMultimap_Test.cpp
+++ b/Common/Source/Draw/Multimaps/DrawMultimap_Test.cpp
@@ -88,7 +88,7 @@ void MapWindow::LKDrawMultimap_Test(LKSurface& Surface, const RECT& rc)
   const auto oldpen = Surface.SelectObject(LKPen_White_N1);
   const auto oldbrush = Surface.SelectObject(LKBrush_LightGrey);
 
-  LKWriteBoxedText(Surface, rct, _T("MULTIMAP PAGE EXAMPLE"), 1, 1 , 0, WTALIGN_LEFT, RGB_BLACK, RGB_WHITE);
+  LKWriteBoxedText(Surface, rct, _T("MULTIMAP PAGE EXAMPLE"), 1, 1, WTALIGN_LEFT, RGB_BLACK, RGB_WHITE);
 
 
   TCHAR ttext[100];
@@ -153,14 +153,14 @@ void MapWindow::LKDrawMultimap_Test(LKSurface& Surface, const RECT& rc)
 		break;
   }
 
-  LKWriteBoxedText(Surface, rct, ttext, 1, 50 , 0, WTALIGN_LEFT, RGB_BLACK, RGB_WHITE);
+  LKWriteBoxedText(Surface, rct, ttext, 1, 50 , WTALIGN_LEFT, RGB_BLACK, RGB_WHITE);
 
   //
   // Be sure to check that an EVENT was generated, otherwise you are checking even bottombar key presses.
   //
   if (LKevent!=LKEVENT_NONE) {
 	_stprintf(ttext,_T("Last coords: X=%d Y=%d  , duration=%ld ms"),X,Y,VKtime);
-	LKWriteBoxedText(Surface, rct, ttext, 1, 100 , 0, WTALIGN_LEFT, RGB_BLACK, RGB_WHITE);
+	LKWriteBoxedText(Surface, rct, ttext, 1, 100 , WTALIGN_LEFT, RGB_BLACK, RGB_WHITE);
   }
 
 

--- a/Common/Source/Draw/Multimaps/DrawVisualGlide.cpp
+++ b/Common/Source/Draw/Multimaps/DrawVisualGlide.cpp
@@ -88,10 +88,10 @@ void MapWindow::DrawVisualGlide(LKSurface& Surface, const DiagrammStruct& sDia) 
     SIZE textSizeTop, textSizeBot;
     Surface.SelectObject(line1Font);
     _stprintf(tmpT, _T("MMMM"));
-    Surface.GetTextSize(tmpT, _tcslen(tmpT), &textSizeTop);
+    Surface.GetTextSize(tmpT, &textSizeTop);
     Surface.SelectObject(line2Font);
     _stprintf(tmpT, _T("55.5%s 79%s%s "), Units::GetDistanceName(), MsgToken(2179), MsgToken(2183));
-    Surface.GetTextSize(tmpT, _tcslen(tmpT), &textSizeBot);
+    Surface.GetTextSize(tmpT, &textSizeBot);
 
     // we can cut the waypoint name, but not the value data, so we use the second row of data
     // to size the box for everything.
@@ -487,21 +487,8 @@ void MapWindow::VGTextInBox(LKSurface& Surface, unsigned short nslot, short numl
     Sideview_VGBox_Number++;
 
     Surface.SelectObject(line1Font);
-    unsigned int tlen = _tcslen(wText1);
-    Surface.GetTextSize(wText1, tlen, &tsize);
+    Surface.GetTextSize(wText1, &tsize);
     int line1fontYsize = tsize.cy;
-
-    // Fit as many characters in the available boxed space
-    if (tsize.cx > maxtSizeX) {
-        LKASSERT(tlen > 0);
-        for (short t = tlen - 1; t > 0; t--) {
-            Surface.GetTextSize(wText1, t, &tsize);
-            if (tsize.cx <= maxtSizeX) {
-                tlen = t;
-                break;
-            }
-        }
-    }
 
     short vy = y + (boxSizeY / 2);
     Surface.SelectObject(bbrush);
@@ -516,13 +503,16 @@ void MapWindow::VGTextInBox(LKSurface& Surface, unsigned short nslot, short numl
     Sideview_VGBox[nslot].bottom = vy;
     Sideview_VGBox[nslot].right = x + (boxSizeX / 2);
 
+    PixelRect ClipRect(Sideview_VGBox[nslot]);
+    ClipRect.Grow(-1*NIBLSCALE(2), 0); // text padding
+    
     // 
     // LINE 1
     // 
-    tx = x - (tsize.cx / 2);
+    tx = max<PixelScalar>(ClipRect.left, x - (tsize.cx / 2));
     ty = y - (vy - y);
-
-    Surface.DrawText(tx, ty, wText1, tlen);
+    
+    Surface.DrawText(tx, ty, wText1, &ClipRect);
 
     if (numlines == 1) goto _end;
 #if BUGSTOP
@@ -535,11 +525,10 @@ void MapWindow::VGTextInBox(LKSurface& Surface, unsigned short nslot, short numl
     // 
     Surface.SetTextColor(RGB_BLACK);
     Surface.SelectObject(line2Font);
-    tlen = _tcslen(wText2);
-    Surface.GetTextSize(wText2, tlen, &tsize);
+    Surface.GetTextSize(wText2, &tsize);
     tx = x - (tsize.cx / 2);
     ty += line1fontYsize - NIBLSCALE(2);
-    Surface.DrawText(tx, ty, wText2, tlen);
+    Surface.DrawText(tx, ty, wText2);
 
     if (numlines == 2) goto _end;
 #if BUGSTOP
@@ -551,11 +540,10 @@ void MapWindow::VGTextInBox(LKSurface& Surface, unsigned short nslot, short numl
     // LINE 3
     //
     Surface.SetTextColor(RGB_BLACK);
-    tlen = _tcslen(wText3);
-    Surface.GetTextSize(wText3, tlen, &tsize);
+    Surface.GetTextSize(wText3, &tsize);
     tx = x - (tsize.cx / 2);
     ty += tsize.cy - NIBLSCALE(2);
-    Surface.DrawText(tx, ty, wText3, tlen);
+    Surface.DrawText(tx, ty, wText3);
 
 _end:
     Surface.SetTextColor(oldTextColor);

--- a/Common/Source/Draw/Multimaps/RenderAirspace.cpp
+++ b/Common/Source/Draw/Multimaps/RenderAirspace.cpp
@@ -724,11 +724,11 @@ void MapWindow::RenderAirspace(LKSurface& Surface, const RECT& rc_input) {
             Units::FormatUserAltitude(calc_terrainalt, buffer, 7);
             LK_tcsncpy(text, MsgToken(1743), TBSIZE - _tcslen(buffer));
             _tcscat(text, buffer);
-            Surface.GetTextSize(text, _tcslen(text), &tsize);
+            Surface.GetTextSize(text, &tsize);
             x = CalcDistanceCoordinat(0, &sDia) - tsize.cx / 2;
             y = CalcHeightCoordinat((calc_terrainalt), &sDia);
             if ((ELV_FACT * tsize.cy) < abs(rc.bottom - y)) {
-                Surface.DrawText(x, rc.bottom - (int) (ELV_FACT * tsize.cy) /* rc.top-tsize.cy*/, text, _tcslen(text));
+                Surface.DrawText(x, rc.bottom - (int) (ELV_FACT * tsize.cy) /* rc.top-tsize.cy*/, text);
             }
         }
 
@@ -739,12 +739,12 @@ void MapWindow::RenderAirspace(LKSurface& Surface, const RECT& rc_input) {
             Units::FormatUserAltitude(wpt_altitude, buffer, 7);
             LK_tcsncpy(text, MsgToken(1743), TBSIZE - _tcslen(buffer));
             _tcscat(text, buffer);
-            Surface.GetTextSize(text, _tcslen(text), &tsize);
+            Surface.GetTextSize(text, &tsize);
             x0 = CalcDistanceCoordinat(wpt_dist, &sDia) - tsize.cx / 2;
             if (abs(x - x0) > tsize.cx) {
                 y = CalcHeightCoordinat((wpt_altitude), &sDia);
                 if ((ELV_FACT * tsize.cy) < abs(rc.bottom - y)) {
-                    Surface.DrawText(x0, rc.bottom - (int) (ELV_FACT * tsize.cy) /* rc.top-tsize.cy*/, text, _tcslen(text));
+                    Surface.DrawText(x0, rc.bottom - (int) (ELV_FACT * tsize.cy) /* rc.top-tsize.cy*/, text);
                 }
             }
         }
@@ -765,7 +765,7 @@ void MapWindow::RenderAirspace(LKSurface& Surface, const RECT& rc_input) {
         Units::FormatUserDistance(wpt_dist, text2, 7);
         _tcscat(text, text2);
 
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
         x = line[0].x - tsize.cx - NIBLSCALE(5);
 
         if (x < x0) bDrawRightSide = true;
@@ -781,7 +781,7 @@ void MapWindow::RenderAirspace(LKSurface& Surface, const RECT& rc_input) {
         Surface.SelectObject(INVERTCOLORS?LKBrush_Black:LKBrush_White);
         #endif
 
-        MapWindow::LKWriteBoxedText(Surface, rc, text, line[0].x, y - 3, 0, WTALIGN_CENTER, RGB_WHITE, RGB_BLACK);
+        MapWindow::LKWriteBoxedText(Surface, rc, text, line[0].x, y - 3, WTALIGN_CENTER, RGB_WHITE, RGB_BLACK);
 
         y = line[0].y - 2 * tsize.cy;
 
@@ -798,7 +798,7 @@ void MapWindow::RenderAirspace(LKSurface& Surface, const RECT& rc_input) {
 
         // size a template
         _stprintf(text, TEXT("Mc 99.9: +12345"));
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
 
         if (IsSafetyAltitudeInUse(overindex)) altarriv += (SAFETYALTITUDEARRIVAL / 10);
 
@@ -821,7 +821,7 @@ void MapWindow::RenderAirspace(LKSurface& Surface, const RECT& rc_input) {
         Surface.SelectObject(LKBrush_White);
         #endif
 
-        MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, 0, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
+        MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
 
 _skip_mc0:
 
@@ -835,14 +835,14 @@ _skip_mc0:
                 Units::FormatUserAltitude(altarriv, buffer, 7);
                 LK_tcsncpy(text, MsgToken(1742), TBSIZE - _tcslen(buffer));
                 _tcscat(text, buffer);
-                Surface.GetTextSize(text, _tcslen(text), &tsize);
+                Surface.GetTextSize(text, &tsize);
                 x = line[0].x - NIBLSCALE(5);
 
                 y = CalcHeightCoordinat((SAFETYALTITUDEARRIVAL / 10 + wpt_altitude + altarriv)*7 / 10, &sDia);
                 Surface.SelectObject(LK_BLACK_PEN);
                 Surface.SelectObject(LKBrush_Nlight);
 
-                MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, 0, WTALIGN_RIGHT, RGB_BLACK, RGB_BLACK);
+                MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, WTALIGN_RIGHT, RGB_BLACK, RGB_BLACK);
             }
         }
 
@@ -858,7 +858,7 @@ _skip_mc0:
         } else {
             _tcscat(text, TEXT("---"));
         }
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
         Surface.SelectObject(LK_BLACK_PEN);
         if (ValidWayPoint(overindex) && WayPointList[overindex].Reachable) {
             Surface.SelectObject(LKBrush_LightGreen);
@@ -877,17 +877,10 @@ _skip_mc0:
             y -= tsize.cy / 2;
 
         #ifndef UNDITHER
-        MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, 0, WTALIGN_LEFT, RGB_BLACK, RGB_RED);
+        MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, WTALIGN_LEFT, RGB_BLACK, RGB_RED);
         #else
-        MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, 0, WTALIGN_LEFT, RGB_BLACK, RGB_RED);
+        MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, WTALIGN_LEFT, RGB_BLACK, RGB_RED);
         #endif
-        /*
-            y = CalcHeightCoordinat  ( SAFETYALTITUDEARRIVAL/10+wpt_altarriv_mc0,  &sDia)-2*tsize.cy;
-            // We don't know if there are obstacles for mc0
-
-            MapWindow::LKWriteBoxedText(hdc,&rc,text,  x, y, 0, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
-         */
-
 
         //
         // FINAL GLIDE MACCREADY
@@ -901,7 +894,7 @@ _skip_mc0:
       if (bDrawRightSide) {
           x = BestReach.x + NIBLSCALE(5);
       }
-      Surface.GetTextSize(text, _tcslen(text), &tsize);
+      Surface.GetTextSize(text, &tsize);
       int yn = BestReach.y;
       if(mc > MACCREADY) {
         if(yn > y + tsize.cy) {
@@ -917,7 +910,7 @@ _skip_mc0:
         }
       }
       Surface.SelectObject(LKBrush_Nlight);
-      MapWindow::LKWriteBoxedText(Surface, rc, text,  x, y, 0, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
+      MapWindow::LKWriteBoxedText(Surface, rc, text,  x, y, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
      }
   } else {
 
@@ -960,7 +953,7 @@ _skip_mc0:
 
             x = line[0].x - tsize.cx - NIBLSCALE(5);
             if (bDrawRightSide) x = line[0].x + NIBLSCALE(5);
-            Surface.GetTextSize(text, _tcslen(text), &tsize);
+            Surface.GetTextSize(text, &tsize);
             int yn = CalcHeightCoordinat(SAFETYALTITUDEARRIVAL / 10 + wpt_altitude, &sDia); //+0.5*tsize.cy;
             if (yn > y + tsize.cy)
                 y = yn;
@@ -974,7 +967,7 @@ _skip_mc0:
             Surface.SelectObject(LKBrush_White);
             #endif
 
-            MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, 0, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
+            MapWindow::LKWriteBoxedText(Surface, rc, text, x, y, WTALIGN_LEFT, RGB_BLACK, RGB_BLACK);
 
         }
   }
@@ -989,7 +982,7 @@ _after_additionals:
         if (altarriv > 0) {
             // Print GR
             _stprintf(text, TEXT("1/%i"), (int) fLD);
-            Surface.GetTextSize(text, _tcslen(text), &tsize);
+            Surface.GetTextSize(text, &tsize);
             x = CalcDistanceCoordinat(wpt_dist / 2, &sDia) - tsize.cx / 2;
             y = CalcHeightCoordinat((DerivedDrawInfo.NavAltitude + altarriv) / 2 + wpt_altitude, &sDia) + tsize.cy;
             if (WayPointList[overindex].Reachable) {
@@ -997,7 +990,7 @@ _after_additionals:
             } else {
                 SelectObject(hdc, LKBrush_Orange);
             }
-            MapWindow::LKWriteBoxedText(hdc, &rc, text, x, y, 0, WTALIGN_CENTER, RGB_BLACK, RGB_BLACK);
+            MapWindow::LKWriteBoxedText(hdc, &rc, text, x, y, WTALIGN_CENTER, RGB_BLACK, RGB_BLACK);
         }
 #endif
 
@@ -1011,11 +1004,11 @@ _after_additionals:
             Units::FormatUserAltitude(calc_altitudeagl, buffer, 7);
             LK_tcsncpy(text, MsgToken(1742), TBSIZE - _tcslen(buffer));
             _tcscat(text, buffer);
-            Surface.GetTextSize(text, _tcslen(text), &tsize);
+            Surface.GetTextSize(text, &tsize);
             x = CalcDistanceCoordinat(0, &sDia) - tsize.cx / 2;
             y = CalcHeightCoordinat((calc_terrainalt + calc_altitudeagl)*0.8, &sDia);
             if ((tsize.cy) < (CalcHeightCoordinat(calc_terrainalt, &sDia) - y)) {
-                Surface.DrawText(x, y, text, _tcslen(text));
+                Surface.DrawText(x, y, text);
             }
         }
         Surface.SetBackgroundTransparent();

--- a/Common/Source/Draw/Multimaps/RenderAirspaceTerrain.cpp
+++ b/Common/Source/Draw/Multimaps/RenderAirspaceTerrain.cpp
@@ -196,7 +196,7 @@ void RenderAirspaceTerrain(LKSurface& Surface, double PosLat, double PosLon, dou
         SIZE aispacesize = {rcd.right - rcd.left, rcd.bottom - rcd.top};
 
         LK_tcsncpy(text, Sideview_pHandeled[iSizeIdx].szAS_Name, NAME_SIZE - 1/* sizeof(text)/sizeof(text[0])*/);
-        Surface.GetTextSize(text, _tcslen(text), &textsize);
+        Surface.GetTextSize(text, &textsize);
 
         int x = rcd.left + aispacesize.cx / 2;
         ;
@@ -210,18 +210,18 @@ void RenderAirspaceTerrain(LKSurface& Surface, double PosLat, double PosLon, dou
 
 
         if ((textsize.cx < aispacesize.cx) && (textsize.cy < aispacesize.cy)) {
-            Surface.DrawText(x - textsize.cx / 2, y - iOffset - textsize.cy / 2, text, _tcslen(text));
+            Surface.DrawText(x - textsize.cx / 2, y - iOffset - textsize.cy / 2, text);
             blongtext = true;
         }
 
         LK_tcsncpy(text, CAirspaceManager::Instance().GetAirspaceTypeShortText(Sideview_pHandeled[iSizeIdx].iType), NAME_SIZE);
-        Surface.GetTextSize(text, _tcslen(text), &textsize);
+        Surface.GetTextSize(text, &textsize);
         if (textsize.cx < aispacesize.cx) {
             if (2 * textsize.cy < aispacesize.cy) {
-                Surface.DrawText(x - textsize.cx / 2, y + iOffset - textsize.cy / 2, text, _tcslen(text));
+                Surface.DrawText(x - textsize.cx / 2, y + iOffset - textsize.cy / 2, text);
             } else {
                 if ((textsize.cy < aispacesize.cy) && (!blongtext))
-                    Surface.DrawText(x - textsize.cx / 2, y - iOffset - textsize.cy / 2, text, _tcslen(text));
+                    Surface.DrawText(x - textsize.cx / 2, y - iOffset - textsize.cy / 2, text);
             }
         }
     }

--- a/Common/Source/Draw/Multimaps/RenderNearAirspace.cpp
+++ b/Common/Source/Draw/Multimaps/RenderNearAirspace.cpp
@@ -361,12 +361,12 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
         LK_tcsncpy(Sideview_szNearAS, near_airspace.Name(), TBSIZE);
     } else {
         _stprintf(text, TEXT("%s"), MsgToken(1259)); // LKTOKEN _@M1259_ "Too far, not calculated"
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
         TxYPt.x = (rc.right - rc.left - tsize.cx) / 2;
         TxYPt.y = (rc.bottom - rc.top) / 2;
 
         Surface.SetBackgroundTransparent();
-        Surface.DrawText(TxYPt.x, TxYPt.y - 20, text, _tcslen(text));
+        Surface.DrawText(TxYPt.x, TxYPt.y - 20, text);
 
         _stprintf(Sideview_szNearAS, TEXT("%s"), text);
 
@@ -449,11 +449,11 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
         Units::FormatUserAltitude(calc_altitudeagl, buffer, 7);
         LK_tcsncpy(text, MsgToken(1742), TBSIZE - _tcslen(buffer)); // AGL:
         _tcscat(text, buffer);
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
         TxYPt.x = CalcDistanceCoordinat(0, &sDia) - tsize.cx / 2;
         TxYPt.y = CalcHeightCoordinat((calc_terrainalt + calc_altitudeagl)*0.8, &sDia);
         if ((tsize.cy) < (CalcHeightCoordinat(calc_terrainalt, &sDia) - TxYPt.y)) {
-            Surface.DrawText(TxYPt.x + IBLSCALE(1), TxYPt.y, text, _tcslen(text));
+            Surface.DrawText(TxYPt.x + IBLSCALE(1), TxYPt.y, text);
         }
     }
 
@@ -468,11 +468,11 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
         Units::FormatUserAltitude(calc_terrainalt, buffer, 7);
         LK_tcsncpy(text, MsgToken(1743), TBSIZE - _tcslen(buffer)); // ELV:
         _tcscat(text, buffer);
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
         x = CalcDistanceCoordinat(0, &sDia) - tsize.cx / 2;
         y = CalcHeightCoordinat(calc_terrainalt, &sDia);
         if ((ELV_FACT * tsize.cy) < abs(rc.bottom - y)) {
-            Surface.DrawText(x, rc.bottom - (int) (ELV_FACT * tsize.cy), text, _tcslen(text));
+            Surface.DrawText(x, rc.bottom - (int) (ELV_FACT * tsize.cy), text);
         }
     }
 
@@ -533,7 +533,7 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
 
         Units::FormatUserDistance(iABS_AS_HorDistance, buffer, 7);
         _stprintf(text, _T(" %s"), buffer);
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
 
         if ((GPSalt - sDia.fYMin /*-calc_terrainalt */) < 300)
             TxXPt.y = CalcHeightCoordinat(GPSalt, &sDia) - tsize.cy;
@@ -545,7 +545,7 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
             TxXPt.x = CalcDistanceCoordinat(iABS_AS_HorDistance, &sDia) - tsize.cx - NIBLSCALE(3);
         else
             TxXPt.x = CalcDistanceCoordinat(iABS_AS_HorDistance / 2.0, &sDia) - tsize.cx / 2;
-        Surface.DrawText(TxXPt.x, TxXPt.y, text, _tcslen(text));
+        Surface.DrawText(TxXPt.x, TxXPt.y, text);
 
 
 
@@ -560,7 +560,7 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
         Surface.DrawDashLine(THICK_LINE, line[0], line[1], Sideview_TextColor, rc);
         Units::FormatUserAltitude((double) abs(iAS_VertDistance), buffer, 7);
         _stprintf(text, _T(" %s"), buffer);
-        Surface.GetTextSize(text, _tcslen(text), &tsize);
+        Surface.GetTextSize(text, &tsize);
 
         if (bLeft)
             TxYPt.x = CalcDistanceCoordinat(iABS_AS_HorDistance, &sDia) - tsize.cx - NIBLSCALE(3);
@@ -570,7 +570,7 @@ void MapWindow::RenderNearAirspace(LKSurface& Surface, const RECT& rci) {
             TxYPt.y = CalcHeightCoordinat(GPSalt - (double) iAS_VertDistance / 2.0, &sDia) - tsize.cy / 2;
         else
             TxYPt.y = min(line[0].y, line[1].y) - tsize.cy;
-        Surface.DrawText(TxYPt.x, TxYPt.y, text, _tcslen(text));
+        Surface.DrawText(TxYPt.x, TxYPt.y, text);
         Surface.SelectObject(hfOldU);
     }
 

--- a/Common/Source/Draw/Multimaps/Sideview.cpp
+++ b/Common/Source/Draw/Multimaps/Sideview.cpp
@@ -123,8 +123,8 @@ void DrawWindRoseDirection(LKSurface& Surface, double fAngle, int x, int y) {
     else
         Surface.SetTextColor(RGB_WHITE);
 
-    Surface.GetTextSize(text, _tcslen(text), &tsize);
-    Surface.DrawText(x - tsize.cx / 2, y - tsize.cy / 2, text, _tcslen(text));
+    Surface.GetTextSize(text, &tsize);
+    Surface.DrawText(x - tsize.cx / 2, y - tsize.cy / 2, text);
 
     return;
 }

--- a/Common/Source/Draw/TextInBox.cpp
+++ b/Common/Source/Draw/TextInBox.cpp
@@ -105,7 +105,7 @@ bool TextInBoxMoveInView(const RECT *clipRect, POINT *offset, RECT *brect){
 
 
 bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR* Value, int x, int y, 
-                          int size, TextInBoxMode_t *Mode, bool noOverlap) {
+                          TextInBoxMode_t *Mode, bool noOverlap) {
 
   SIZE tsize;
   RECT brect;
@@ -121,10 +121,6 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
 
   if (Mode == NULL) return false;
 
-  if (size==0) {
-    size = _tcslen(Value);
-  }
-  
   const auto hbOld = Surface.SelectObject(LKBrush_White);
   const auto hpOld = Surface.SelectObject(LK_BLACK_PEN);
 
@@ -146,7 +142,7 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
     }
   }
   
-  Surface.GetTextSize(Value, size, &tsize);
+  Surface.GetTextSize(Value, &tsize);
 
   if (Mode->AlligneRight){
     x -= tsize.cx;
@@ -192,7 +188,7 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
       Surface.RoundRect(brect, NIBLSCALE(4), NIBLSCALE(4));
       Surface.SelectObject(oldPen);
       if (Mode->SetTextColor) Surface.SetTextColor(Mode->Color); else Surface.SetTextColor(RGB_BLACK);
-      Surface.DrawText(x, y, Value, size);
+      Surface.DrawText(x, y, Value);
       drawn=true;
     }
 
@@ -222,7 +218,7 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
   
     if (!noOverlap || notoverlapping) {
       LKColor oldColor = Surface.SetBkColor(RGB_WHITE);
-      Surface.DrawText(x, y, Value, size);
+      Surface.DrawText(x, y, Value);
       Surface.SetBkColor(oldColor);
       drawn=true;
     }
@@ -280,16 +276,19 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
     // Simplified, shadowing better and faster
     // ETO_OPAQUE not necessary since we pass a NULL rect
     //
-    Surface.DrawText(x-1, y-1, Value, size);
-    Surface.DrawText(x-1, y+1, Value, size);
-    Surface.DrawText(x+1, y-1, Value, size);
-    Surface.DrawText(x+1, y+1, Value, size);
+#ifdef USE_FREETYPE
+#warning "to slow, rewrite using freetype outline"
+#endif
+    Surface.DrawText(x-1, y-1, Value);
+    Surface.DrawText(x-1, y+1, Value);
+    Surface.DrawText(x+1, y-1, Value);
+    Surface.DrawText(x+1, y+1, Value);
 
     if (OutlinedTp && 1) {
-        Surface.DrawText(x-2, y, Value, size);
-        Surface.DrawText(x+2, y, Value, size);
-        Surface.DrawText(x, y-2, Value, size);
-        Surface.DrawText(x, y+2, Value, size);
+        Surface.DrawText(x-2, y, Value);
+        Surface.DrawText(x+2, y, Value);
+        Surface.DrawText(x, y-2, Value);
+        Surface.DrawText(x, y+2, Value);
     }
 
       if (OutlinedTp) {
@@ -297,7 +296,7 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
       } else {
         Surface.SetTextColor(RGB_BLACK);
       }
-      Surface.DrawText(x, y, Value, size);
+      Surface.DrawText(x, y, Value);
 
       if (OutlinedTp)
         Surface.SetTextColor(RGB_BLACK); // TODO somewhere else text color is not set correctly
@@ -346,7 +345,7 @@ bool MapWindow::TextInBox(LKSurface& Surface, const RECT *clipRect,  const TCHAR
   
     if (!noOverlap || notoverlapping) {
       Surface.SetTextColor(Mode->Color);
-      Surface.DrawText(x, y, Value, size);
+      Surface.DrawText(x, y, Value);
       Surface.SetTextColor(RGB_BLACK);
       drawn=true;
     }

--- a/Common/Source/Fonts2.cpp
+++ b/Common/Source/Fonts2.cpp
@@ -654,13 +654,12 @@ void Init_Fonts_2(void)
   LKWindowSurface windowSurface;
   LKBitmapSurface tmpSurface;
   tmpSurface.Create(windowSurface, 1, 1);
-  SIZE TextSize = {0,0};
+
   const auto oldFont = tmpSurface.SelectObject(LK8BottomBarTitleFont);
-  tmpSurface.GetTextSize(_T("M"), 1, &TextSize);
-  int syTitle = TextSize.cy;
+  const int syTitle = tmpSurface.GetTextHeight(_T("M"));;
+
   tmpSurface.SelectObject(LK8BottomBarValueFont);
-  tmpSurface.GetTextSize(_T("5"), 1, &TextSize);
-  int syValue = TextSize.cy;
+  const int syValue = tmpSurface.GetTextHeight(_T("5"));;
 
   if (ScreenLandscape)
       BottomSize = syValue + syTitle;

--- a/Common/Source/LKMW3include_navbox1.cpp
+++ b/Common/Source/LKMW3include_navbox1.cpp
@@ -5,19 +5,19 @@
 
 
   Surface.SelectObject(LK8BottomBarValueFont);
-  Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+  Surface.GetTextSize(BufferValue, &TextSize);
   if (showunit==true)
-	LKWriteText(Surface, BufferValue, rcx, yRow1Value, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+	LKWriteText(Surface, BufferValue, rcx, yRow1Value, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
   else
         #ifdef UNDITHER
-	LKWriteText(Surface, BufferValue, rcx, yRow1Value, 0, WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE, false);
+	LKWriteText(Surface, BufferValue, rcx, yRow1Value, WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE, false);
 	#else
-	LKWriteText(Surface, BufferValue, rcx, yRow1Value, 0, WTMODE_NORMAL,WTALIGN_CENTER,RGB_AMBER, false);
+	LKWriteText(Surface, BufferValue, rcx, yRow1Value, WTMODE_NORMAL,WTALIGN_CENTER,RGB_AMBER, false);
 	#endif
 
   if (showunit==true && !HideUnits) {
 	Surface.SelectObject(LK8BottomBarUnitFont);
-	LKWriteText(Surface, BufferUnit, rcx+(TextSize.cx/2)+NIBLSCALE(1), yRow1Unit , 0, WTMODE_NORMAL, WTALIGN_LEFT,barTextColor, false);
+	LKWriteText(Surface, BufferUnit, rcx+(TextSize.cx/2)+NIBLSCALE(1), yRow1Unit , WTMODE_NORMAL, WTALIGN_LEFT,barTextColor, false);
   }
   Surface.SelectObject(LK8BottomBarTitleFont);
   rcy=yRow1Title;

--- a/Common/Source/LKMW3include_navbox2.cpp
+++ b/Common/Source/LKMW3include_navbox2.cpp
@@ -6,19 +6,19 @@
 
 
   Surface.SelectObject(LK8BottomBarValueFont);
-  Surface.GetTextSize(BufferValue, _tcslen(BufferValue), &TextSize);
+  Surface.GetTextSize(BufferValue, &TextSize);
   if (showunit==true)
-	LKWriteText(Surface, BufferValue, rcx, yRow2Value, 0, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
+	LKWriteText(Surface, BufferValue, rcx, yRow2Value, WTMODE_NORMAL,WTALIGN_CENTER,barTextColor, false);
   else
-        #ifdef UNDITHER
-	LKWriteText(Surface, BufferValue, rcx, yRow2Value, 0, WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE, false);
+    #ifdef UNDITHER
+	LKWriteText(Surface, BufferValue, rcx, yRow2Value, WTMODE_NORMAL,WTALIGN_CENTER,RGB_WHITE, false);
 	#else
-	LKWriteText(Surface, BufferValue, rcx, yRow2Value, 0, WTMODE_NORMAL,WTALIGN_CENTER,RGB_AMBER, false);
+	LKWriteText(Surface, BufferValue, rcx, yRow2Value, WTMODE_NORMAL,WTALIGN_CENTER,RGB_AMBER, false);
 	#endif
 
   if (showunit==true && !HideUnits) {
 	Surface.SelectObject(LK8BottomBarUnitFont);
-	LKWriteText(Surface, BufferUnit, rcx+(TextSize.cx/2)+NIBLSCALE(1), yRow2Unit , 0, WTMODE_NORMAL, WTALIGN_LEFT,barTextColor, false);
+	LKWriteText(Surface, BufferUnit, rcx+(TextSize.cx/2)+NIBLSCALE(1), yRow2Unit, WTMODE_NORMAL, WTALIGN_LEFT,barTextColor, false);
   }
 
   Surface.SelectObject(LK8BottomBarTitleFont);

--- a/Common/Source/Message.cpp
+++ b/Common/Source/Message.cpp
@@ -117,7 +117,7 @@ void Message::Resize() {
                                               ? LK8InfoBigFont
                                               : MapWindowBoldFont);
 
-    Surface.GetTextSize(msgText.c_str(), size, &tsize);
+    Surface.GetTextSize(msgText.c_str(), &tsize);
 
     Surface.SelectObject(oldfont); // 100215
 

--- a/Common/Source/Screen/LKSurface.h
+++ b/Common/Source/Screen/LKSurface.h
@@ -185,9 +185,9 @@ public:
 #ifdef USE_MEMORY_CANVAS
     void AlphaBlendNotWhite(const RECT& dstRect, const LKSurface& Surface, const RECT& srcRect, uint8_t globalOpacity);
 #endif    
-    bool GetTextSize(const TCHAR* lpString, int cbString, SIZE* lpSize);
-    void DrawText(int X, int Y, const TCHAR* lpString, UINT cbCount, RECT* ClipRect = nullptr);
-    int DrawText(const TCHAR* lpchText, int nCount, RECT *lpRect, UINT uFormat);
+    bool GetTextSize(const TCHAR* lpString, SIZE* lpSize);
+    void DrawText(int X, int Y, const TCHAR* lpString, RECT* ClipRect = nullptr);
+    int DrawText(const TCHAR* lpchText, RECT *lpRect, UINT uFormat);
 
     int GetTextWidth(const TCHAR *text);
     int GetTextHeight(const TCHAR *text);

--- a/Common/Source/Topology/Topology.cpp
+++ b/Common/Source/Topology/Topology.cpp
@@ -769,7 +769,7 @@ bool XShapeLabel::renderSpecial(LKSurface& Surface, int x, int y, const RECT& Cl
 
 	SIZE tsize;
 	RECT brect;
-	Surface.GetTextSize(label, size, &tsize);
+	Surface.GetTextSize(label, &tsize);
 
 	// shift label from center point of shape
 	x+= NIBLSCALE(2); 
@@ -795,7 +795,7 @@ bool XShapeLabel::renderSpecial(LKSurface& Surface, int x, int y, const RECT& Cl
 	Surface.SetTextColor(LKColor(0,50,50)); // PETROL too light at 66
         #endif
     
-	Surface.DrawText(x, y, label, size);
+	Surface.DrawText(x, y, label);
 	return true; // 101016
   }
   return false; // 101016

--- a/Common/Source/WindowControls.cpp
+++ b/Common/Source/WindowControls.cpp
@@ -1783,7 +1783,7 @@ void WndForm::Paint(LKSurface& Surface){
         
         Surface.FillRect(&rcLine, LKBrush_Green);
 
-        Surface.DrawText(mTitleRect.left+NIBLSCALE(2), mTitleRect.top, szCaption, nChar);
+        Surface.DrawText(mTitleRect.left+NIBLSCALE(2), mTitleRect.top, szCaption);
 
         Surface.SelectObject(oldFont);
     } 
@@ -1808,7 +1808,7 @@ void WndForm::SetCaption(const TCHAR *Value) {
         SIZE tsize = {0,0};
         LKWindowSurface Surface(*this);
         const auto oldFont = Surface.SelectObject(mhTitleFont);
-        Surface.GetTextSize(Value, nChar, &tsize);
+        Surface.GetTextSize(Value, &tsize);
         Surface.SelectObject(oldFont);
         
         mTitleRect.bottom = mTitleRect.top + tsize.cy;
@@ -2023,7 +2023,7 @@ void WndButton::Paint(LKSurface& Surface){
 
     if (mLastDrawTextHeight < 0){
 
-      Surface.DrawText(szCaption, nSize, &rc,
+      Surface.DrawText(szCaption, &rc,
           DT_CALCRECT
         | DT_EXPANDTABS
         | DT_CENTER
@@ -2042,7 +2042,7 @@ void WndButton::Paint(LKSurface& Surface){
 
     rc.top += ((GetHeight()-4-mLastDrawTextHeight)/2);
 
-    Surface.DrawText(szCaption, nSize, &rc,
+    Surface.DrawText(szCaption, &rc,
         DT_EXPANDTABS
       | DT_CENTER
       | DT_NOCLIP
@@ -2333,7 +2333,7 @@ void WndProperty::Paint(LKSurface& Surface){
 
   const TCHAR * szCaption = GetWndText();
   const size_t nSize = _tcslen(szCaption);
-  Surface.GetTextSize(szCaption, nSize, &tsize);
+  Surface.GetTextSize(szCaption, &tsize);
   if (nSize==0) {
       tsize.cy=0; //@ 101115 BUGFIX
   }
@@ -2350,7 +2350,7 @@ void WndProperty::Paint(LKSurface& Surface){
 	org.x = 1;
   }
 
-  Surface.DrawText(org.x, org.y, szCaption, nSize);
+  Surface.DrawText(org.x, org.y, szCaption);
 
   // these are button left and right icons for waypoint select, for example
   if (mDialogStyle) // can't but dlgComboPicker here b/c it calls paint when combopicker closes too
@@ -2373,22 +2373,10 @@ void WndProperty::Paint(LKSurface& Surface){
     RECT rcText = mEditRect;
     InflateRect(&rcText, -NIBLSCALE(3), -1);
     
-#ifndef USE_GDI
-    // SubCanvas is used for clipping.
-    SubCanvas ClipCanvas(Surface, rcText.GetOrigin(), rcText.GetSize() );
-    rcText.Offset(-rcText.left, -rcText.top);
-
-    ClipCanvas.Select(*mhValueFont);
-    ClipCanvas.SetTextColor(RGB_BLACK);
-    ClipCanvas.SetBackgroundTransparent();
-
-    ClipCanvas.DrawFormattedText(&rcText, mValue.c_str(), DT_EXPANDTABS|(mMultiLine?DT_WORDBREAK:DT_SINGLELINE|DT_VCENTER));
-#else
     Surface.SelectObject(mhValueFont);
     Surface.SetTextColor(RGB_BLACK);
 
-    Surface.DrawText(mValue.c_str(), mValue.size(), &rcText, DT_EXPANDTABS|(mMultiLine?DT_WORDBREAK:DT_SINGLELINE|DT_VCENTER));
-#endif
+    Surface.DrawText(mValue.c_str(), &rcText, DT_EXPANDTABS|(mMultiLine?DT_WORDBREAK:DT_SINGLELINE|DT_VCENTER));
 
     Surface.SelectObject(oldPen);
     Surface.SelectObject(oldBrush);
@@ -2475,7 +2463,7 @@ void WndFrame::Paint(LKSurface& Surface){
     RECT rc = GetClientRect();
     InflateRect(&rc, -2, -2); // todo border width
 
-    Surface.DrawText(szCaption, nSize, &rc,mCaptionStyle);
+    Surface.DrawText(szCaption,&rc,mCaptionStyle);
 
     mLastDrawTextHeight = rc.bottom - rc.top;
 

--- a/Common/Source/xcs/Screen/Memory/Canvas.cpp
+++ b/Common/Source/xcs/Screen/Memory/Canvas.cpp
@@ -290,7 +290,7 @@ Canvas::DrawClippedText(int x, int y, unsigned max_width, const TCHAR *text)
   const TCHAR *clipped_text = text;
   unsigned width = Canvas::CalcTextWidth(text);
   if (width > max_width) {
-    // that wrong, does not handle multibyte char.
+    #warning "that wrong, does not handle multibyte char."
     unsigned new_size;
     fixed target_percent = fixed(max_width) / fixed(width);
     new_size = fixed(StringLength(text)) * target_percent;


### PR DESCRIPTION
 - first: with utf8 we can't split string using pointer arithmetic, we need to use code point iterator for advance from begin to split character
 - second: freetype text text size calc & rendering are slow

so the only good way for do clipping is to use canvas clipping instead of string truncate and multiple GetTextSize() call.

in this commit :
 - char count parameters are removed from LKSuface::DrawText method, because it's useless and source of bug if count are less than string size.
 - All eext clipping are fixed using ClipRect instead of number of char ( done inside LKSurface::DrawText if ClipRect are provided ).