### PR TITLE
Start device Dialog allways with Device A selected

### DIFF
--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -4764,7 +4764,7 @@ void InitDlgDevice(WndForm *pWndForm) {
       pWnd->SetLeft(lx);
       ((WndButton*)pWnd)->LedSetMode(LEDMODE_OFFGREEN);
       ((WndButton*)pWnd)->LedSetOnOff(!DeviceList[i].Disabled);
-
+      if(i==0) OnA((WndButton*)pWnd);
       lx += w + SPACEBORDER;
     }
   }


### PR DESCRIPTION
The selected button and the Device data was not in line after startup
Now we always start with Device A to be in line with the default selected button A