### PR TITLE
Frequncy parser fix

### DIFF
--- a/Common/Source/Dialogs/dlgAirspaceDetails.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceDetails.cpp
@@ -128,10 +128,19 @@ double  ExtractFrequency(TCHAR *text)
 	         {
 		       if((text[i+3] == '.') || (text[i+3] == ','))
 		       {
-		         kHz = _tcstol(&text[i+4], nullptr, 10);
-		         if(kHz > 0)
-		           while (kHz < 100)
-		    	     kHz *=10;
+		    	 kHz =0;
+		    	 if((i+4) < iTxtlen)
+			       if((text[i+4] >= '0') && (text[i+4] <= '9'))
+			    	   kHz += (text[i+4]-'0') * 100;
+
+		    	 if((i+5) < iTxtlen)
+			       if((text[i+5] >= '0') && (text[i+5] <= '9'))
+			    	   kHz += (text[i+5]-'0') * 10;
+
+		    	 if((i+6) < iTxtlen)
+			       if((text[i+6] >= '0') && (text[i+6] <= '9'))
+			    	   kHz += (text[i+6]-'0');
+
 		       }
 		       fFreq = (double) Mhz+ (double)kHz/1000.0f;
 		       return fFreq;


### PR DESCRIPTION
leding zeros in kHz was not converted correctly
e.g. 118.025 was converted to 118.250
now fixed with a more simple approach (simple char conversion).