### PR TITLE
FIX: Airspace parse error

### DIFF
--- a/Common/Source/Library/StringFunctions.cpp
+++ b/Common/Source/Library/StringFunctions.cpp
@@ -127,7 +127,9 @@ BOOL ReadString(ZZIP_FILE *zFile, int Max, TCHAR *String, charset& cs)
     if(c == '\n'){
       break;
     }
-
+    if(c == '\r'){
+      break;
+    }
     sTmp[i] = c;
     i++;
   }


### PR DESCRIPTION
In some open aispace files, not every line ends with CR+LF or LF, for example the dutch as can be found here:
https://www.dropbox.com/s/713g4uehyu8il9o/EHv17_3.txt?dl=0

these CR only lines cause parse errors!!!
This fix ends string reading on CR or LF which prevents this parse erros.