### PR TITLE
fix invalid "X" coordinate in xml dialog layout

### DIFF
--- a/Common/Data/Dialogs/dlgConfigPilot_P.xml
+++ b/Common/Data/Dialogs/dlgConfigPilot_P.xml
@@ -5,13 +5,13 @@
     <WndFrame Name="frmPilot" X="0" Y="0" Width="235" Height="222" Font="2">
       <WndButton Name="cmdPilotName" Caption="_@M525_" X="2" Y="11" Width="235"  Height="22" Font="2" />
     </WndFrame>
-    <WndProperty Name="prpLiveTrackerInterval" Caption="_@M1779_" X="2" Y="70" Width="235" Height="25" CaptionWidth="150" Font="2" Help="_@H1258_">
+    <WndProperty Name="prpLiveTrackerInterval" Caption="_@M1779_" X="0" Y="70" Width="-1" Height="25" CaptionWidth="150" Font="2" Help="_@H1258_">
       <DataField Name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="0.0" Max="60.0" Step="1.0" />
     </WndProperty>
-    <WndProperty Name="prpLiveTrackerRadar_config" Caption="_@M2322_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1295_">
+    <WndProperty Name="prpLiveTrackerRadar_config" Caption="_@M2322_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1295_">
       <DataField Name="" DataType="boolean"/>
     </WndProperty>
-    <WndProperty Name="prpLiveTrackerStart_config" Caption="_@M2333_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1298_">
+    <WndProperty Name="prpLiveTrackerStart_config" Caption="_@M2333_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1298_">
         <DataField name="" DataType="enum"  Min="0" Max="2" Step="1" OnDataAccess="OnLiveTrackerStartConfig"/>
     </WndProperty>
     <WndButton Name="cmdLiveTrackersrv" Caption="_@M1782_" X="2" Y="-1" Width="200"  Height="25" Font="2" />

--- a/Common/Data/Dialogs/dlgConfiguration_P.xml
+++ b/Common/Data/Dialogs/dlgConfiguration_P.xml
@@ -13,25 +13,25 @@
       <WndProperty Name="prpTerrainFile" Caption="_@M706_" X="1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H102_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpWaypointFile" Caption="_@M806_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H103_">
+      <WndProperty Name="prpWaypointFile" Caption="_@M806_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H103_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAdditionalWaypointFile" Caption="_@M807_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H104_">
+      <WndProperty Name="prpAdditionalWaypointFile" Caption="_@M807_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H104_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAirspaceFile" Caption="_@M63_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H105_">
+      <WndProperty Name="prpAirspaceFile" Caption="_@M63_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H105_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAdditionalAirspaceFile" Caption="_@M64_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H106_">
+      <WndProperty Name="prpAdditionalAirspaceFile" Caption="_@M64_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H106_"> 
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAirfieldFile" Caption="_@M799_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H107_">
+      <WndProperty Name="prpAirfieldFile" Caption="_@M799_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H107_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpWaypointsOutOfRange" Caption="_@M824_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H236_">
+      <WndProperty Name="prpWaypointsOutOfRange" Caption="_@M824_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H236_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpLanguageFile" Caption="_@M387_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H223_">
+      <WndProperty Name="prpLanguageFile" Caption="_@M387_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H223_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
       <WndButton Name="cmdLKMapOpen"  Caption="_@M2328_" X="1" Y="-1" Width="-1"  Height="22" Font="2" OnClickNotify="OnLKMapOpenClicked" />
@@ -41,245 +41,245 @@
       <WndButton Name="cmdAirspaceColours"  Caption="_@M189_" X="72" Y="2" Width="70"  Height="22" Font="2" OnClickNotify="OnAirspaceColoursClicked" />
       <WndButton Name="cmdAirspaceMode"  Caption="_@M286_" X="142" Y="2" Width="70"  Height="22" Font="2" OnClickNotify="OnAirspaceModeClicked" />
 
-      <WndProperty Name="prpAirspaceDisplay" Caption="_@M67_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1250_">
+      <WndProperty Name="prpAirspaceDisplay" Caption="_@M67_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1250_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1" OnDataAccess="OnAirspaceDisplay"/>
       </WndProperty>
