### PR TITLE
permanent FT24 tracker,

### DIFF
--- a/Common/Source/LiveTracker.cpp
+++ b/Common/Source/LiveTracker.cpp
@@ -348,7 +348,7 @@ void LiveTrackerUpdate(const NMEA_INFO& Basic, const DERIVED_INFO& Calculated) {
 	t_of_day = mkgmtime(&t);
 
 	newpoint.unix_timestamp = t_of_day;
-	newpoint.flying = Calculated.Flying;
+	newpoint.flying = true; //Calculated.Flying;
 	newpoint.latitude = Basic.Latitude;
 	newpoint.longitude = Basic.Longitude;
 	newpoint.alt = Calculated.NavAltitude;


### PR DESCRIPTION
the tracker started after takeoff detection only.
This makes testing for users almost impossible. This patch enables flight tracking as soon as LK starts.