### PR TITLE
better FAI grid scale in Analysis dialog

### DIFF
--- a/Common/Source/Dialogs/Analysis/RenderContest.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderContest.cpp
@@ -191,7 +191,7 @@ void Statistics::RenderFAIOptimizer(LKSurface& Surface, const RECT& rc)
 {
 
 unsigned int ui;
-double fXY_Scale = 2.5;
+double fXY_Scale = 2.6;
 double lat0 = 0;
 double lon0 = 0;
 double lat1 = 0;
@@ -209,21 +209,7 @@ double fTotalPercent = 1.0;
 #endif
 
 ResetScale();
-static FAI_Sector ContestFAISector[6];
-
-double fZoom=50;
-if(Statistics::yscale >0)
-  fZoom =  2500.0/Statistics::yscale;
-double         fTic = 10;
-  if(fZoom > 5)  fTic = 10;
-  if(fZoom > 10) fTic = 25;
-  if(fZoom > 25) fTic = 50;
-  if(fZoom > 30) fTic = 100;
-#ifdef FAI_GRID_DEBUG
-  StartupStore(_T("RenderContest Statistics::yscale:%f  fZoom:%f  fTic:%f %s"), Statistics::yscale,fZoom, fTic, NEWLINE);
-#endif
-  if( DISTANCEMODIFY > 0.0)
-	fTic =fTic/ DISTANCEMODIFY;
+static FAI_Sector ContestFAISector[10];
 
 
   CContestMgr::CResult result = CContestMgr::Instance().Result( CContestMgr::TYPE_FAI_TRIANGLE, true);
@@ -318,8 +304,19 @@ double         fTic = 10;
                       break;
                   }
                   #endif
-            if(ui < 3)
+            if(ui < 5)
             {
+
+            double fTic,fDist_c, fAngle ;
+            DistanceBearing(lat1, lon1, lat2, lon2, &fDist_c, &fAngle);
+			fTic= 10/DISTANCEMODIFY;
+			if(fDist_c > 5/DISTANCEMODIFY)   fTic = 20/DISTANCEMODIFY;
+			if(fDist_c > 50/DISTANCEMODIFY)  fTic = 50/DISTANCEMODIFY;
+			if(fDist_c > 100/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
+			//  if(fDist_c > 200/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
+			if(fDist_c > 500/DISTANCEMODIFY) fTic = 250/DISTANCEMODIFY;
+
+
 			ContestFAISector[2*ui].CalcSectorCache(lat1,  lon1,  lat2,  lon2, fTic, 1);
 			ContestFAISector[2*ui].AnalysisDrawFAISector ( Surface, rc,  GeoPoint(lat_c,lon_c) , rgbCol) ;
 			ContestFAISector[2*ui+1].CalcSectorCache(lat1,  lon1,  lat2,  lon2, fTic, 0);

--- a/Common/Source/Dialogs/Analysis/RenderTask.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderTask.cpp
@@ -183,18 +183,6 @@ static  FAI_Sector TaskFAISector[2*MAXTASKPOINTS];
       }
     }
 
-    double fZoom = 100.0f;
-    if(Statistics::yscale >0)
-      fZoom =  2500.0/Statistics::yscale;
-    double         fTic = 100;
-    if(fZoom > 30) fTic = 100;
-    if(fZoom > 15) fTic = 50;
-    if(fZoom > 10) fTic = 25;
-    if(fZoom > 3)  fTic = 10;
-    if(fZoom > 1)  fTic = 5;
-    else           fTic = 1;
-    if( DISTANCEMODIFY > 0.0)
-      fTic = 10* fTic/ DISTANCEMODIFY;
 #ifdef FAI_GRID_DEBUG
     StartupStore(_T("RenderContest yscale:%f  fZoom:%f  fTic:%f DISTANCEMODIFY:%f %s"), yscale,fZoom, fTic, DISTANCEMODIFY, NEWLINE);
 #endif
@@ -223,6 +211,17 @@ static  FAI_Sector TaskFAISector[2*MAXTASKPOINTS];
 	//	DrawLine(hdc, rc, x1, y1, x2, y2, STYLE_DASHGREEN);
 		if( ValidTaskPoint(4) && i <2)
 			goto skip_FAI;
+
+            double fTic,fDist_c, fAngle ;
+            DistanceBearing(lat1, lon1, lat2, lon2, &fDist_c, &fAngle);
+			fTic= 1/DISTANCEMODIFY;
+			if(fDist_c > 5/DISTANCEMODIFY)   fTic = 10/DISTANCEMODIFY;
+			if(fDist_c > 50/DISTANCEMODIFY)  fTic = 25/DISTANCEMODIFY;
+			if(fDist_c > 100/DISTANCEMODIFY) fTic = 50/DISTANCEMODIFY;
+			//  if(fDist_c > 200/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
+			if(fDist_c > 500/DISTANCEMODIFY) fTic = 250/DISTANCEMODIFY;
+
+
 #ifndef DITHER
 	    TaskFAISector[2*i].CalcSectorCache(lat1,  lon1,  lat2,  lon2, fTic, 1);
 	    TaskFAISector[2*i].AnalysisDrawFAISector ( Surface, rc,  GeoPoint(lat_c,lon_c) , RGB_LIGHTYELLOW) ;
@@ -246,6 +245,15 @@ static  FAI_Sector TaskFAISector[2*MAXTASKPOINTS];
 	  lon1 = WayPointList[Task[3].Index].Longitude;
 	  lat2 = WayPointList[Task[1].Index].Latitude;
 	  lon2 = WayPointList[Task[1].Index].Longitude;
+            double fTic,fDist_c, fAngle ;
+            DistanceBearing(lat1, lon1, lat2, lon2, &fDist_c, &fAngle);
+			fTic= 1/DISTANCEMODIFY;
+			if(fDist_c > 5/DISTANCEMODIFY)   fTic = 10/DISTANCEMODIFY;
+			if(fDist_c > 50/DISTANCEMODIFY)  fTic = 25/DISTANCEMODIFY;
+			if(fDist_c > 100/DISTANCEMODIFY) fTic = 50/DISTANCEMODIFY;
+			//  if(fDist_c > 200/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
+			if(fDist_c > 500/DISTANCEMODIFY) fTic = 250/DISTANCEMODIFY;
+
 
 // RenderFAISector ( Surface, rc, lat1, lon1, lat2, lon2, lat_c, lon_c,1, RGB_LIGHTGREY );
 // RenderFAISector ( Surface, rc, lat1, lon1, lat2, lon2, lat_c, lon_c,0, RGB_GREY   );


### PR DESCRIPTION
with the cached FAI sectors the grid scale was based on the zoom level (which is good for main map). For Analysis it is better to have each sector different 8as it was before).