-      <WndProperty Name="prpClipAltitude" Caption="_@M183_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H109_" Keyboard="1">
+      <WndProperty Name="prpClipAltitude" Caption="_@M183_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H109_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="0" Max="20000" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAltWarningMargin" Caption="_@M1630_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1251_" Keyboard="1">
+      <WndProperty Name="prpAltWarningMargin" Caption="_@M1630_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1251_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="0" Max="20000" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAirspaceFillType" Caption="_@M940_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1200_">
+      <WndProperty Name="prpAirspaceFillType" Caption="_@M940_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1200_">
         <DataField Name="" DataType="enum" OnDataAccess="OnAirspaceFillType"/>
       </WndProperty>
-      <WndProperty Name="prpAirspaceOpacity" Caption="_@M944_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1201_">
+      <WndProperty Name="prpAirspaceOpacity" Caption="_@M944_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1201_">
         <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpAspPermDisable" Caption="_@M967_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1265_">
+      <WndProperty Name="prpAspPermDisable" Caption="_@M967_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1265_">
         <DataField name="" DataType="enum" OnDataAccess="OnAspPermModified"/>
       </WndProperty>	  	  
     </WndFrame>
     <WndFrame Name="frmTerrain" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpTerrainRamp" Caption="_@M703_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H119_">
+      <WndProperty Name="prpTerrainRamp" Caption="_@M703_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H119_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-    <WndProperty Name="prpAutoContrast" Caption="_@M981_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1296_">
+    <WndProperty Name="prpAutoContrast" Caption="_@M981_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1296_">
         <DataField Name="" DataType="boolean" OnDataAccess="OnAutoContrastChange"/>
       </WndProperty>
-      <WndProperty Name="prpTerrainContrast" Caption="_@M704_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H117_">
+      <WndProperty Name="prpTerrainContrast" Caption="_@M704_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H117_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f" EditFormat="%.0f" Min="0" Max="100" Step="5"/>
       </WndProperty>
-      <WndProperty Name="prpTerrainBrightness" Caption="_@M702_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H118_">
+      <WndProperty Name="prpTerrainBrightness" Caption="_@M702_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H118_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f" EditFormat="%.0f" Min="0" Max="100" Step="5"/>
       </WndProperty>
-      <WndProperty Name="prpShading" Caption="_@M610_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H120_">
+      <WndProperty Name="prpShading" Caption="_@M610_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H120_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpBgMapcolor" Caption="_@M257_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H121_">
+      <WndProperty Name="prpBgMapcolor" Caption="_@M257_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H121_">
         <DataField Name="" DataType="enum" Min="0" Max="9" Step="1"/>
       </WndProperty>
       <WndButton Name="cmdSetTopology"  Caption="_@M197_" X="70" Y="-1" Width="-1"  Height="22" Font="2" OnClickNotify="OnSetTopologyClicked" />
-      <WndProperty Name="prpLKMaxLabels" Caption="_@M430_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H122_">
+      <WndProperty Name="prpLKMaxLabels" Caption="_@M430_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H122_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f" EditFormat="%.0f" Min="0" Max="100" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmDisplay" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpWaypointLabels" Caption="_@M379_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H123_">
+      <WndProperty Name="prpWaypointLabels" Caption="_@M379_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H123_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpTrail" Caption="_@M740_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H124_">
+      <WndProperty Name="prpTrail" Caption="_@M740_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H124_">
         <DataField Name="" DataType="enum"  Min="0" Max="3" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpOrientation" Caption="_@M506_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H125_">
+      <WndProperty Name="prpOrientation" Caption="_@M506_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H125_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAutoOrientScale" Caption="_@M485_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H126_">
+      <WndProperty Name="prpAutoOrientScale" Caption="_@M485_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H126_">
         <DataField Name="" DataType="double" DisplayFormat="%.1f" EditFormat="%.1f" Min="1" Max="100" Step="0.5"/>
       </WndProperty>
-      <WndProperty Name="prpAutoZoom" Caption="_@M115_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H127_">
+      <WndProperty Name="prpAutoZoom" Caption="_@M115_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H127_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpTrailDrift" Caption="_@M739_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H128_">
+      <WndProperty Name="prpTrailDrift" Caption="_@M739_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H128_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpSnailScale" Caption="_@M741_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H129_">
+      <WndProperty Name="prpSnailScale" Caption="_@M741_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H129_">
         <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpCirclingZoom" Caption="_@M174_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H130_">
