### PR TITLE
New infoboxes

### DIFF
--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -1504,6 +1504,16 @@ A positive value indicates a HEAD WIND, and a negative value indicates a TAIL WI
 If true airspeed is not available, estimated TAS is used. 
 In this case the value is only guessed against the current wind set.
 
+@933
+[Maximum efficiency speed to fly]
+This is the speed to fly for maximizing distance in the current wind and netto vario conditions.
+This is not MacCready STF (neither MC=0) that on the contrary tend to minimize task time and does not depend on current head wind conditions (except that on final glide). 
+Use this speed if you want to maximize efficiency and glide distance
+
+@934
+[Target Req. Efficicency]
+Required efficiency to the current target
+
 #
 # END INFOBOXES 800 - 1199
 #

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -2198,5 +2198,8 @@ _@M2309_  "RADIO"
 _@M2310_  "Vol"
 _@M2311_  "Sqw"
 
+# New infoboxes
 _@M2312_ "Speed of maximum efficiency"
 _@M2313_ "SpMe"
+_@M2314_ "Target Req. Efficicency"
+_@M2315_ "E.Tar"

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -2197,3 +2197,6 @@ _@M2308_  "Frequency"
 _@M2309_  "RADIO"
 _@M2310_  "Vol"
 _@M2311_  "Sqw"
+
+_@M2312_ "Speed of maximum efficiency"
+_@M2313_ "SpMe"

--- a/Common/Header/Calculations.h
+++ b/Common/Header/Calculations.h
@@ -157,6 +157,9 @@ typedef struct _DERIVED_INFO
   // optimum speed to fly instantaneously
   double VOpt; 
 
+  // Maximum efficiency speed to fly
+  double Vme;
+
   // JMW estimated track bearing at next time step
   double NextTrackBearing;
 

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -674,6 +674,8 @@
 #define LK_ALTERN1_DISTNM		131
 #define LK_ALTERN2_DISTNM		132
 
+#define LK_SPEED_ME     133		// Maximum efficiency speed to fly
+
 // The following values are not available for custom configuration
 
 #define LK_WIND			141		//

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -675,6 +675,7 @@
 #define LK_ALTERN2_DISTNM		132
 
 #define LK_SPEED_ME     133		// Maximum efficiency speed to fly
+#define LK_TARGET_RE     134		// Target Req. Efficicency
 
 // The following values are not available for custom configuration
 

