### PR TITLE
Glider sector airspace

### DIFF
--- a/Common/Distribution/LK8000/_System/CREDITS.TXT
+++ b/Common/Distribution/LK8000/_System/CREDITS.TXT
@@ -3,6 +3,7 @@
 [Latest software changes]
 In summary what's up in current branch:
 
+Airspace Class Glider Sector "GldSec" added (GSEC open airspace, GLIDING OpenAIP)
 Up to 6 devices can now be set in Device configuration
 New Aircraft symbols in Aircraft configuration, choose the best for you!
 New tracking mode in Pilot configuration

--- a/Common/Header/Airspace.h
+++ b/Common/Header/Airspace.h
@@ -22,7 +22,8 @@
 #define CLASSG                          14
 #define CLASSTMZ                        15
 #define CLASSRMZ                        16
-#define AIRSPACECLASSCOUNT              17
+#define GLIDERSECT                      17
+#define AIRSPACECLASSCOUNT              18
 
 #define ALLON 0
 #define CLIP 1

--- a/Common/Header/LKProfiles.h
+++ b/Common/Header/LKProfiles.h
@@ -54,7 +54,8 @@ const char *szRegistryColour[] =     { "Colour0",
 				  "Colour13",
                   "Colour14",
                   "Colour15",
-                  "Colour16"
+                  "Colour16",
+                  "Colour17"
 };
 
 #ifdef HAVE_HATCHED_BRUSH
@@ -74,7 +75,8 @@ const char *szRegistryBrush[] =     {  "Brush0",
 				  "Brush13",
                   "Brush14",
                   "Brush15",
-                  "Brush16"
+                  "Brush16",
+                  "Brush17"
 };
 #endif
 
@@ -94,7 +96,8 @@ const char *szRegistryAirspaceMode[] =     {  "AirspaceMode0",
 					       "AirspaceMode13",
                            "AirspaceMode14",
                            "AirspaceMode15",
-                           "AirspaceMode16"
+                           "AirspaceMode16",
+                           "AirspaceMode17"
 };
 
 char szRegistryAcknowledgementTime[]=	 "AcknowledgementTime1";

--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -1999,9 +1999,12 @@ bool CAirspaceManager::FillAirspacesFromOpenAIP(ZZIP_FILE *fp) {
             break;
         case 'G':
             if(len==1) Type=CLASSG; // G class airspace
-            if(len ==2) if (_tcsicmp(dataStr,_T("GP"))==0) Type=NOGLIDER;
-            if(len ==4) if (_tcsicmp(dataStr,_T("GSEC"))==0) Type=GLIDERSECT;
-
+            else
+            {
+              if (_tcsicmp(dataStr,_T("GP"))==0)      Type=NOGLIDER;
+              if (_tcsicmp(dataStr,_T("GSEC"))==0)    Type=GLIDERSECT;
+              if (_tcsicmp(dataStr,_T("GLIDING"))==0) Type=GLIDERSECT;
+            }
             break;
         //case 'O':
             //if (_tcsicmp(dataStr,_T("OTH"))==0) continue; //TODO: OTH missing in LK8000

--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -34,7 +34,7 @@
 
 extern	  double  ExtractFrequency(TCHAR*);
 
-static const int k_nAreaCount = 15;
+static const int k_nAreaCount = 16;
 static const TCHAR* k_strAreaStart[k_nAreaCount] = {
     _T("R"),
     _T("Q"),
@@ -50,7 +50,8 @@ static const TCHAR* k_strAreaStart[k_nAreaCount] = {
     _T("GP"),
     _T("CTR"),
     _T("TMZ"),
-    _T("RMZ")
+    _T("RMZ"),
+    _T("GSEC")
 };
 static const int k_nAreaType[k_nAreaCount] = {
     RESTRICT,
@@ -67,7 +68,8 @@ static const int k_nAreaType[k_nAreaCount] = {
     NOGLIDER,
     CTR,
     CLASSTMZ,
-    CLASSRMZ
+    CLASSRMZ,
+    GLIDERSECT
 };
 
 
@@ -1997,7 +1999,9 @@ bool CAirspaceManager::FillAirspacesFromOpenAIP(ZZIP_FILE *fp) {
             break;
         case 'G':
             if(len==1) Type=CLASSG; // G class airspace
-            //else if (_tcsicmp(dataStr,_T("GLIDING"))==0) Type=GLIDING; //TODO: GLIDING missing in LK8000
+            if(len ==2) if (_tcsicmp(dataStr,_T("GP"))==0) Type=NOGLIDER;
+            if(len ==4) if (_tcsicmp(dataStr,_T("GSEC"))==0) Type=GLIDERSECT;
+
             break;
         //case 'O':
             //if (_tcsicmp(dataStr,_T("OTH"))==0) continue; //TODO: OTH missing in LK8000
@@ -2947,6 +2951,9 @@ const TCHAR* CAirspaceManager::GetAirspaceTypeText(int type) {
             return TEXT("TMZ");
 	case CLASSRMZ:
 	    return TEXT("RMZ");
+	case GLIDERSECT:
+	    return TEXT("GldSect");
+
         case OTHER:
             // LKTOKEN  _@M765_ = "Unknown"
             return MsgToken(765);
@@ -2989,6 +2996,8 @@ const TCHAR* CAirspaceManager::GetAirspaceTypeShortText(int type) {
             return TEXT("TMZ");
         case CLASSRMZ:
             return TEXT("RMZ");
+        case GLIDERSECT:
+            return TEXT("GldSec");
         default:
             return TEXT("?");
     }


### PR DESCRIPTION
added missing "glider sector" airspace
defined in Open Air as AC GSEC
defined in OpenAIP as GLIDER or GSEC

GSEC   is used in German official authority airspace 2017 as can be found here:
http://www.daec.de/fachbereiche/luftraum-flugbetrieb/luftraumdaten/

Change request here:
http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=8533