### PR TITLE
bugfix

### DIFF
--- a/Common/Source/Draw/UpdateAndRefresh.cpp
+++ b/Common/Source/Draw/UpdateAndRefresh.cpp
@@ -18,7 +18,7 @@
 void MapWindow::RequestFastRefresh() {
 
 #ifdef ENABLE_OPENGL
-  MainWindow.Invalidate();
+  MainWindow.Redraw(MapRect);
 #else
   drawTriggerEvent.set();
 #endif
@@ -28,7 +28,7 @@ void MapWindow::RequestFastRefresh() {
 void MapWindow::RefreshMap() {
   MapDirty = true;
 #ifdef ENABLE_OPENGL
-  MainWindow.Invalidate();
+  MainWindow.Redraw(MapRect);
 #else
   drawTriggerEvent.set();
 #endif

--- a/Common/Source/Library/StringFunctions.cpp
+++ b/Common/Source/Library/StringFunctions.cpp
@@ -50,7 +50,8 @@ static void DetectCharsetAndFixString (char* String, charset& cs) {
         // 1 - string start with BOM switch charset to utf8
         if(String[0] == (char)0xEF && String[1] == (char)0xBB && String[2] == (char)0xBF) {
             cs = charset::utf8;
-            strcpy(String, String+3); // skip BOM
+            size_t len = strlen(String) + 1;
+            memmove(String, String+3, len-3); // skip BOM
         }
     }
     if(cs == charset::unknown && !ValidateUTF8(String) ) {

--- a/Common/Source/Library/cpp-mmf/memory_mapped_file.cpp
+++ b/Common/Source/Library/cpp-mmf/memory_mapped_file.cpp
@@ -38,7 +38,9 @@ namespace memory_mapped_file
 
     base_mmf::~base_mmf()
     {
-        close();
+        if(is_open()) {
+            close();
+        }
     }
 
     void base_mmf::close()

--- a/Common/Source/Window/Linux/WndMainBase.h
+++ b/Common/Source/Window/Linux/WndMainBase.h
@@ -35,24 +35,32 @@ public:
 
     virtual void Redraw(const RECT& Rect) { 
         __super::Redraw(Rect);
+        PostRedrawEvent();
+    }
+
+    virtual void Redraw() {
+        __super::Redraw();
+        PostRedrawEvent();
+    }
+
+    virtual void SetWndText(const TCHAR* lpszText) { assert(false); }
+    virtual const TCHAR* GetWndText() const { assert(false); return _T(""); }
+
+    void RunModalLoop() {
+        this->RunEventLoop();
+    }
+
+    static void PostRedrawEvent() {
 #if defined(ENABLE_SDL)
 #if !(SDL_MAJOR_VERSION >= 2)
         SDL_Event event;
         event.type = SDL_VIDEOEXPOSE;
         ::SDL_PushEvent(&event);
 #endif
+#else
+        Event event(Event::NOP);
+        event_queue->Push(event);
 #endif
-    }
-
-    virtual void Redraw() {
-        __super::Redraw();
-    }
-    
-    virtual void SetWndText(const TCHAR* lpszText) { assert(false); }
-    virtual const TCHAR* GetWndText() const { assert(false); return _T(""); }
-
-    void RunModalLoop() {
-        this->RunEventLoop();
     }
 };
 


### PR DESCRIPTION
- screen refresh rate can't be fast than 2Hz if no user input.
- Warning: invalid file descriptor -1 in syscall close() reported by valgrind
- possible string corruption on utf8 with BOM file loading ( waypoint, airspaces ... )

