### PR TITLE
Show disabled airspaces in light grey only

### DIFF
--- a/Common/Source/Draw/DrawAirSpacesBorders.cpp
+++ b/Common/Source/Draw/DrawAirSpacesBorders.cpp
@@ -38,7 +38,7 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
       } // for
 
       /***********************************************************************
-       * now draw aispaces on top (normal order) with thin pen
+       * now draw airspaces on top (normal order) with thin pen
        ***********************************************************************/
 
       for (CAirspaceList::const_iterator it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
@@ -48,9 +48,8 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
           } else {
             Surface.SelectObject(hAirspacePens[(*it)->Type()]);
           }
-          if((*it)->DrawStyle()==adsDisabled)
-            Surface.SelectObject(LKPen_Black_N0 );
-          (*it)->Draw(Surface, false);
+          if((*it)->DrawStyle() != adsDisabled)
+            (*it)->Draw(Surface, false);
         }
       }//for
 

--- a/Common/Source/Draw/MapWndProc.cpp
+++ b/Common/Source/Draw/MapWndProc.cpp
@@ -111,7 +111,7 @@ std::array<RasterPoint, NUMTERRAINSWEEPS+1> MapWindow::Groundline2;
 #endif
 
 // 17 is number of airspace types
-int      MapWindow::iAirspaceColour[AIRSPACECLASSCOUNT] = {5,0,0,10,0,0,10,2,0,10,9,3,7,7,7,10,10};
+int      MapWindow::iAirspaceColour[AIRSPACECLASSCOUNT] = {5,0,0,10,0,0,10,2,0,10,9,3,7,7,7,10,1};
 int      MapWindow::iAirspaceMode[AIRSPACECLASSCOUNT] = {0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0};
 #ifdef HAVE_HATCHED_BRUSH
 int      MapWindow::iAirspaceBrush[AIRSPACECLASSCOUNT] = {2,0,0,0,3,3,3,3,0,3,2,3,3,3,3,3,3};


### PR DESCRIPTION
(look like enabled before at least on a Kobo)
Changed default color of Glider Sector to light green (makes more sense)