### PR TITLE
update Task info when panning Task Point

### DIFF
--- a/Common/Data/Language/DEFAULT_MENU.TXT
+++ b/Common/Data/Language/DEFAULT_MENU.TXT
@@ -232,7 +232,7 @@ type=key
 data=APP1
 event=MarkLocation pan
 label=_@M2070_
-location=1
+location=11
 
 mode=pan
 type=key

--- a/Common/Source/Draw/DrawMapScale.cpp
+++ b/Common/Source/Draw/DrawMapScale.cpp
@@ -127,7 +127,7 @@ void MapWindow::DrawMapScale(LKSurface& Surface, const RECT& rc /* the Map Rect*
 
     DistanceBearing(DrawInfo.Latitude,DrawInfo.Longitude,GetPanLatitude(),GetPanLongitude(),&pandistance,&panbearing);
     if(ValidTaskPoint(PanTaskEdit))
-    {
+    {  RefreshTask();
         double Dist = DerivedDrawInfo.TaskTotalDistance;
     	if( DerivedDrawInfo.TaskFAI)
     	{

--- a/Common/Source/Draw/DrawMapScale.cpp
+++ b/Common/Source/Draw/DrawMapScale.cpp
@@ -132,10 +132,10 @@ void MapWindow::DrawMapScale(LKSurface& Surface, const RECT& rc /* the Map Rect*
     	if( DerivedDrawInfo.TaskFAI)
     	{
     	  Dist = DerivedDrawInfo.TaskFAIDistance;
-          _stprintf(Scale2, _T("FAI Task %.1f%s %.1f%s %s %.0f%s"),  Dist*DISTANCEMODIFY, Units::GetDistanceName(),pandistance*DISTANCEMODIFY,Units::GetDistanceName(), Scale1 ,panbearing,MsgToken(2179) );
+          _stprintf(Scale2, _T("FAI Task %.1f%s %s %.0f%s"),  Dist*DISTANCEMODIFY, Units::GetDistanceName(), Scale1 ,panbearing,MsgToken(2179) );
     	}
         else
-    	  _stprintf(Scale2, _T("     Task %.1f%s %.1f%s %s %.0f%s"),  Dist*DISTANCEMODIFY, Units::GetDistanceName(),pandistance*DISTANCEMODIFY, Units::GetDistanceName(), Scale1 ,panbearing,MsgToken(2179) );
+    	  _stprintf(Scale2, _T("     Task %.1f%s %s %.0f%s"),  Dist*DISTANCEMODIFY, Units::GetDistanceName(), Scale1 ,panbearing,MsgToken(2179) );
     }
     else
     {


### PR DESCRIPTION
while moving a task point in PAN the task distance must be updated for graphical task editor. 
Did no more work as it use to. Why?