+      <WndProperty Name="prpCirclingZoom" Caption="_@M174_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H130_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpDeclutterMode" Caption="_@M225_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H131_">
+      <WndProperty Name="prpDeclutterMode" Caption="_@M225_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H131_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpNewMapDeclutter" Caption="_@M224_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H132_">
+      <WndProperty Name="prpNewMapDeclutter" Caption="_@M224_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H132_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmInfoBoxCruise" X="0" Y="0" Width="235" Height="202" Font="2">
 
-      <WndProperty Name="prpInfoBoxCruise0" Caption="1" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise0" Caption="1" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise1" Caption="2" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise1" Caption="2" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise2" Caption="3" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise2" Caption="3" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise3" Caption="4" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise3" Caption="4" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise4" Caption="5" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise4" Caption="5" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise5" Caption="6" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise5" Caption="6" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise6" Caption="7" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise6" Caption="7" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCruise7" Caption="8" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCruise7" Caption="8" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmInfoBoxCircling" X="0" Y="0" Width="235" Height="202" Font="2">
 
-      <WndProperty Name="prpInfoBoxCircling0" Caption="1" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling0" Caption="1" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling1" Caption="2" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling1" Caption="2" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling2" Caption="3" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling2" Caption="3" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling3" Caption="4" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling3" Caption="4" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling4" Caption="5" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling4" Caption="5" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling5" Caption="6" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling5" Caption="6" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling6" Caption="7" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling6" Caption="7" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxCircling7" Caption="8" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxCircling7" Caption="8" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmInfoBoxFinalGlide" X="0" Y="0" Width="235" Height="202" Font="2">
 
-      <WndProperty Name="prpInfoBoxFinalGlide0" Caption="1" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide0" Caption="1" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide1" Caption="2" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide1" Caption="2" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide2" Caption="3" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide2" Caption="3" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide3" Caption="4" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide3" Caption="4" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide4" Caption="5" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide4" Caption="5" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide5" Caption="6" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide5" Caption="6" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide6" Caption="7" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide6" Caption="7" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxFinalGlide7" Caption="8" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxFinalGlide7" Caption="8" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmInfoBoxAuxiliary" X="0" Y="0" Width="235" Height="202" Font="2">
 
-      <WndProperty Name="prpInfoBoxAux0" Caption="1" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux0" Caption="1" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux1" Caption="2" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux1" Caption="2" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux2" Caption="3" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux2" Caption="3" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux3" Caption="4" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux3" Caption="4" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux4" Caption="5" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux4" Caption="5" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux5" Caption="6" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux5" Caption="6" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux6" Caption="7" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux6" Caption="7" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpInfoBoxAux7" Caption="8" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
+      <WndProperty Name="prpInfoBoxAux7" Caption="8" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="20" Font="2" OnHelp="OnInfoBoxHelp">
         <DataField Name="" DataType="enum"  Min="0" Max="100" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmSafety" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpSafetyAltitudeArrival" Caption="_@M576_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H133_" Keyboard="1">
+      <WndProperty Name="prpSafetyAltitudeArrival" Caption="_@M576_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H133_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="0" Max="10000" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpSafetyAltitudeMode" Caption="_@M575_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H134_">
+      <WndProperty Name="prpSafetyAltitudeMode" Caption="_@M575_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H134_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpSafetyAltitudeTerrain" Caption="_@M707_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H135_" Keyboard="1">
+      <WndProperty Name="prpSafetyAltitudeTerrain" Caption="_@M707_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H135_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="0" Max="10000" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpSafetyMacCready" Caption="_@M574_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H136_" Keyboard="1">
+      <WndProperty Name="prpSafetyMacCready" Caption="_@M574_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H136_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.1f %s" EditFormat="%.1f" Min="0" Max="10" Step="0.1"/>
       </WndProperty>
-      <WndProperty  Name="prpBugs" Caption="_@M253_"  X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1257_" Keyboard="1">
+      <WndProperty  Name="prpBugs" Caption="_@M253_"  X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1257_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.0f%%" EditFormat="%.0f" Min="50" Max="100" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpUseTotalEnergy" Caption="_@M1669_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1256_">
+      <WndProperty Name="prpUseTotalEnergy" Caption="_@M1669_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1256_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpBestWarning" Caption="_@M141_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H137_">
+      <WndProperty Name="prpBestWarning" Caption="_@M141_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H137_">
         <DataField Name="" DataType="boolean" />
       </WndProperty>
