### PR TITLE
limit for runway directions

### DIFF
--- a/Common/Source/Waypoints/ParseCUP.cpp
+++ b/Common/Source/Waypoints/ParseCUP.cpp
@@ -215,7 +215,7 @@ bool ParseCUPWayPointString(TCHAR *String,WAYPOINT *Temp)
   if ((_tcslen(pToken) == 1) && (pToken[0]==DUMCHAR))
 	Temp->RunwayDir=-1;
   else
-	Temp->RunwayDir = (int)_tcstol(pToken, NULL, 10);
+	Temp->RunwayDir = (int)AngleLimit360(_tcstol(pToken, NULL, 10));
   #ifdef CUPDEBUG
   StartupStore(_T("   CUP RUNWAY DIRECTION=<%d>%s"),Temp->RunwayDir,NEWLINE);
   #endif


### PR DESCRIPTION
Don't know why but some airfields in CUP Files of openflightmaps
have negative runway directions. LK does not handle tha correctly and may cause critical bugs. So I use AngleLimit just to be save.