### PR TITLE
Seperate optimizer fix

### DIFF
--- a/Common/Source/Dialogs/Analysis/Update.cpp
+++ b/Common/Source/Dialogs/Analysis/Update.cpp
@@ -252,7 +252,6 @@ void UpdateAnalysis(void){
       bool typeFAITriangle = false;
 
       CContestMgr::CResult result = CContestMgr::Instance().Result(contestType, false);
-unsigned int iTmpMainMapOptMode = FAI_OptimizerMode; /* save optimizer mode of main map */
       switch (contestType) /* temporary change optimizer mode for analyzer calculations */
       {
         case CContestMgr::TYPE_FAI_TRIANGLE:  typeFAITriangle = true; FAI_OptimizerMode =3; break;
@@ -280,7 +279,7 @@ unsigned int iTmpMainMapOptMode = FAI_OptimizerMode; /* save optimizer mode of m
     // 	LKASSERT( fDist >0 );
         if(fDist < 10.0)
           fDist= 1000.0;
-        FAI_OptimizerMode = iTmpMainMapOptMode;  /* restore optimizer mode for main map */
+
 
         TCHAR distStr[50];  TCHAR speedStr[50];
         if(typeFAITriangle && bFAI)

--- a/Common/Source/Dialogs/Analysis/dlgStatistics.cpp
+++ b/Common/Source/Dialogs/Analysis/dlgStatistics.cpp
@@ -302,6 +302,7 @@ static bool entered = false;
 if (entered == true) /* prevent re entrance */
 	return;
 
+unsigned int iTmpMainMapOptMode = FAI_OptimizerMode ; /* remember optimizer mode of main map */
   wfa=NULL;
   waGrid=NULL;
   waInfo=NULL;
@@ -397,8 +398,15 @@ if (entered == true) /* prevent re entrance */
 
   penThinSignal.Release();
 
+  if(FAI_OptimizerMode != iTmpMainMapOptMode) /* Analysis let in a different optimizer mode */
+  {
+    FAI_OptimizerMode = iTmpMainMapOptMode; /* restore optimizer mode for main map */
+	CContestMgr::Instance().Result(CContestMgr::TYPE_FAI_TRIANGLE, false); /* recalc optimizer for main map */
+	CContestMgr::Instance().RefreshFAIOptimizer();
+  }
 
   MapWindow::RequestFastRefresh();
+
   FullScreen();
 
   entered = false;


### PR DESCRIPTION
much better (resource friendly) way to seperate the Analysis page optimizer from main map optimizer.
Now MainMap Optimizer stored when opening Analysis Dialog
Restoreing and recalculating on close dialog and only if it is different