-      <WndProperty Name="prpLockSettingsInFlight" Caption="_@M577_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H138_">
+      <WndProperty Name="prpLockSettingsInFlight" Caption="_@M577_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H138_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmFinalGlide" X="1" Y="0" Width="-1" Height="222" Font="2">
 
-      <WndProperty Name="prpAutoWind" Caption="_@M114_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H139_">
+      <WndProperty Name="prpAutoWind" Caption="_@M114_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H139_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpWindCalcSpeed" Caption="_@M744_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H140_" Keyboard="1">
+      <WndProperty Name="prpWindCalcSpeed" Caption="_@M744_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H140_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="5" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpWindCalcTime" Caption="_@M745_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H141_">
+      <WndProperty Name="prpWindCalcTime" Caption="_@M745_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H141_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f s" EditFormat="%.0f" Min="5" Max="20" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAutoMcStatus" Caption="_@M109_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1255_">
+      <WndProperty Name="prpAutoMcStatus" Caption="_@M109_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1255_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpAutoMcMode" Caption="_@M109_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H142_">
+      <WndProperty Name="prpAutoMcMode" Caption="_@M109_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H142_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAverEffTime" Caption="_@M371_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H143_">
+      <WndProperty Name="prpAverEffTime" Caption="_@M371_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H143_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpThermalLocator" Caption="_@M715_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H144_">
+      <WndProperty Name="prpThermalLocator" Caption="_@M715_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H144_">
         <DataField Name="" DataType="enum" Min="0" Max="2" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpOrbiter" Caption="_@M713_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H145_">
+      <WndProperty Name="prpOrbiter" Caption="_@M713_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H145_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpAutoForceFinalGlide" Caption="_@M108_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2"  Help="_@H146_">
+      <WndProperty Name="prpAutoForceFinalGlide" Caption="_@M108_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2"  Help="_@H146_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpEnableNavBaroAltitude" Caption="_@M770_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H147_">
+      <WndProperty Name="prpEnableNavBaroAltitude" Caption="_@M770_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H147_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
     </WndFrame>
@@ -302,42 +302,42 @@
       <WndProperty Name="prpAlarmGearAltitude" Caption="_@M1830_" X="2" Y="-1" Width="233" Height="22" CaptionWidth="150" Font="2" Help="_@H1270_" keyboard="1">
         <DataField name="" DataType="double" DisplayFormat="%.0f %s" EditFormat="%.0f" Min="0" Max="5000" Step="1"/>
       </WndProperty>           
-      <WndProperty Name="prpSonarWarning" Caption="_@M1870_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1290_">
+      <WndProperty Name="prpSonarWarning" Caption="_@M1870_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1290_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmUnits" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpUnitsSpeed" Caption="_@M61_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H170_">
+      <WndProperty Name="prpUnitsSpeed" Caption="_@M61_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H170_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpUnitsDistance" Caption="_@M244_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H171_">
+      <WndProperty Name="prpUnitsDistance" Caption="_@M244_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H171_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpUnitsLift" Caption="_@M390_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H172_">
+      <WndProperty Name="prpUnitsLift" Caption="_@M390_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H172_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpUnitsAltitude" Caption="_@M88_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H173_">
+      <WndProperty Name="prpUnitsAltitude" Caption="_@M88_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H173_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpUnitsTaskSpeed" Caption="_@M691_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H174_">
+      <WndProperty Name="prpUnitsTaskSpeed" Caption="_@M691_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H174_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpUnitsLatLon" Caption="_@M917_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H175_">
+      <WndProperty Name="prpUnitsLatLon" Caption="_@M917_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H175_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpPressureHg" Caption="_@M531_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H176_">
+      <WndProperty Name="prpPressureHg" Caption="_@M531_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H176_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpUTCOffset" Caption="_@M758_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1177_">
+      <WndProperty Name="prpUTCOffset" Caption="_@M758_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1177_">
         <DataField Name="" DataType="double" DisplayFormat="%.2f" EditFormat="%.2f" Min="-13" Max="13" Step="0.25" OnDataAccess="OnUTCData"/>
       </WndProperty>
