### PR TITLE
Sound table

### DIFF
--- a/Common/Source/Sound/ExtDev/sound_table.cpp
+++ b/Common/Source/Sound/ExtDev/sound_table.cpp
@@ -31,11 +31,20 @@ bool sound_table::init() {
     TCHAR srcfile[MAX_PATH] = {};
      _stprintf(srcfile,_T("%s" LKD_CONF DIRSEP LKSOUNDTABLE),LKGetLocalPath());
     
-    FILE *fp;
-    if ( (fp=_tfopen(srcfile, _T("rt"))) == NULL ) {
-        StartupStore(_T("...Cannot load conversion sound table file for external sound : %s" ) NEWLINE ,srcfile);
-        return false;
-    }
+     FILE *fp;
+	 if ( (fp=_tfopen(srcfile, _T("rt"))) == NULL ) {
+		 StartupStore(_T("...Loading default Sound Table : %s" ), NEWLINE );
+		 for (int i=DEFAULT;i<last;i++) {
+			 TCHAR str[200]; // Nmea string can have max (200 - soundCodeSize - 1)
+			 str[array_size(str)-1] = _T('\0');  // added make sure the string is terminated
+			 _stprintf(str,"LKALARM,%d", i);
+			 set((sound_code_t)i,str);
+			 StartupStore(_T("..SOUND %d %s: %s" ), i,str,NEWLINE );
+		 }
+		 return true;
+	 }
+
+
 
     TCHAR str[200]; // Nmea string can have max (200 - soundCodeSize - 1) 
     str[array_size(str)-1] = _T('\0');  // added make sure the string is terminated

--- a/Common/Source/Sound/ExtDev/sound_table.cpp
+++ b/Common/Source/Sound/ExtDev/sound_table.cpp
@@ -39,7 +39,6 @@ bool sound_table::init() {
 			 str[array_size(str)-1] = _T('\0');  // added make sure the string is terminated
 			 _stprintf(str,"LKALARM,%d", i);
 			 set((sound_code_t)i,str);
-			 StartupStore(_T("..SOUND %d %s: %s" ), i,str,NEWLINE );
 		 }
 		 return true;
 	 }


### PR DESCRIPTION
Added a default behaviour for the output sound messages sent to the serial port of Kobo.
If SOUND_TABLE.TXT is not found on the _Configuration folder sound messages will be sent as :
$LKALARM,SOUND_CODE_ID
Where SOUND_CODE_ID is the one defined in sound_table.h ( typedef enum sound_code )
If SOUND_TABLE.TXT is found the custom messages in that file  will be used.