### PR TITLE
fix #805

### DIFF
--- a/Common/Source/Message.cpp
+++ b/Common/Source/Message.cpp
@@ -17,9 +17,14 @@ public:
     WndMessage() : WndTextEdit() { }
     
 protected:
+    virtual bool OnLButtonDown(const POINT& Pos) {
+        // requiered otherwise on Win32 this windows capture all event and never release.
+        return true;
+    }
+
     virtual bool OnLButtonUp(const POINT& Pos) {
         Message::Acknowledge(0);
-        return false;
+        return true;
     }
 };
 


### PR DESCRIPTION
…urn true, otherwise EDIT ctrl continue to capture all events even if is hidden. (WIN32 only)

previous fix are wrong : don"t work on Linux Target.

fix #805