-      <WndProperty Name="prpLocalTime" Caption="_@M402_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" ReadOnly="1"/>
-      <WndProperty Name="prpEarthModel" Caption="Earth Model" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpLocalTime" Caption="_@M402_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" ReadOnly="1"/>
+      <WndProperty Name="prpEarthModel" Caption="Earth Model" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" >
         <DataField Name="" DataType="enum"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmInterface" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpMenuTimeout" Caption="_@M434_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H182_">
+      <WndProperty Name="prpMenuTimeout" Caption="_@M434_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H182_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f s" EditFormat="%.0f" Min="1" Max="120" Step="1"/>
       </WndProperty>
       <WndButton Name="cmdSetCustomKeys" Caption="_@M196_" X="70" Y="-1" Width="-1"  Height="22" Font="2" OnClickNotify="OnSetCustomKeysClicked" />
@@ -347,60 +347,60 @@
       <WndButton Name="cmdSetMultimaps" Caption="_@M1822_" X="70" Y="-1" Width="-1"  Height="22" Font="2" OnClickNotify="OnMultimapsClicked" />
     </WndFrame>
     <WndFrame Name="frmAppearance" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpGliderScreenPosition" Caption="_@M327_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H183_">
+      <WndProperty Name="prpGliderScreenPosition" Caption="_@M327_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H183_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f %%" EditFormat="%.0f" Min="10" Max="70" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAppIndLandable" Caption="_@M381_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H184_">
+      <WndProperty Name="prpAppIndLandable" Caption="_@M381_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H184_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpMapBox" Caption="_@M383_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H185_">
+      <WndProperty Name="prpMapBox" Caption="_@M383_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H185_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpArrivalValue" Caption="_@M384_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H186_">
+      <WndProperty Name="prpArrivalValue" Caption="_@M384_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H186_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpAppInverseInfoBox" Caption="_@M362_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H187_">
+      <WndProperty Name="prpAppInverseInfoBox" Caption="_@M362_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H187_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpOutlinedTp" Caption="_@M808_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H188_">
+      <WndProperty Name="prpOutlinedTp" Caption="_@M808_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H188_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpOverColor" Caption="_@M508_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H189_">
+      <WndProperty Name="prpOverColor" Caption="_@M508_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H189_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpTpFilter" Caption="_@M750_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H190_">
+      <WndProperty Name="prpTpFilter" Caption="_@M750_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H190_">
         <DataField Name="" DataType="enum" Min="0" Max="10" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpHideUnits" Caption="_@M337_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H191_">
+      <WndProperty Name="prpHideUnits" Caption="_@M337_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H191_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpBarOpacity" Caption="_@M950_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1202_">
+      <WndProperty Name="prpBarOpacity" Caption="_@M950_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1202_">
         <DataField Name="" DataType="enum"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmFonts" X="1" Y="0" Width="-1" Height="222" Font="2">
-     <WndProperty Name="prpOverlayTarget" Caption="_@M1886_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" >
+     <WndProperty Name="prpOverlayTarget" Caption="_@M1886_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpOverlayValues" Caption="_@M1887_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpOverlayValues" Caption="_@M1887_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpFontMapWaypoint" Caption="_@M1880_" X="-1" Y="-998"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpFontMapWaypoint" Caption="_@M1880_" X="0" Y="-998"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpFontMapTopology" Caption="_@M1881_" X="-1" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpFontMapTopology" Caption="_@M1881_" X="0" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpFontInfopage1L" Caption="_@M1882_" X="-1" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpFontInfopage1L" Caption="_@M1882_" X="0" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpFontBottomBar" Caption="_@M1883_" X="-1" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpFontBottomBar" Caption="_@M1883_" X="0" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpFontVisualGlide" Caption="_@M1888_" X="-1" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
+      <WndProperty Name="prpFontVisualGlide" Caption="_@M1888_" X="0" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" >
    <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpUseTwoLines" Caption="_@M1885_" X="-1" Y="-997" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1292_">
+      <WndProperty Name="prpUseTwoLines" Caption="_@M1885_" X="0" Y="-997" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1292_">
         <DataField Name="" DataType="boolean" />
       </WndProperty>
 
@@ -410,51 +410,51 @@
     <WndFrame Name="frmVarioAppearance" X="1" Y="0" Width="-1" Height="222" Font="2">
        <WndButton Name="cmdSetOverlays" Caption="_@M195_" X="70" Y="1" Width="-1"  Height="22" Font="2" OnClickNotify="OnSetOverlaysClicked" />
 