--- a/Common/Source/Calc/SpeedToFly.cpp
+++ b/Common/Source/Calc/SpeedToFly.cpp
@@ -51,8 +51,6 @@ void SpeedToFly(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
     Calculated->Vme = LowPassFilter(Calculated->Vme, Vme, 0.6);
 
     HeadWind = 0;
-
-    HeadWind = 0;
     if (Calculated->FinalGlide && ValidTaskPoint(ActiveTaskPoint)) {
         // according to MC theory STF take account of wind only if on final Glide
         // TODO : for the future add config parameter for always use wind.

--- a/Common/Source/Calc/SpeedToFly.cpp
+++ b/Common/Source/Calc/SpeedToFly.cpp
@@ -40,7 +40,19 @@ void SpeedToFly(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
         }
     }
 
+    double netto; if (Basic->NettoVarioAvailable) netto=Basic->NettoVario; else netto=Calculated->NettoVario;
+
+    // calculate maximum efficiency speed to fly
     double HeadWind = 0;
+    if ( Calculated->HeadWind != -999 ) {
+        HeadWind = Calculated->HeadWind;
+    }
+    double Vme = GlidePolar::STF(0, netto, HeadWind);
+    Calculated->Vme = LowPassFilter(Calculated->Vme, Vme, 0.6);
+
+    HeadWind = 0;
+
+    HeadWind = 0;
     if (Calculated->FinalGlide && ValidTaskPoint(ActiveTaskPoint)) {
         // according to MC theory STF take account of wind only if on final Glide
         // TODO : for the future add config parameter for always use wind.
@@ -49,7 +61,6 @@ void SpeedToFly(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
         }
     }
 
-    double netto; if (Basic->NettoVarioAvailable) netto=Basic->NettoVario; else netto=Calculated->NettoVario;
 
     // this is IAS for best Ground Glide ratio acounting current air mass ( wind / Netto vario )
     double VOptnew = GlidePolar::STF(MACCREADY, netto, HeadWind);

--- a/Common/Source/DataOptions.cpp
+++ b/Common/Source/DataOptions.cpp
@@ -302,9 +302,10 @@ void FillDataOptions()
 	SetDataOption(130, ugNone, TEXT("_@M1287_"), TEXT("HDG")); // Heading, text is changed in lkprocess
 	SetDataOption(131, ugDistance, TEXT("_@M1843_"), TEXT("Atn1 nm")); // Alternate1 distance NMiles
 	SetDataOption(132, ugDistance, TEXT("_@M1844_"), TEXT("Atn2 nm")); // Alternate2 distance NMiles
+	SetDataOption(133, ugHorizontalSpeed,TEXT("_@M2312_"), TEXT("_@M2313_")); // Speed of maximum efficiency
 
 	//Before adding new items, consider changing NUMDATAOPTIONS_MAX
-    static_assert(132 < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
+    static_assert(133 < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
 
     
     // Fill all null string pointer with empty string, avoid to check all time is used.

--- a/Common/Source/DataOptions.cpp
+++ b/Common/Source/DataOptions.cpp
@@ -303,9 +303,11 @@ void FillDataOptions()
 	SetDataOption(131, ugDistance, TEXT("_@M1843_"), TEXT("Atn1 nm")); // Alternate1 distance NMiles
 	SetDataOption(132, ugDistance, TEXT("_@M1844_"), TEXT("Atn2 nm")); // Alternate2 distance NMiles
 	SetDataOption(133, ugHorizontalSpeed,TEXT("_@M2312_"), TEXT("_@M2313_")); // Speed of maximum efficiency
+	SetDataOption(134, ugNone,TEXT("_@M2314_"), TEXT("_@M2315_"));  // Target Req. Efficicency
+
 
 	//Before adding new items, consider changing NUMDATAOPTIONS_MAX
-    static_assert(133 < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
+    static_assert(134 < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
 
     
     // Fill all null string pointer with empty string, avoid to check all time is used.

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -870,6 +870,15 @@ goto_bearing:
 			_stprintf(BufferUnit, TEXT("%s"),(Units::GetHorizontalSpeedName()));
 			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
 			break;
+
+		// Speed of maximum efficiency
+		case LK_SPEED_ME:
+			value=SPEEDMODIFY*DerivedDrawInfo.Vme;
+			if (value<0||value>999) value=0; else valid=true;
+			_stprintf(BufferValue, TEXT("%d"),(int)value);
+			_stprintf(BufferUnit, TEXT("%s"),(Units::GetHorizontalSpeedName()));
+			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
+			break;
 				
 		// B44
 		case LK_NETTO:

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -879,7 +879,44 @@ goto_bearing:
 			_stprintf(BufferUnit, TEXT("%s"),(Units::GetHorizontalSpeedName()));
 			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
 			break;
-				
+
+		case LK_TARGET_RE: // Target Req. Efficicency
+			switch (OvertargetMode) {
+				case OVT_TASK:
+					LKFormatValue(LK_NEXT_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_TASKCENTER:
+					LKFormatValue(LK_NEXT_CENTER_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_BALT:
+					LKFormatValue(LK_BESTALTERN_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_ALT1:
+					LKFormatValue(LK_ALTERN1_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_ALT2:
+					LKFormatValue(LK_ALTERN2_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_HOME:
+					LKFormatGR(HomeWaypoint, false, BufferValue, BufferUnit);
+					break;
+				case OVT_THER:
+					LKFormatGR(RESWP_LASTTHERMAL, true, BufferValue, BufferUnit);
+					break;
+				case OVT_MATE:
+					LKFormatGR(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
+					break;
+				case OVT_FLARM:
+					LKFormatGR(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
+					break;
+				default:
+					LKFormatValue(LK_NEXT_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+			}
+			_stprintf(BufferTitle, TEXT("E.Tar"));
+			break;
+
+
 		// B44
 		case LK_NETTO:
 			value=LIFTMODIFY*DerivedDrawInfo.NettoVario;

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -871,51 +871,6 @@ goto_bearing:
 			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
 			break;
 
-		// Speed of maximum efficiency
-		case LK_SPEED_ME:
-			value=SPEEDMODIFY*DerivedDrawInfo.Vme;
-			if (value<0||value>999) value=0; else valid=true;
-			_stprintf(BufferValue, TEXT("%d"),(int)value);
-			_stprintf(BufferUnit, TEXT("%s"),(Units::GetHorizontalSpeedName()));
-			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
-			break;
-
-		case LK_TARGET_RE: // Target Req. Efficicency
-			switch (OvertargetMode) {
-				case OVT_TASK:
-					LKFormatValue(LK_NEXT_GR, false, BufferValue, BufferUnit, BufferTitle);
-					break;
-				case OVT_TASKCENTER:
-					LKFormatValue(LK_NEXT_CENTER_GR, false, BufferValue, BufferUnit, BufferTitle);
-					break;
-				case OVT_BALT:
-					LKFormatValue(LK_BESTALTERN_GR, false, BufferValue, BufferUnit, BufferTitle);
-					break;
-				case OVT_ALT1:
-					LKFormatValue(LK_ALTERN1_GR, false, BufferValue, BufferUnit, BufferTitle);
-					break;
-				case OVT_ALT2:
-					LKFormatValue(LK_ALTERN2_GR, false, BufferValue, BufferUnit, BufferTitle);
-					break;
-				case OVT_HOME:
-					LKFormatGR(HomeWaypoint, false, BufferValue, BufferUnit);
-					break;
-				case OVT_THER:
-					LKFormatGR(RESWP_LASTTHERMAL, true, BufferValue, BufferUnit);
-					break;
-				case OVT_MATE:
-					LKFormatGR(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
-					break;
-				case OVT_FLARM:
-					LKFormatGR(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
-					break;
-				default:
-					LKFormatValue(LK_NEXT_GR, false, BufferValue, BufferUnit, BufferTitle);
-					break;
-			}
-			_stprintf(BufferTitle, TEXT("E.Tar"));
-			break;
-
 
 		// B44
 		case LK_NETTO:
@@ -2463,6 +2418,51 @@ olc_score:
 			_stprintf(BufferUnit, TEXT("nm"));
 			break;
 
+		// B133 Speed of maximum efficiency
+		case LK_SPEED_ME:
+			value=SPEEDMODIFY*DerivedDrawInfo.Vme;
+			if (value<0||value>999) value=0; else valid=true;
+			_stprintf(BufferValue, TEXT("%d"),(int)value);
+			_stprintf(BufferUnit, TEXT("%s"),(Units::GetHorizontalSpeedName()));
+			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
+			break;
+
+		// B134 Target Req. Efficicency
+		case LK_TARGET_RE: // Target Req. Efficicency
+			switch (OvertargetMode) {
+				case OVT_TASK:
+					LKFormatValue(LK_NEXT_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_TASKCENTER:
+					LKFormatValue(LK_NEXT_CENTER_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_BALT:
+					LKFormatValue(LK_BESTALTERN_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_ALT1:
+					LKFormatValue(LK_ALTERN1_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_ALT2:
+					LKFormatValue(LK_ALTERN2_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+				case OVT_HOME:
+					LKFormatGR(HomeWaypoint, false, BufferValue, BufferUnit);
+					break;
+				case OVT_THER:
+					LKFormatGR(RESWP_LASTTHERMAL, true, BufferValue, BufferUnit);
+					break;
+				case OVT_MATE:
+					LKFormatGR(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
+					break;
+				case OVT_FLARM:
+					LKFormatGR(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
+					break;
+				default:
+					LKFormatValue(LK_NEXT_GR, false, BufferValue, BufferUnit, BufferTitle);
+					break;
+			}
+			_stprintf(BufferTitle, TEXT("E.Tar"));
+			break;
 
 		// B141
 		case LK_WIND:


### PR DESCRIPTION
As discussed in the forum I have added 2 new infoboxes.

1)	[Maximum efficiency speed to fly] 
This is the speed to fly for maximizing distance in the current wind and netto vario conditions.
This is not MacCready STF (neither MC=0) that on the contrary tend to minimize task time and does not depend on current head wind conditions (except that on final glide). 

Maybe a border line information but anyway an important parameter in the STF theory.

2)	[Target Req. Efficicency]
Required efficiency to the current target

This is necessary to fix a problem in the HG/PG mode where there is no way, at the moment, to have this information neither on the overlay nor in the bottom bar.

In my local repo I also have some other  infoboxes suggested by Bruno ( Target Distance .. ) but they are not really necessary  as that information are on the default overlay content. Let me know if you prefer me to commit also this.

Regards
Tony
