### PR TITLE
Android fix "Application Not Responding" on shutdown or ComPort restart

### DIFF
--- a/Common/Distribution/LK8000/_System/CREDITS.TXT
+++ b/Common/Distribution/LK8000/_System/CREDITS.TXT
@@ -1,4 +1,4 @@
-#B2;
+#B3;
 [Welcome to LK8000]
 Hello! You have just installed or updated LK8000, and starting from this version we can provide more informations about changes and improvements.
 Join our free support forum at http://www.postfrontal.com/forum
@@ -13,9 +13,17 @@ Please ADVANCE TO THE NEXT PAGE to start reading about changes and enhancements.
 
 [Latest software changes]
 
+Version 6.1l
+
+. fix "Application Not Responding" on shutdown or ComPort restart
+
+Version 6.1k
+
+. fix "red screen" artefact on some device
+
 Version 6.1j
 
-fix Circling Wind calcuation with GPS rate > 1Hz
+. fix Circling Wind calcuation with GPS rate > 1Hz
 . android : support GPSBip device
 . android : scan for available Bluetooth LE device when device config is open.
 . few other minor fix

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -97,7 +97,7 @@
 
 #define LKFORK		"LK8000"
 #define LKVERSION	"6"
-#define LKRELEASE	"1l0"
+#define LKRELEASE	"1l"
 
 #define LKDATADIR	"LK8000"
 #define LKPROFILE	"DEFAULT_PROFILE.prf"

--- a/Common/Source/xcs/Android/InternalSensors.cpp
+++ b/Common/Source/xcs/Android/InternalSensors.cpp
@@ -182,7 +182,6 @@ Java_org_LK8000_InternalGPS_setConnected(JNIEnv *env, jobject obj,
 {
 
   unsigned index = getDeviceIndex(env, obj);
-  LockComm();
   PDeviceDescriptor_t pdev = devX(index);
   if(pdev) {
     pdev->HB = LKHearthBeats;
@@ -207,7 +206,6 @@ Java_org_LK8000_InternalGPS_setConnected(JNIEnv *env, jobject obj,
     }
     GPS_INFO.NAVWarning = !(pdev->nmeaParser.gpsValid);
   }
-  UnlockComm();
 }
 
 extern "C"

--- a/README
+++ b/README
@@ -15,6 +15,7 @@ HISTORY OF MASTER BRANCH
 6.1i  Jun       13  2017
 6.1j  Jul       18  2017
 6.1k  Jul       24  2017 ( Android only )
+6.1l  Aug       03  2017 ( Android only )
 
 ================================================================================
 = Build Target                                                                 =

--- a/android-studio/app/build.gradle
+++ b/android-studio/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "org.lk8000"
         minSdkVersion 9
         targetSdkVersion 19
-        versionCode 33
-        versionName "6.1k"
+        versionCode 34
+        versionName "6.1l"
         setProperty("archivesBaseName", "LK8000-$versionName")
         manifestPlaceholders = [applicationLabel: "@string/app_name"]
         externalNativeBuild {


### PR DESCRIPTION
InternalGPS : deadlock between close & setConnected.
caused by misused LockComm inside RxThread.