-      <WndProperty Name="prpOverlayClock" Caption="_@M615_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H237_">
+      <WndProperty Name="prpOverlayClock" Caption="_@M615_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H237_">
         <DataField Name="" DataType="enum" Min="0" Max="3" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpFinalGlideTerrain" Caption="_@M326_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H194_">
+      <WndProperty Name="prpFinalGlideTerrain" Caption="_@M326_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H194_">
         <DataField Name="" DataType="enum" Min="0" Max="2" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpGlideBarMode" Caption="_@M324_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1254_">
+      <WndProperty Name="prpGlideBarMode" Caption="_@M324_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1254_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpLKVarioBar" Caption="_@M785_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H196_">
+      <WndProperty Name="prpLKVarioBar" Caption="_@M785_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H196_">
         <DataField Name="" DataType="enum" Min="0" Max="1" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpLKVarioVal" Caption="_@M1424_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1204_">
+      <WndProperty Name="prpLKVarioVal" Caption="_@M1424_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1204_">
         <DataField Name="" DataType="enum" Min="0" Max="1" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpThermalBar" Caption="_@M712_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H197_">
+      <WndProperty Name="prpThermalBar" Caption="_@M712_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H197_">
         <DataField Name="" DataType="enum" Min="0" Max="2" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpTrackBar" Caption="_@M736_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H198_">
+      <WndProperty Name="prpTrackBar" Caption="_@M736_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H198_">
         <DataField Name="" DataType="boolean" />
       </WndProperty>
-      <WndProperty Name="prpEnableFLARMMap" Caption="_@M983_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H199_">
+      <WndProperty Name="prpEnableFLARMMap" Caption="_@M983_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H199_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmTask" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpAutoAdvance" Caption="_@M111_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H200_">
+      <WndProperty Name="prpAutoAdvance" Caption="_@M111_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H200_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpTaskStartLine" Caption="_@M655_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H201_">
+      <WndProperty Name="prpTaskStartLine" Caption="_@M655_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H201_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpTaskStartRadius" Caption="_@M649_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H202_" Keyboard="1">
+      <WndProperty Name="prpTaskStartRadius" Caption="_@M649_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H202_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.2f %s" EditFormat="%.2f" Min="0" Max="100" Step="0.01" />
       </WndProperty>
-      <WndProperty Name="prpTaskFAISector" Caption="_@M588_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H203_">
+      <WndProperty Name="prpTaskFAISector" Caption="_@M588_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H203_">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpTaskSectorRadius" Caption="_@M586_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H204_" Keyboard="1">
+      <WndProperty Name="prpTaskSectorRadius" Caption="_@M586_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H204_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.2f %s" EditFormat="%.2f" Min="0" Max="100" Step="0.01" />
       </WndProperty>
-      <WndProperty Name="prpTaskFinishLine" Caption="_@M297_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H205_" Keyboard="1">
+      <WndProperty Name="prpTaskFinishLine" Caption="_@M297_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H205_" Keyboard="1">
         <DataField Name="" DataType="enum"  Min="0" Max="50" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpTaskFinishRadius" Caption="_@M295_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H206_" Keyboard="1">
+      <WndProperty Name="prpTaskFinishRadius" Caption="_@M295_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="100" Font="2" Help="_@H206_" Keyboard="1">
         <DataField Name="" DataType="double" DisplayFormat="%.2f %s" EditFormat="%.2f" Min="0" Max="100" Step="0.01" />
       </WndProperty>
       <WndButton Name="cmdTaskRules" Caption="_@M690_" X="70" Y="-1" Width="-1"  Height="30" Font="2" OnClickNotify="OnTaskRulesClicked" />
@@ -463,7 +463,7 @@
       <WndProperty Name="prpLoggerShortName" Caption="_@M611_" X="1" Y="1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H207_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpDisableAutoLogger" Caption="_@M113_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H208_">
+      <WndProperty Name="prpDisableAutoLogger" Caption="_@M113_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H208_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
     </WndFrame>
@@ -474,56 +474,56 @@
       <WndButton Name="cmdWaypointDelete" Caption="_@M230_" X="50" Y="-1" Width="150"  Height="28" Font="2" Tag="4" OnClickNotify="OnWaypointDeleteClicked" />
     </WndFrame>
     <WndFrame Name="frmSpecials1" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpSaveRuntime" Caption="_@M2305_" X="-1" Y="1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H239_">
