### PR TITLE
fix kobo.mk for compatibility with make 3.81

### DIFF
--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -58,7 +58,7 @@ KOBO_KERNEL = \
  $(patsubst kobo/kernel/%, LK8000/kobo/%, $(KOBO_KERNEL_SOURCES))
 
 
-define build-kobofs = 
+define build-kobofs
 $(Q)rm -rf $(BIN)/$(1)/KoboRoot
 
 $(Q)install -m 0755 -d  $(BIN)/$(1)/KoboRoot/drivers	


### PR DESCRIPTION
in make doc, we can read
"You may omit the variable assignment operator if you prefer. If omitted, make assumes it to be ‘=’ and creates a recursively-expanded variable"

but with make 3.81 (debian Wheezy) that wrong.