### PR TITLE
exclude Port sharing for TCP/UDP Ports.

### DIFF
--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -558,8 +558,8 @@ BOOL devInit() {
             ReadPortSettings(i, Port, &SpeedIndex, &BitIndex);
         }
         // remember: Port1 is the port used by device A, port1 may be Com3 or Com1 etc
-
-        if(std::find(UsedPort.begin(), UsedPort.end(), Port) != UsedPort.end()) {
+        if (_tcsncmp(Port, _T("COM"),3) == 0) {  // shared ports for COM Ports only
+          if(std::find(UsedPort.begin(), UsedPort.end(), Port) != UsedPort.end()) {
             unsigned int j;
             for( j = 0; j < i ; j++)
             {
@@ -583,6 +583,7 @@ BOOL devInit() {
               }
             }
             continue;
+          }
         }
         UsedPort.insert(Port);
         

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -558,7 +558,12 @@ BOOL devInit() {
             ReadPortSettings(i, Port, &SpeedIndex, &BitIndex);
         }
         // remember: Port1 is the port used by device A, port1 may be Com3 or Com1 etc
-        if (_tcsncmp(Port, _T("COM"),3) == 0) {  // shared ports for COM Ports only
+        if ((_tcsncmp(Port, _T("COM"),3)           == 0) ||
+            (_tcsncmp(Port, _T("IOIOUart_"), 9)    == 0) ||
+            (_tcsncmp(Port, _T("USB:"), 4)         == 0) ||
+            (_tcscmp(Port, _T("Bluetooth Server")) == 0)
+           )
+        {  // shared ports for COM Ports only
           if(std::find(UsedPort.begin(), UsedPort.end(), Port) != UsedPort.end()) {
             unsigned int j;
             for( j = 0; j < i ; j++)


### PR DESCRIPTION
This is important for multiple TCPClient connections to different ports or IP addresses, for example.
Bug reported here:
http://www.postfrontal.com/forum/topic.asp?whichpage=1.8&TOPIC_ID=8467&#70051