### PR TITLE
Becker AR620x driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1056,6 +1056,7 @@ DEVS	:=\
 	$(DEV)/devLXNano3.cpp \
 	$(DEV)/devXCTracer.cpp \
 	$(DEV)/devGPSBip.cpp \
+	$(DEV)/devAR620x.cpp \
 
 VOLKS	:=\
 	$(DEV)/Volkslogger/dbbconv.cpp \


### PR DESCRIPTION
added Driver for Becker AR620x radio devices (connect via RS422)