+      <WndProperty Name="prpSaveRuntime" Caption="_@M2305_" X="0" Y="1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H239_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpSetSystemTimeFromGPS" Caption="_@M766_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H210_">
+      <WndProperty Name="prpSetSystemTimeFromGPS" Caption="_@M766_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H210_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpAutoBacklight" Caption="_@M106_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H211_">
+      <WndProperty Name="prpAutoBacklight" Caption="_@M106_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H211_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpAutoSoundVolume" Caption="_@M110_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H212_">
+      <WndProperty Name="prpAutoSoundVolume" Caption="_@M110_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H212_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
 	  <WndProperty Name="prpAndroidScreenOrientation" Caption="_@M2330_" X="2" Y="-1"  Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1297_">
         <DataField Name="" DataType="enum" Min="0" Max="1" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpFontRenderer" Caption="_@M954_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1203_">
+      <WndProperty Name="prpFontRenderer" Caption="_@M954_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1203_">
         <DataField Name="" DataType="enum"/>
       </WndProperty>
-      <WndProperty Name="prpEngineeringMenu" Caption="_@M260_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H213_">
+      <WndProperty Name="prpEngineeringMenu" Caption="_@M260_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H213_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmSpecials2" X="1" Y="0" Width="-1" Height="222" Font="2">
-      <WndProperty Name="prpPGClimbZoom" Caption="_@M170_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H214_">
+      <WndProperty Name="prpPGClimbZoom" Caption="_@M170_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H214_">
         <DataField Name="" DataType="enum"  Min="0" Max="2" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpPGCruiseZoom" Caption="_@M202_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H215_">
+      <WndProperty Name="prpPGCruiseZoom" Caption="_@M202_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H215_">
         <DataField Name="" DataType="enum"  Min="0" Max="2" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpPGAutoZoomThreshold" Caption="_@M1697_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1213_">
+      <WndProperty Name="prpPGAutoZoomThreshold" Caption="_@M1697_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1213_">
         <DataField Name="" DataType="double" DisplayFormat="%.1f %s" EditFormat="%.1f" Min="1.0" Max="20.0" Step="0.5" />
       </WndProperty>
-      <WndProperty Name="prpUseUngestures" Caption="_@M1792_"  X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1260_">
+      <WndProperty Name="prpUseUngestures" Caption="_@M1792_"  X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1260_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpPGOptimizeRoute" Caption="_@M1686_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H9999_">
+      <WndProperty Name="prpPGOptimizeRoute" Caption="_@M1686_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H9999_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
     </WndFrame>
     <WndFrame Name="frmEngineering1" X="1" Y="0" Width="-1" Height="222" Font="1">
-      <WndProperty Name="prpDebounceTimeout" Caption="_@M220_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H221_">
+      <WndProperty Name="prpDebounceTimeout" Caption="_@M220_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H221_">
         <DataField Name="" DataType="double" DisplayFormat="%.0f ms" EditFormat="%.0f" Min="0" Max="1000" Step="25"/>
       </WndProperty>
-      <WndProperty Name="prpInputFile" Caption="_@M268_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H222_">
+      <WndProperty Name="prpInputFile" Caption="_@M268_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="130" Font="2" Help="_@H222_">
         <DataField Name="" DataType="filereader" Min="0" Max="200" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpCheckSum" Caption="_@M449_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H161_">
+      <WndProperty Name="prpCheckSum" Caption="_@M449_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H161_">
         <DataField Name="" DataType="enum"  Min="0" Max="1" Step="1"/>
       </WndProperty>
-      <WndProperty Name="prpIphoneGestures" Caption="_@M346_" X="-1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H180_">
+      <WndProperty Name="prpIphoneGestures" Caption="_@M346_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H180_">
         <DataField Name="" DataType="enum" Min="0" Max="1" Step="1" />
       </WndProperty>
       <WndProperty Name="prpGPSAltitudeOffset" Caption="_@M318_" X="1" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H159_">


### PR DESCRIPTION
this mistake exist from long time but are hidden because negative X was clipped to 0, 
now negative X follow same rule as negative Y value ( commit 7825d9e1e12c9536d6748ed4ca530835b4b9c5c1 ) 