### PR TITLE
new Airspace lookup dialog with

### DIFF
--- a/Common/Data/Dialogs/dlgAirspaceSelect_L.xml
+++ b/Common/Data/Dialogs/dlgAirspaceSelect_L.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
+<PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd" >
   <WndForm Name="frmAirspaceSelect" Type="Dialog" X="0" Y="0" Width="320" Height="240" Caption="_@M591_" Font="2" >
-    <WndFrame X="0" Y="0" Width="100" Height="20" Font="2" Caption="_@M287_" />
-    <WndProperty Name="prpFltName"      Caption="_@M451_"      X="2" Y="-1"  Width="98" Height="36" CaptionWidth="0" Font="2" >
-      <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterName"/>
-    </WndProperty>
-    <WndProperty Name="prpFltDistance"  Caption="_@M245_"  X="2" Y="-1"  Width="98" Height="36" CaptionWidth="0" Font="2" >
+    <WndFrame X="0" Y="0" Width="95" Height="2" Font="2" Caption="" />
+    <WndFrame X="20" Y="0" Width="91" Height="22" Font="2" Caption="_@M287_" />
+    <WndButton Name="cmdName" Caption="*" X="2" Y="17" Width="93"  Height="22" Font="2" />
+    <WndProperty Name="prpFltDistance"  Caption="_@M245_"  X="2" Y="-1"  Width="93" Height="38" CaptionWidth="0" Font="2" >
       <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterDistance"/>
     </WndProperty>
-    <WndProperty Name="prpFltDirection" Caption="_@M238_" X="2" Y="-1"  Width="98" Height="36" CaptionWidth="0" Font="2" >
+    <WndProperty Name="prpFltDirection" Caption="_@M238_" X="2" Y="-1"  Width="93" Height="38" CaptionWidth="0" Font="2" >
       <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterDirection"/>
     </WndProperty>
-    <WndProperty Name="prpFltType" Caption="_@M752_" X="2" Y="-1"  Width="98" Height="36" CaptionWidth="0" Font="2" >
+    <WndProperty Name="prpFltType" Caption="_@M752_" X="2" Y="-1"  Width="93" Height="38" CaptionWidth="0" Font="2" >
       <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterType"/>
     </WndProperty>
-    <WndButton Name="cmdClose" Caption="_@M186_" X="2" Y="190" Width="60"  Height="28" Font="2" Tag="3" />
-    <WndListFrame Name="frmAirspaceList" X="102" Y="0" Width="-2" Height="222" Font="2" OnListInfo="OnWpListInfo">
-      <WndOwnerDrawFrame Name="frmAirspaceListEntry" X="2" Y="2" Width="-2" Height="18" Font="2"  OnPaint="OnPaintListItem"/>
+    <WndButton Name="cmdSelect" Caption="_@M595_" X="2" Y="160" Width="93"  Height="28" Font="2" Tag="3" />    
+    <WndButton Name="cmdClose" Caption="_@M186_" X="2" Y="192" Width="93"  Height="28" Font="2" Tag="3" />
+    <WndListFrame Name="frmAirspaceList" X="97" Y="1" Width="-2" Height="-1" Font="2" OnListInfo="OnWpListInfo">
+      <WndOwnerDrawFrame Name="frmAirspaceListEntry" X="2" Y="2" Width="-2" Height="24" Font="2"  OnPaint="OnPaintListItem"/>
     </WndListFrame>
   </WndForm>
 </PMML>
+
+

--- a/Common/Data/Dialogs/dlgAirspaceSelect_P.xml
+++ b/Common/Data/Dialogs/dlgAirspaceSelect_P.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
+<PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd" >
   <WndForm Name="frmAirspaceSelect" Type="Dialog" X="0" Y="0" Width="240" Height="320" Caption="_@M591_" Font="2" >
-    <WndFrame X="0" Y="0" Width="100" Height="20" Font="2" Caption="_@M287_" />
-    <WndButton Name="cmdClose" Caption="_@M186_" X="100" Y="0" Width="60"  Height="28" Font="2" Tag="3" />
-    <WndProperty Name="prpFltName"      Caption="_@M451_"      X="2" Y="32"  Width="98" Height="40" CaptionWidth="0" Font="2" >
-      <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterName"/>
-    </WndProperty>
-    <WndProperty Name="prpFltType" Caption="_@M752_" X="100" Y="32"  Width="98" Height="40" CaptionWidth="0" Font="2" >
+
+    <WndButton Name="cmdSelect" Caption="_@M595_" X="4" Y="2" Width="114"  Height="28" Font="2" Tag="3" />
+    <WndButton Name="cmdClose" Caption="_@M186_" X="118" Y="2" Width="114"  Height="28" Font="2" Tag="3" />
+    
+	<WndFrame X="20" Y="33" Width="80" Height="18" Font="2" Caption="_@M287_" />
+    <WndButton Name="cmdName" Caption="*" X="20" Y="48" Width="86"  Height="22" Font="2" />
+	
+    <WndProperty Name="prpFltType" Caption="_@M752_" X="118" Y="32"  Width="114" Height="40" CaptionWidth="0" Font="2" >
       <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterType"/>
     </WndProperty>
-    <WndProperty Name="prpFltDistance"  Caption="_@M245_"  X="2" Y="74"  Width="98" Height="40" CaptionWidth="0" Font="2" >
+	
+    <WndProperty Name="prpFltDistance"  Caption="_@M245_"  X="4" Y="74"  Width="114" Height="40" CaptionWidth="0" Font="2" >
       <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterDistance"/>
     </WndProperty>
-    <WndProperty Name="prpFltDirection" Caption="_@M238_" X="100" Y="74"  Width="98" Height="40" CaptionWidth="0" Font="2" >
+    <WndProperty Name="prpFltDirection" Caption="_@M238_" X="118" Y="74"  Width="114" Height="40" CaptionWidth="0" Font="2" >
       <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s" OnDataAccess="OnFilterDirection"/>
     </WndProperty>
-    <WndListFrame Name="frmAirspaceList" X="2" Y="116" Width="-2" Height="-2" Font="2" OnListInfo="OnWpListInfo">
-      <WndOwnerDrawFrame Name="frmAirspaceListEntry" X="0" Y="2" Width="-2" Height="18" Font="2"  OnPaint="OnPaintListItem"/>
+    <WndListFrame Name="frmAirspaceList" X="1" Y="116" Width="-1" Height="-1" Font="2" OnListInfo="OnWpListInfo">
+      <WndOwnerDrawFrame Name="frmAirspaceListEntry" X="2" Y="2" Width="-2" Height="18" Font="2"  OnPaint="OnPaintListItem"/>
     </WndListFrame>
   </WndForm>
 </PMML>

--- a/Common/Data/Dialogs/dlgTextEntry_Keyboard_L.xml
+++ b/Common/Data/Dialogs/dlgTextEntry_Keyboard_L.xml
@@ -2,7 +2,7 @@
 <PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
   <WndForm Name="frmTextEntry_Keyboard" Type="Dialog" X="0" Y="0" Width="320" Height="240" Caption="_@M251_" Font="2" >
     <WndProperty Name="prpText"  Caption="_@M711_"   X="2" Y="2" Width="294" Height="22" CaptionWidth="60" Font="2" ReadOnly="1" />
-	<WndProperty Name="prpMatch"  Caption="Match:"    X="0" Y="190" Width="90"  Height="33"  CaptionWidth="90" Font="2" ReadOnly="1" />
+	<WndProperty Name="prpMatch"  Caption="Match:"    X="60" Y="190" Width="70"  Height="33"  CaptionWidth="70" Font="2" ReadOnly="1" />
     <WndButton   Caption="_@M228_"    X="280" Y="2" Width="38"  Height="22" Font="2" OnClickNotify="OnDel"/>
     <WndButton   Name="prp1" Caption="1"    X="0"   Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
     <WndButton   Name="prp2" Caption="2"    X="32"  Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
@@ -45,13 +45,64 @@
     <WndButton   Name="prpB"  Caption="B"    X="128" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
     <WndButton   Name="prpN"  Caption="N"    X="160" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
     <WndButton   Name="prpM"  Caption="M"    X="192" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    
+    
+    <WndButton   Name="prp_1" Caption="!"    X="0"   Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_2" Caption="+"    X="32"  Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_3" Caption="$"    X="64"  Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_4" Caption="%"    X="96"  Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_5" Caption="#"    X="128" Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_6" Caption="/"    X="160" Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_7" Caption="("    X="192" Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_8" Caption=")"    X="224" Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>	
+    <WndButton   Name="prp_9" Caption="="    X="256" Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_0" Caption="?"    X="288" Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>	
+	
+    <WndButton   Name="prp_Q"  Caption="q"    X="0"   Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_W"  Caption="w"    X="32"  Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_E"  Caption="e"    X="64"  Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_R"  Caption="r"    X="96"  Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_T"  Caption="t"    X="128" Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_Y"  Caption="y"    X="160" Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_U"  Caption="u"    X="192" Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_I"  Caption="i"    X="224" Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_O"  Caption="o"    X="256" Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_P"  Caption="p"    X="288" Y="64" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+
+	
+    <WndButton   Name="prp_A"  Caption="a"    X="10"   Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_S"  Caption="s"    X="42"  Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_D"  Caption="d"    X="74"  Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_F"  Caption="f"    X="106"  Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_G"  Caption="g"    X="138" Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_H"  Caption="h"    X="170" Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_J"  Caption="j"    X="202" Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_K"  Caption="k"    X="234" Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_L"  Caption="l"    X="266" Y="103" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+ 
+		
+    <WndButton   Name="prp_Z"  Caption="z"    X="0"   Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_X"  Caption="x"    X="32"  Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_C"  Caption="c"    X="64"  Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_V"  Caption="v"    X="96"  Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_B"  Caption="b"    X="128" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_N"  Caption="n"    X="160" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_M"  Caption="m"    X="192" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+        
+    
     <WndButton   Name="prpAt" Caption="@"    X="224" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_At" Caption="*"    X="224" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+     
     <WndButton   Name="prpDot" Caption="."   X="256" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prp_Dot" Caption=":"   X="256" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>    
     <WndButton   Name="prpMin" Caption="-"   X="288" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
-    <!--  <WndButton   Name="prpUn" Caption="_"    X="300" Y="142" Width="30"  Height="39" Font="2" OnClickNotify="OnKey"/>	-->
-    <WndButton   Name="prpDate" Caption="_@M219_" X="0"   Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnDate"/>	
-    <WndButton   Name="prpTime" Caption="_@M720_" X="60"  Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnTime"/>
-    <WndButton   Name="prpSpace" Caption="_@M831_" X="120" Y="181" Width="80"  Height="39" Font="2" OnClickNotify="OnSpace"/>
+    <WndButton   Name="prp_Min" Caption="_"   X="288" Y="142" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>
+ <!--   <WndButton   Name="prpUn" Caption="_"    X="300" Y="142" Width="30"  Height="39" Font="2" OnClickNotify="OnKey"/> -->	
+    <WndButton   Name="prpShift" Caption="Shift" X="0" Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnShift"/>  
+    <WndButton   Name="prpDate" Caption="_@M219_" X="60"   Y="181" Width="40"  Height="39" Font="2" OnClickNotify="OnDate"/>	
+    <WndButton   Name="prpTime" Caption="_@M720_" X="100"  Y="181" Width="40"  Height="39" Font="2" OnClickNotify="OnTime"/>
+      
+    <WndButton   Name="prpSpace" Caption="_@M831_" X="140" Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnSpace"/>
     <WndButton   Name="prpClear" Caption="_@M180_" X="200" Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnClear"/>
     <WndButton   Name="prpOk" Caption="OK" X="260" Y="181" Width="58"  Height="39" Font="2" OnClickNotify="OnOk"/>
   </WndForm>

--- a/Common/Data/Dialogs/dlgTextEntry_Keyboard_L.xml
+++ b/Common/Data/Dialogs/dlgTextEntry_Keyboard_L.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
   <WndForm Name="frmTextEntry_Keyboard" Type="Dialog" X="0" Y="0" Width="320" Height="240" Caption="_@M251_" Font="2" >
-    <WndProperty Name="prpText"  Caption="_@M711_"   X="2" Y="2" Width="294" Height="22" CaptionWidth="40" Font="2" ReadOnly="1" />
+    <WndProperty Name="prpText"  Caption="_@M711_"   X="2" Y="2" Width="294" Height="22" CaptionWidth="60" Font="2" ReadOnly="1" />
 	<WndProperty Name="prpMatch"  Caption="Match:"    X="0" Y="190" Width="90"  Height="33"  CaptionWidth="90" Font="2" ReadOnly="1" />
     <WndButton   Caption="_@M228_"    X="280" Y="2" Width="38"  Height="22" Font="2" OnClickNotify="OnDel"/>
     <WndButton   Name="prp1" Caption="1"    X="0"   Y="25" Width="32"  Height="39" Font="2" OnClickNotify="OnKey"/>

--- a/Common/Data/Dialogs/dlgTextEntry_Keyboard_L.xml
+++ b/Common/Data/Dialogs/dlgTextEntry_Keyboard_L.xml
@@ -51,7 +51,7 @@
     <!--  <WndButton   Name="prpUn" Caption="_"    X="300" Y="142" Width="30"  Height="39" Font="2" OnClickNotify="OnKey"/>	-->
     <WndButton   Name="prpDate" Caption="_@M219_" X="0"   Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnDate"/>	
     <WndButton   Name="prpTime" Caption="_@M720_" X="60"  Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnTime"/>
-    <WndButton   Name="prpSpace" Caption="_@M831_" X="120" Y="181" Width="80"  Height="39" Font="2" OnClickNotify="OnKey"/>
+    <WndButton   Name="prpSpace" Caption="_@M831_" X="120" Y="181" Width="80"  Height="39" Font="2" OnClickNotify="OnSpace"/>
     <WndButton   Name="prpClear" Caption="_@M180_" X="200" Y="181" Width="60"  Height="39" Font="2" OnClickNotify="OnClear"/>
     <WndButton   Name="prpOk" Caption="OK" X="260" Y="181" Width="58"  Height="39" Font="2" OnClickNotify="OnOk"/>
   </WndForm>

--- a/Common/Data/Dialogs/dlgTextEntry_Keyboard_P.xml
+++ b/Common/Data/Dialogs/dlgTextEntry_Keyboard_P.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
   <WndForm Name="frmTextEntry_Keyboard" Type="Dialog" X="0" Y="0" Width="240" Height="320" Caption="_@M251_" Font="2" >
-    <WndProperty Name="prpText"  Caption="_@M711_"   X="2" Y="2" Width="218" Height="22" CaptionWidth="40" Font="2" ReadOnly="1" />
+    <WndProperty Name="prpText"  Caption="_@M711_"   X="2" Y="2" Width="218" Height="22" CaptionWidth="60" Font="2" ReadOnly="1" />
 	<WndProperty Name="prpMatch"  Caption="Match:"   X="0" Y="265" Width="120"  Height="35"  CaptionWidth="120" Font="2" ReadOnly="1" />
     <WndButton   Caption="_@M228_"    X="200" Y="2" Width="40"  Height="22" Font="2" OnClickNotify="OnDel"/>
     <WndButton  Name="prpA" Caption="A"    X="0" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>

--- a/Common/Data/Dialogs/dlgTextEntry_Keyboard_P.xml
+++ b/Common/Data/Dialogs/dlgTextEntry_Keyboard_P.xml
@@ -48,7 +48,7 @@
     <WndButton  Name="prp8" Caption="8"    X="40" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp9"  Caption="9"    X="80" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp0" Caption="0"    X="120" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
-    <WndButton  Name="prpSpace"  Caption="_@M831_"    X="160" Y="230" Width="80"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prpSpace"  Caption="_@M831_"    X="160" Y="230" Width="80"  Height="35" Font="2" OnClickNotify="OnSpace"/>
 
     <WndButton  Name="prpDate" Caption="_@M219_"    X="0" Y="265" Width="60"  Height="35" Font="2" OnClickNotify="OnDate"/>
     <WndButton  Name="prpTime" Caption="_@M720_"    X="60" Y="265" Width="60"  Height="35" Font="2" OnClickNotify="OnTime"/>

--- a/Common/Data/Dialogs/dlgTextEntry_Keyboard_P.xml
+++ b/Common/Data/Dialogs/dlgTextEntry_Keyboard_P.xml
@@ -3,6 +3,7 @@
   <WndForm Name="frmTextEntry_Keyboard" Type="Dialog" X="0" Y="0" Width="240" Height="320" Caption="_@M251_" Font="2" >
     <WndProperty Name="prpText"  Caption="_@M711_"   X="2" Y="2" Width="218" Height="22" CaptionWidth="60" Font="2" ReadOnly="1" />
 	<WndProperty Name="prpMatch"  Caption="Match:"   X="0" Y="265" Width="120"  Height="35"  CaptionWidth="120" Font="2" ReadOnly="1" />
+	<WndButton   Name="prpShift" Caption="Shift" X="0" Y="265" Width="50"  Height="35" Font="2" OnClickNotify="OnShift"/> 
     <WndButton   Caption="_@M228_"    X="200" Y="2" Width="40"  Height="22" Font="2" OnClickNotify="OnDel"/>
     <WndButton  Name="prpA" Caption="A"    X="0" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prpB" Caption="B"    X="40" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
@@ -34,9 +35,12 @@
     <WndButton  Name="prpY" Caption="Y"    X="0" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prpZ" Caption="Z"    X="40" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prpDot" Caption="."    X="80" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_Dot" Caption=":"    X="80" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prpMin" Caption="-"    X="120" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
-    <WndButton  Name="prpUn" Caption="_"    X="160" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_Min" Caption="_"    X="120" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+ <!--   <WndButton  Name="prpUn" Caption="_"    X="160" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/> -->
     <WndButton  Name="prpAt" Caption="@"    X="200" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_At" Caption="*"    X="200" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp1" Caption="1"    X="0" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp2" Caption="2"    X="40" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp3" Caption="3"    X="80" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
@@ -48,11 +52,55 @@
     <WndButton  Name="prp8" Caption="8"    X="40" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp9"  Caption="9"    X="80" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
     <WndButton  Name="prp0" Caption="0"    X="120" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    
+    <WndButton  Name="prp_A" Caption="a"    X="0" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_B" Caption="b"    X="40" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_C" Caption="c"    X="80" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_D" Caption="d"    X="120" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_E" Caption="e"    X="160" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_F" Caption="f"    X="200" Y="25" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+
+    <WndButton  Name="prp_G" Caption="g"    X="0" Y="60" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_H" Caption="h"    X="40" Y="60" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_I" Caption="i"    X="80" Y="60" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_J" Caption="j"    X="120" Y="60" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_K" Caption="k"    X="160" Y="60" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_L" Caption="l"    X="200" Y="60" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+
+    <WndButton  Name="prp_M" Caption="m"    X="0" Y="95" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_N" Caption="n"    X="40" Y="95" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_O" Caption="o"    X="80" Y="95" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_P" Caption="p"    X="120" Y="95" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_Q" Caption="q"    X="160" Y="95" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_R" Caption="r"    X="200" Y="95" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_S" Caption="s"    X="0" Y="130" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_T" Caption="t"    X="40" Y="130" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_U" Caption="u"    X="80" Y="130" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_V" Caption="v"    X="120" Y="130" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_W" Caption="w"    X="160" Y="130" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_X" Caption="x"    X="200" Y="130" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+
+    <WndButton  Name="prp_Y" Caption="y"    X="0" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_Z" Caption="z"    X="40" Y="165" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+
+    <WndButton  Name="prp_1" Caption="!"    X="0" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_2" Caption="+"    X="40" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_3" Caption="$"    X="80" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_4" Caption="%"    X="120" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_5" Caption="#"    X="160" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_6" Caption="/"    X="200" Y="200" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+
+    <WndButton  Name="prp_7" Caption="("    X="0" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_8" Caption=")"    X="40" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_9"  Caption="="    X="80" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    <WndButton  Name="prp_0" Caption="?"    X="120" Y="230" Width="40"  Height="35" Font="2" OnClickNotify="OnKey"/>
+    
+    
     <WndButton  Name="prpSpace"  Caption="_@M831_"    X="160" Y="230" Width="80"  Height="35" Font="2" OnClickNotify="OnSpace"/>
 
-    <WndButton  Name="prpDate" Caption="_@M219_"    X="0" Y="265" Width="60"  Height="35" Font="2" OnClickNotify="OnDate"/>
-    <WndButton  Name="prpTime" Caption="_@M720_"    X="60" Y="265" Width="60"  Height="35" Font="2" OnClickNotify="OnTime"/>
-    <WndButton  Name="prpClear" Caption="_@M180_" X="120" Y="265" Width="60"  Height="35" Font="2" OnClickNotify="OnClear"/>
+    <WndButton  Name="prpDate" Caption="_@M219_"    X="50" Y="265" Width="40"  Height="35" Font="2" OnClickNotify="OnDate"/>
+    <WndButton  Name="prpTime" Caption="_@M720_"    X="90" Y="265" Width="40"  Height="35" Font="2" OnClickNotify="OnTime"/>
+    <WndButton  Name="prpClear" Caption="_@M180_" X="130" Y="265" Width="50"  Height="35" Font="2" OnClickNotify="OnClear"/>
     <WndButton  Name="prpOk" Caption="Ok"   X="180" Y="265" Width="60"  Height="35" Font="2" OnClickNotify="OnOk"/>
   </WndForm>
 </PMML>

--- a/Common/Header/Dialogs.h
+++ b/Common/Header/Dialogs.h
@@ -70,6 +70,7 @@ void dlgWayPointDetailsShowModal(short mypage);
 short dlgWayQuickShowModal(void);
 int  dlgTextEntryShowModal(TCHAR *text, int width=0, bool WPKeyRed= false);
 void dlgNumEntryShowModal(TCHAR *text, int width, bool );
+int  dlgTextEntryShowModalAirspace(TCHAR *text, int width);
 void dlgTeamCodeShowModal(void);
 void dlgStartPointShowModal(void);
 void dlgWaypointEditShowModal(WAYPOINT *wpt);

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -15,6 +15,7 @@
 #include "Dialogs.h"
 #include "Event/Event.h"
 #include "resource.h"
+#include "Sound/Sound.h"
 
 typedef struct{
   CAirspace *airspace;
@@ -75,6 +76,7 @@ static void OnEnableClicked(WndButton* pWnd)
       CAirspace *airspace = AirspaceSelectInfo[i].airspace;
       if (airspace) {
           wf->SetTimerNotify(0,NULL);
+          LKSound(TEXT("LK_TICK.WAV"));
           CAirspaceManager::Instance().PopupAirspaceDetail(airspace);
       }
     }
@@ -106,8 +108,10 @@ if (airspace) {
 
   if(airspace->Enabled())
   {
+      LKSound(TEXT("LK_BEEP0.WAV"));
      CAirspaceManager::Instance().AirspaceDisable(*airspace);
   }else{
+      LKSound(TEXT("LK_BEEP1.WAV"));
      CAirspaceManager::Instance().AirspaceEnable(*airspace);
   }
 

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -704,7 +704,7 @@ static void OnWPSCloseClicked(WndButton* pWnd){
       pForm->SetModalResult(mrCancel);
     }
   }
-
+  wf->SetTimerNotify(0,NULL);
 
 }
 
@@ -830,7 +830,7 @@ void dlgAirspaceSelect(void) {
   }else
         ItemIndex = -1;
 
-  wf->SetTimerNotify(1000, OnTimerNotify);
+  wf->SetTimerNotify(10000, OnTimerNotify);
 
 
 

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -200,7 +200,7 @@ static void PrepareData(void){
   if (NumberOfAirspaces==0) return;
 
 
-  _stprintf(sNameFilter,_T(""));
+  _tcscpy(sNameFilter,_T(""));
   AirspaceSelectInfo = (AirspaceSelectInfo_t*)
     malloc(sizeof(AirspaceSelectInfo_t) * NumberOfAirspaces);
 

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -244,7 +244,7 @@ static void PrepareData(void){
 static void UpdateList(void){
   int i;
  ItemIndex = 0;
-bool  distancemode = true;
+
   UpLimit= NumberOfAirspaces;
   LowLimit =0;
   FullFlag=false;
@@ -261,7 +261,7 @@ bool  distancemode = true;
   }
 
   if (DistanceFilterIdx != 0){
-    distancemode = true;
+
     qsort(AirspaceSelectInfo, UpLimit,
         sizeof(AirspaceSelectInfo_t), AirspaceDistanceCompare);
     for (i=0; i<(int)UpLimit; i++){
@@ -273,7 +273,7 @@ bool  distancemode = true;
   }
 
   if (DirectionFilterIdx != 0){
-    distancemode = true;
+
     qsort(AirspaceSelectInfo, UpLimit,
         sizeof(AirspaceSelectInfo_t), AirspaceDirectionCompare);
     for (i=0; i<UpLimit; i++){
@@ -300,7 +300,7 @@ bool  distancemode = true;
   for (i=0; i<UpLimit; i++){
     // compare entire name which may be more than 4 chars
 
-      LKASSERT(AirspaceSelectInfo[i].Index>=0 && AirspaceSelectInfo[i].Index< NumberOfAirspaces);
+      LKASSERT(i>=0 && i< NumberOfAirspaces);
       LK_tcsncpy(wname,AirspaceSelectInfo[i].airspace->Name() , NAME_SIZE);
       CharUpper(wname);
 
@@ -313,7 +313,7 @@ bool  distancemode = true;
   if (_tcscmp(sTmp, TEXT("")) != 0) { // if it's blanks, then leave UpLimit at end of list
     for (; i<UpLimit; i++){
 
-        LKASSERT(AirspaceSelectInfo[i].Index>=0 && AirspaceSelectInfo[i].Index< NumberOfAirspaces);
+        LKASSERT(i>=0 && i< NumberOfAirspaces);
       LK_tcsncpy(wname,AirspaceSelectInfo[i].airspace->Name(), NAME_SIZE);
       CharUpper(wname);
 
@@ -330,7 +330,7 @@ bool  distancemode = true;
       // now we create a secondary index pointing to this list
       for (i=0, matches=0; i<UpLimit; i++) {
 
-          LKASSERT(AirspaceSelectInfo[i].Index>=0 && AirspaceSelectInfo[i].Index< NumberOfAirspaces);
+          LKASSERT(i>=0 && i< NumberOfAirspaces);
               LK_tcsncpy(wname,AirspaceSelectInfo[i].airspace->Name(), NAME_SIZE);
               CharUpper(wname);
 

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -31,16 +31,19 @@ static double Longitude;
 static WndForm *wf=NULL;
 static WndListFrame *wAirspaceList=NULL;
 static WndOwnerDrawFrame *wAirspaceListEntry = NULL;
-
-static const TCHAR NameFilter[] = TEXT("*ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_");
+#define NAMEFILTERLEN 10
+static TCHAR sNameFilter[NAMEFILTERLEN+1];
+static WndButton *wpnewName = NULL;
 static unsigned NameFilterIdx=0;
+
+static bool FullFlag=false; // 100502
 
 static const double DistanceFilter[] = {0.0, 25.0, 50.0, 75.0, 100.0, 150.0, 
                                   250.0, 500.0, 1000.0};
 static unsigned DistanceFilterIdx=0;
 
 #define DirHDG -1
-
+static int *StrIndex=NULL;
 static const int DirectionFilter[] = {0, DirHDG, 360, 30, 60, 90, 120, 150, 
                                 180, 210, 240, 270, 300, 330};
 static unsigned DirectionFilterIdx=0;
@@ -57,31 +60,63 @@ static int ItemIndex = -1;
 
 static AirspaceSelectInfo_t *AirspaceSelectInfo=NULL;
 
-static void OnAirspaceListEnter(WindowControl * Sender, 
-				WndListFrame::ListInfo_t *ListInfo){
-  (void)Sender; (void)ListInfo;
+
+
+
+static void OnEnableClicked(WndButton* pWnd)
+{
 
   if (ItemIndex != -1) {
-
+     const size_t i = (FullFlag) ? StrIndex[LowLimit + ItemIndex] : (LowLimit + ItemIndex);
     if ((UpLimit-LowLimit>0)
         && (ItemIndex >= 0)  // JMW fixed bug, was >0
         && (ItemIndex < (UpLimit - LowLimit))) {
 
-      CAirspace *airspace = AirspaceSelectInfo[LowLimit+ItemIndex].airspace;
+      CAirspace *airspace = AirspaceSelectInfo[i].airspace;
       if (airspace) {
           wf->SetTimerNotify(0,NULL);
           CAirspaceManager::Instance().PopupAirspaceDetail(airspace);
       }
     }
   } else {
-    if(Sender) {
-      WndForm * pForm = Sender->GetParentWndForm();
+    if(pWnd) {
+      WndForm * pForm = pWnd->GetParentWndForm();
       if(pForm) {
         pForm->SetModalResult(mrCancel);
       }
     }    
   }
 }
+
+
+
+
+
+static void OnAirspaceListEnter(WindowControl * Sender,  WndListFrame::ListInfo_t *ListInfo)
+{
+
+if (ItemIndex != -1) {
+
+if ((UpLimit-LowLimit>0)
+&& (ItemIndex >= 0)  // JMW fixed bug, was >0
+&& (ItemIndex < (UpLimit - LowLimit))) {
+const size_t i = (FullFlag) ? StrIndex[LowLimit + ItemIndex] : (LowLimit + ItemIndex);
+CAirspace *airspace = AirspaceSelectInfo[i].airspace;
+if (airspace) {
+
+  if(airspace->Enabled())
+  {
+     CAirspaceManager::Instance().AirspaceDisable(*airspace);
+  }else{
+     CAirspaceManager::Instance().AirspaceEnable(*airspace);
+  }
+
+}
+}
+}
+}
+
+
 
 static int AirspaceNameCompare(const void *elem1, const void *elem2 ){
   if (((const AirspaceSelectInfo_t *)elem1)->FourChars < ((const AirspaceSelectInfo_t *)elem2)->FourChars)
@@ -154,12 +189,21 @@ static void PrepareData(void){
 
   if (NumberOfAirspaces==0) return;
 
+
+  _stprintf(sNameFilter,_T(""));
   AirspaceSelectInfo = (AirspaceSelectInfo_t*)
     malloc(sizeof(AirspaceSelectInfo_t) * NumberOfAirspaces);
 
   if (AirspaceSelectInfo==NULL) {
 	OutOfMemory(_T(__FILE__),__LINE__);
 	return;
+  }
+
+  StrIndex = (int*)malloc(sizeof(int)*(NumberOfAirspaces+1));
+  if (StrIndex==NULL) {
+        OutOfMemory(_T(__FILE__),__LINE__);
+
+        return;
   }
 
   int index=0;
@@ -194,17 +238,16 @@ static void PrepareData(void){
 
 }
 
+
+
+
 static void UpdateList(void){
-
-//  TCHAR sTmp[128];
   int i;
-  bool distancemode = false;
-
-  ItemIndex = 0;
-
+ ItemIndex = 0;
+bool  distancemode = true;
   UpLimit= NumberOfAirspaces;
   LowLimit =0;
-
+  FullFlag=false;
   if (TypeFilterIdx>0) {
 
     qsort(AirspaceSelectInfo, NumberOfAirspaces,
@@ -241,36 +284,73 @@ static void UpdateList(void){
     }
   }
 
-  if (NameFilterIdx != 0){
-    TCHAR sTmp[8];
-    LowLimit = UpLimit;
-    qsort(AirspaceSelectInfo, UpLimit,
-        sizeof(AirspaceSelectInfo_t), AirspaceNameCompare);
-    sTmp[0] = NameFilter[NameFilterIdx];
-    sTmp[1] = '\0';
-    sTmp[2] = '\0';
-    CharUpper(sTmp);
-    for (i=0; i<UpLimit; i++){
-      if ((BYTE)(AirspaceSelectInfo[i].FourChars >> 24) >= (sTmp[0]&0xff)){
-        LowLimit = i;
-        break;
-      }
-    }
 
+  TCHAR sTmp[NAMEFILTERLEN+1];
+  TCHAR wname[NAME_SIZE+1];
+  LowLimit = UpLimit;
+  qsort(AirspaceSelectInfo, UpLimit,
+      sizeof(AirspaceSelectInfo_t), AirspaceNameCompare);
+
+  LK_tcsncpy(sTmp,sNameFilter, NAMEFILTERLEN);
+  CharUpper(sTmp);
+  int iFilterLen = _tcslen(sNameFilter);
+
+  if (iFilterLen<GC_SUB_STRING_THRESHOLD)
+  {
+  for (i=0; i<UpLimit; i++){
+    // compare entire name which may be more than 4 chars
+
+      LKASSERT(AirspaceSelectInfo[i].Index>=0 && AirspaceSelectInfo[i].Index< NumberOfAirspaces);
+      LK_tcsncpy(wname,AirspaceSelectInfo[i].airspace->Name() , NAME_SIZE);
+      CharUpper(wname);
+
+    if (_tcsnicmp(wname,sTmp,iFilterLen) >= 0) {
+      LowLimit = i;
+      break;
+    }
+  }
+
+  if (_tcscmp(sTmp, TEXT("")) != 0) { // if it's blanks, then leave UpLimit at end of list
     for (; i<UpLimit; i++){
-      if ((BYTE)(AirspaceSelectInfo[i].FourChars >> 24) != (sTmp[0]&0xff)){
+
+        LKASSERT(AirspaceSelectInfo[i].Index>=0 && AirspaceSelectInfo[i].Index< NumberOfAirspaces);
+      LK_tcsncpy(wname,AirspaceSelectInfo[i].airspace->Name(), NAME_SIZE);
+      CharUpper(wname);
+
+      if (_tcsnicmp(wname,sTmp,iFilterLen) != 0) {
         UpLimit = i;
         break;
       }
     }
   }
+  } else { // iFilterLen>3, fulltext search 100502
+      FullFlag=true;
+      int matches=0;
+      // the AirspaceSelectInfo list has been sorted by filters, and then sorted by name. 0-UpLimit is the size.
+      // now we create a secondary index pointing to this list
+      for (i=0, matches=0; i<UpLimit; i++) {
 
-  if (!distancemode) {
-    qsort(&AirspaceSelectInfo[LowLimit], UpLimit-LowLimit,
-	  sizeof(AirspaceSelectInfo_t), AirspaceNameCompare);
-  } else {
-    qsort(&AirspaceSelectInfo[LowLimit], UpLimit-LowLimit,
-	  sizeof(AirspaceSelectInfo_t), AirspaceDistanceCompare);
+          LKASSERT(AirspaceSelectInfo[i].Index>=0 && AirspaceSelectInfo[i].Index< NumberOfAirspaces);
+              LK_tcsncpy(wname,AirspaceSelectInfo[i].airspace->Name(), NAME_SIZE);
+              CharUpper(wname);
+
+              if ( _tcsstr(  wname,sTmp ) ) {
+                      StrIndex[matches++]=i;
+              }
+      }
+      // No need to set flag if no results
+      if (matches>0) {
+              LowLimit=0;
+              UpLimit=matches;
+/*
+              for (i=0; i<UpLimit; i++)
+                      StartupStore(_T("StrIndex[%d] = %d <%s>\n"), i, StrIndex[i], WayPointList[WayPointSelectInfo[StrIndex[i]].Index].Name);
+*/
+      } else {
+              LowLimit=0;
+              UpLimit=0;
+      }
+
   }
 
   wAirspaceList->ResetList();
@@ -279,7 +359,8 @@ static void UpdateList(void){
 }
 
 
-static WndProperty *wpName;
+
+//static WndProperty *wpName;
 static WndProperty *wpDistance;
 static WndProperty *wpDirection;
 
@@ -298,57 +379,96 @@ static void FilterMode(bool direction) {
     }
   } else {
     NameFilterIdx=0;
-    if (wpName) {
+/*    if (wpName) {
       wpName->GetDataField()->Set(TEXT("**"));
       wpName->RefreshDisplay();
-    }
+    }*/
   }
 }
 
 
+static void SetNameCaption(const TCHAR* tFilter) {
 
-static void OnFilterName(DataField *Sender, DataField::DataAccessKind_t Mode){
+  TCHAR namfilter[50];
+  if ( _tcscmp(tFilter,_T("*")) == 0)
+        _tcscpy(namfilter,_T("*"));
+  else {
+        if (_tcslen(tFilter) <GC_SUB_STRING_THRESHOLD)
+                _stprintf(namfilter,_T("%s*"),tFilter);
+        else
+          {
+                if (_tcslen(tFilter) <6)
+                        _stprintf(namfilter,_T("*%s*"),tFilter);
+                else {
+                        _tcscpy(namfilter,_T("*"));
+                        _tcsncat(namfilter,tFilter,5);
+                        namfilter[5]='\0';
+                        _tcscat(namfilter,_T("..*"));
+                }
+        }
 
-  TCHAR sTmp[12];
-  int siz;
+  }
+//  StartupStore(_T("SETCAPTION <%s>\n"),namfilter);
+  wpnewName->SetCaption(namfilter);
 
-  switch(Mode){
-    case DataField::daGet:
-    break;
-    case DataField::daPut:
-    break;
-    case DataField::daChange:
-    break;
-    case DataField::daInc:
-      NameFilterIdx++;
-	siz=sizeof(NameFilter[0]);
-	LKASSERT(siz>0);
-      if (siz>0) // 100101
-      if (NameFilterIdx > sizeof(NameFilter)/sizeof(NameFilter[0])-2)
-        NameFilterIdx = 1;
-      FilterMode(true);
-      UpdateList();
-    break;
-    case DataField::daDec:
-      if (NameFilterIdx == 0) {
-	siz=sizeof(NameFilter[0]);
-	LKASSERT(siz>0);
-        if (siz>0) // 100101
-		NameFilterIdx = sizeof(NameFilter)/sizeof(NameFilter[0])-1;
+}
+
+static void OnFilterName(WndButton* pWnd) {
+
+  int SelectedAsp=-1;
+  int CursorPos=0;
+TCHAR newNameFilter[NAMEFILTERLEN+1];
+
+LK_tcsncpy(newNameFilter, sNameFilter, NAMEFILTERLEN);
+SelectedAsp =  dlgTextEntryShowModalAirspace(newNameFilter, NAMEFILTERLEN);
+
+
+
+int i= _tcslen(newNameFilter)-1;
+while (i>=0) {
+ if (newNameFilter[i]!=_T(' ')) {
+         break;
+ }
+ newNameFilter[i]=0;
+ i--;
+};
+
+LK_tcsncpy(sNameFilter, newNameFilter, NAMEFILTERLEN);
+
+
+if (wpnewName) {
+      if (sNameFilter[0]=='\0') {
+          SetNameCaption(TEXT("*"));
+      } else {
+          SetNameCaption(sNameFilter);
       }
-      else
-        NameFilterIdx--;
-      FilterMode(true);
-      UpdateList();
-    break;
-  case DataField::daSpecial:
-    break;
-  }
-
-  _stprintf(sTmp, TEXT("%c*"), NameFilter[NameFilterIdx]);
-  Sender->Set(sTmp);
-
 }
+
+FilterMode(true);
+UpdateList();
+
+if((SelectedAsp>=0) && (SelectedAsp < NumberOfAirspaces))
+{
+    CursorPos = SelectedAsp;
+    /*
+ for (i=0; i<UpLimit; i++)
+ {
+
+     if(AirspaceSelectInfo[i].Index == SelectedAsp)
+     {
+           CursorPos = i;
+     }
+     */
+ }
+
+
+ wAirspaceList->SetFocus();
+wAirspaceList->SetItemIndexPos(CursorPos);
+wAirspaceList->Redraw();
+}
+
+
+
 
 
 
@@ -494,66 +614,72 @@ static void OnFilterType(DataField *Sender,
 
 }
 
-static int DrawListIndex=0;
 
-static void OnPaintListItem(WindowControl * Sender, LKSurface& Surface){
-  (void)Sender;
-  int n = UpLimit - LowLimit;
-  TCHAR sTmp[12];
 
-  if (DrawListIndex < n){
+static unsigned int DrawListIndex=0;
 
-    int i = LowLimit + DrawListIndex;
+// Painting elements after init
+
+static void OnPaintListItem(WindowControl * Sender, LKSurface& Surface) {
+    if (!Sender) {
+        return;
+    }
+
+    unsigned int n = UpLimit - LowLimit;
+    TCHAR sTmp[50];
 
     Surface.SetTextColor(RGB_BLACK);
 
-// Poco::Thread::sleep(100);
-	const TCHAR *Name = NULL;
-	if (AirspaceSelectInfo[i].airspace) Name = AirspaceSelectInfo[i].airspace->Name();
-    if (Name) {
-      const PixelRect rcClient(Sender->GetClientRect());
-      const int w0 = rcClient.GetSize().cx;
-      const int w1 = Surface.GetTextWidth(TEXT("XXX")) + DLGSCALE(2);
-      
-      _stprintf(sTmp, TEXT(" 000%s"), Units::GetDistanceName());
-      const int w2 = Surface.GetTextWidth(sTmp) + DLGSCALE(2);
-      
-      _stprintf(sTmp, _T(" -000%s"), MsgToken(2179));
-      const int w3 = Surface.GetTextWidth(sTmp) + DLGSCALE(2);
-      
-      const int x1 = w0-w1-w2-w3;
+    const int LineHeight = Sender->GetHeight();
+    const int TextHeight = Surface.GetTextHeight(_T("dp"));
 
-      Surface.DrawTextClip(DLGSCALE(2), DLGSCALE(2), Name, x1-DLGSCALE(5));
-      
-      sTmp[0] = '\0';
-      sTmp[1] = '\0';
-      sTmp[2] = '\0';
-	  LK_tcsncpy(sTmp, CAirspaceManager::GetAirspaceTypeShortText(AirspaceSelectInfo[i].Type), 4);
-      // left justified
-     
-      Surface.DrawText(x1, DLGSCALE(2), sTmp);
+    const int TextPos = (LineHeight - TextHeight) / 2; // offset for text vertical center
 
-      // right justified after airspace type
-      _stprintf(sTmp, TEXT("%.0f%s"), AirspaceSelectInfo[i].Distance, Units::GetDistanceName());
-      const int x2 = w0-w3-Surface.GetTextWidth(sTmp);
-      Surface.DrawText(x2, DLGSCALE(2), sTmp);
-      
-      // right justified after distance
-      _stprintf(sTmp, TEXT("%d%s"),  iround(AirspaceSelectInfo[i].Direction), MsgToken(2179));
-      const int x3 = w0-Surface.GetTextWidth(sTmp);
-      Surface.DrawText(x3, DLGSCALE(2), sTmp);
+    if (DrawListIndex < n) {
+
+        const size_t i = (FullFlag) ? StrIndex[LowLimit + DrawListIndex] : (LowLimit + DrawListIndex);
+
+        // Poco::Thread::sleep(100);
+
+        const int width = Sender->GetWidth(); // total width
+
+        const int w0 = LineHeight; // Picto Width
+        const int w2 = Surface.GetTextWidth(TEXT(" 000km")); // distance Width
+        _stprintf(sTmp, _T(" 000%s "), MsgToken(2179));
+        const int w3 = Surface.GetTextWidth(sTmp); // bearing width
+
+        const int w1 = width - w0 - 2*w2 - w3; // Max Name width
+
+        // Draw Picto
+        const RECT PictoRect = {0, 0, w0, LineHeight};
+
+        AirspaceSelectInfo[i].airspace->DrawPicto(Surface, PictoRect);
+
+
+        // Draw Name
+        Surface.DrawTextClip(w0, TextPos, AirspaceSelectInfo[i].airspace->Name() , w1);
+
+        LK_tcsncpy(sTmp,  CAirspaceManager::GetAirspaceTypeShortText(AirspaceSelectInfo[i].Type) , 4);
+        const int w4 = Surface.GetTextWidth(sTmp);
+
+        Surface.DrawTextClip(w1+w2, TextPos, sTmp,w4);
+
+        // Draw Distance : right justified after waypoint Name
+        _stprintf(sTmp, TEXT("%.0f%s"), AirspaceSelectInfo[i].Distance  , Units::GetDistanceName());
+        const int x2 = width - w3 - Surface.GetTextWidth(sTmp);
+        Surface.DrawText(x2, TextPos, sTmp);
+
+        // Draw Bearing right justified after distance
+        _stprintf(sTmp, TEXT("%d%s"), iround(AirspaceSelectInfo[i].Direction), MsgToken(2179));
+        const int x3 = width - Surface.GetTextWidth(sTmp);
+        Surface.DrawText(x3, TextPos, sTmp);
     } else {
-      // should never get here!
+        if (DrawListIndex == 0) {
+            // LKTOKEN  _@M466_ = "No Match!"
+            Surface.DrawText(IBLSCALE(2), TextPos, MsgToken(466));
+        }
     }
-  } else {
-    if (DrawListIndex == 0){
-      Surface.SetTextColor(RGB_BLACK);
-	// LKTOKEN  _@M466_ = "No Match!" 
-      Surface.DrawText(DLGSCALE(2), DLGSCALE(2), MsgToken(466));
-    }
-  }
 }
-
 // DrawListIndex = number of things to draw
 // ItemIndex = current selected item
 
@@ -578,7 +704,12 @@ static void OnWPSCloseClicked(WndButton* pWnd){
       pForm->SetModalResult(mrCancel);
     }
   }
+
+
 }
+
+
+
 
 static bool OnTimerNotify(WndForm* pWnd) {
   if (DirectionFilterIdx == 1){
@@ -624,7 +755,6 @@ static bool FormKeyDown(WndForm* pWnd, unsigned KeyCode){
 }
 
 static CallBackTableEntry_t CallBackTable[]={
-  DataAccessCallbackEntry(OnFilterName),
   DataAccessCallbackEntry(OnFilterDistance),
   DataAccessCallbackEntry(OnFilterDirection),
   DataAccessCallbackEntry(OnFilterType),
@@ -636,7 +766,7 @@ static CallBackTableEntry_t CallBackTable[]={
 
 void dlgAirspaceSelect(void) {
 
-  StartHourglassCursor();
+//  StartHourglassCursor();
 
   UpLimit = 0;
   LowLimit = 0;
@@ -656,6 +786,16 @@ void dlgAirspaceSelect(void) {
    FindByName(TEXT("cmdClose")))->
     SetOnClickNotify(OnWPSCloseClicked);
 
+  ((WndButton *)wf->
+   FindByName(TEXT("cmdSelect")))->
+    SetOnClickNotify(OnEnableClicked);
+
+  ((WndButton *)wf->
+   FindByName(TEXT("cmdName")))->
+    SetOnClickNotify(OnFilterName);
+
+  wpnewName = (WndButton*)wf->FindByName(TEXT("cmdName"));
+
   wAirspaceList = (WndListFrame*)wf->FindByName(TEXT("frmAirspaceList"));
   LKASSERT(wAirspaceList!=NULL);
   wAirspaceList->SetBorderKind(BORDERLEFT);
@@ -666,26 +806,41 @@ void dlgAirspaceSelect(void) {
   LKASSERT(wAirspaceListEntry!=NULL);
   wAirspaceListEntry->SetCanFocus(true);
 
-  wpName = (WndProperty*)wf->FindByName(TEXT("prpFltName"));
+//  wpName = (WndProperty*)wf->FindByName(TEXT("prpFltName"));
+
   wpDistance = (WndProperty*)wf->FindByName(TEXT("prpFltDistance"));
   wpDirection = (WndProperty*)wf->FindByName(TEXT("prpFltDirection"));
 
   PrepareData();
+
   if (AirspaceSelectInfo==NULL){
 	StopHourglassCursor();
 	goto _return;
   }
   UpdateList();
 
+
+  if ((wf->ShowModal() == mrOK) && (UpLimit - LowLimit > 0) && (ItemIndex >= 0)
+   && (ItemIndex < (UpLimit - LowLimit))) {
+
+        if (FullFlag)
+                ItemIndex = StrIndex[LowLimit + ItemIndex];
+        else
+                ItemIndex = LowLimit + ItemIndex;
+  }else
+        ItemIndex = -1;
+
   wf->SetTimerNotify(1000, OnTimerNotify);
 
-  StopHourglassCursor();
-  wf->ShowModal();
+
 
 _return:
   if (AirspaceSelectInfo!=NULL) free(AirspaceSelectInfo);
+  if (StrIndex!=NULL) free(StrIndex);
+  StrIndex = NULL;
   delete wf;
   wf = NULL;
+
   return;
 
 }

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -614,7 +614,7 @@ static void OnFilterType(DataField *Sender,
     break;
     case DataField::daInc:
       TypeFilterIdx++;
-      if (TypeFilterIdx > AIRSPACECLASSCOUNT) TypeFilterIdx = 0;		//Need to limit+1 because idx shifted with +1
+      if (TypeFilterIdx > (AIRSPACECLASSCOUNT+1)) TypeFilterIdx = 0;		//Need to limit+1 because idx shifted with +1
       FilterMode(false);
       UpdateList();
     break;

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -199,8 +199,7 @@ static void PrepareData(void){
 
   if (NumberOfAirspaces==0) return;
 
-
-  _tcscpy(sNameFilter,_T(""));
+  sNameFilter[0] =_T('\0');
   AirspaceSelectInfo = (AirspaceSelectInfo_t*)
     malloc(sizeof(AirspaceSelectInfo_t) * NumberOfAirspaces);
 

--- a/Common/Source/Dialogs/dlgAirspaceSelect.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceSelect.cpp
@@ -631,10 +631,10 @@ static void OnFilterType(DataField *Sender,
   }
 
   if (TypeFilterIdx>0) {
-      if( TypeFilterIdx == AIRSPACECLASSCOUNT+1)
-        _tcscpy(sTmp, MsgToken(239));
-      else
-	LK_tcsncpy(sTmp, CAirspaceManager::GetAirspaceTypeText(TypeFilterIdx-1), sizeof(sTmp)/sizeof(sTmp[0])-1);
+    if( TypeFilterIdx == AIRSPACECLASSCOUNT+1)
+      _tcscpy(sTmp, MsgToken(239));
+    else
+      LK_tcsncpy(sTmp, CAirspaceManager::GetAirspaceTypeText(TypeFilterIdx-1), sizeof(sTmp)/sizeof(sTmp[0])-1);
   } else {
 	_tcscpy(sTmp, TEXT("*"));
   }

--- a/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
+++ b/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
@@ -32,21 +32,28 @@ void RemoveKeys(char *EnabledKeyString, unsigned char size);
 #define KEYRED_NONE     0
 #define KEYRED_WAYPOINT 1
 #define KEYRED_AIRSPACE 2
-
+#define MAX_SEL_LIST_SIZE       120
+#define NO_LAYOUTS 2
+#define UPPERCASE 0
+#define LOWERCASE 1
+uint8_t  KeyboardLayout =LOWERCASE;
 uint8_t  WaypointKeyRed = KEYRED_NONE;
 
  int IdenticalIndex=-1;
  int IdenticalOffset = 0;
 
+
 char ToUpper(char in)
 {
+  return in;
+/*
 	if(in == '\xD6') return '\xD6'; // Ö -> Ö
 	if(in == '\xDC') return '\xDC'; // Ü -> Ü
 	if(in == '\xC4') return '\xC4'; // Ä -> Ä
 	if(in == '\xF6') return '\xD6'; // ö -> Ö
 	if(in == '\xFC') return '\xDC'; // ü -> Ü
-	if(in == '\xE4') return '\xC4'; // ä -> Ä
-	return toupper(in);
+	if(in == '\xE4') return '\xC4'; // ä -> Ä*/
+//	return toupper(in);
 }
 
 static void UpdateTextboxProp(void)
@@ -100,6 +107,13 @@ static void UpdateTextboxProp(void)
     wp = (WndProperty*)wf->FindByName(TEXT("prpMatch")); 
     if(WaypointKeyRed == KEYRED_NONE)
     {
+   //   if(cursor < GC_SUB_STRING_THRESHOLD/*1*/)   /* enable all keys if no char entered */
+      {
+
+       char Charlist[MAX_SEL_LIST_SIZE]={"abcdefghijklmnopqrstuvwxyz?!+$%#/()=:*_ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.@- \xD6\xDC\xC4"};
+
+        RemoveKeys((char*)Charlist , sizeof(Charlist));
+      }
       if(wp != NULL) wp->SetVisible(false);
     }
     else
@@ -154,6 +168,16 @@ static void OnKey(WndButton* pWnd) {
     if (cursor < max_width - 1) {
         edittext[cursor++] = ToUpper(Caption[0]);
     }
+    UpdateTextboxProp();
+}
+
+
+static void OnShift(WndButton* pWnd) {
+    LKASSERT(pWnd);
+    if(!pWnd) return;
+
+    KeyboardLayout++;
+    KeyboardLayout %= NO_LAYOUTS;
     UpdateTextboxProp();
 }
 
@@ -256,6 +280,7 @@ static CallBackTableEntry_t CallBackTable[]={
   ClickNotifyCallbackEntry(OnOk),
   ClickNotifyCallbackEntry(OnDel),
   ClickNotifyCallbackEntry(OnSpace),
+  ClickNotifyCallbackEntry(OnShift),
   ClickNotifyCallbackEntry(OnDate),
   ClickNotifyCallbackEntry(OnTime),
   OnHelpCallbackEntry(OnHelpClicked),
@@ -276,7 +301,7 @@ void dlgTextEntryKeyboardShowModal(TCHAR *text, int width, unsigned ResID)
   ClearText();
 
   if (_tcslen(text)>0) {
-    CharUpper(text);
+  //  CharUpper(text);
     LK_tcsncpy(edittext, text, max_width-1);
     // show previous test.
     // this text is replaced by first key down
@@ -342,11 +367,13 @@ BOOL dlgKeyboard(WndProperty* theProperty){
 
 void ReduceKeysByWaypointList(void)
 {
-#define MAX_SEL_LIST_SIZE	60
+
 char SelList[MAX_SEL_LIST_SIZE]={""};
 unsigned int NumChar=0;
 bool CharEqual = true;
-char Charlist[MAX_SEL_LIST_SIZE]={"ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.@-_ \xD6\xDC\xC4"};
+
+char Charlist[MAX_SEL_LIST_SIZE]={"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.@-_?!+$%#/()=:* \xD6\xDC\xC4"};
+
 
 unsigned int i,j,EqCnt=WayPointList.size();
 
@@ -361,7 +388,7 @@ IdenticalOffset =999;
 IdenticalIndex = -1;
   if(cursor < GC_SUB_STRING_THRESHOLD/*1*/)   /* enable all keys if no char entered */
   {
-    RemoveKeys((char*)Charlist, sizeof(Charlist));
+    RemoveKeys((char*)Charlist , sizeof(Charlist));
   }
   else
   {
@@ -385,7 +412,7 @@ IdenticalIndex = -1;
             LKASSERT((k+Offset) < NameLen);
             TCHAR ac = (TCHAR)WayPointList[i].Name[k+Offset];
             TCHAR bc = (TCHAR)edittext[k];
-            if(  ToUpper(ac) !=   ToUpper(bc) ) /* waypoint has string ?*/
+            if(  toupper(ac) !=   toupper(bc) ) /* waypoint has string ?*/
             {
               CharEqual = false;
             }
@@ -426,7 +453,8 @@ IdenticalIndex = -1;
         {
      //     StartupStore(_T(". j=%i  MAX_SEL_LIST_SIZE= %i\n"),j,MAX_SEL_LIST_SIZE);
           LKASSERT(NumChar<MAX_SEL_LIST_SIZE);
-          SelList[NumChar++] = newChar;
+          SelList[NumChar++] = toupper(newChar);
+          SelList[NumChar++] = tolower(newChar);
         }
       }
     }
@@ -476,11 +504,11 @@ const CAirspaceList CAirspaceManager::GetAllAirspaces() const {
 **********************************************************************************/
 void ReduceKeysByAirspaceList(void)
 {
-#define MAX_SEL_LIST_SIZE       60
 char SelList[MAX_SEL_LIST_SIZE]={""};
 unsigned int NumChar=0;
 bool CharEqual = true;
-char Charlist[MAX_SEL_LIST_SIZE]={"ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.@-_ \xD6\xDC\xC4"};
+char Charlist[MAX_SEL_LIST_SIZE]={"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.@-_?!+$%#/()=:* \xD6\xDC\xC4"};
+
 
 unsigned int i,j,EqCnt=WayPointList.size();
 
@@ -499,7 +527,8 @@ TCHAR AS_Name[255];
 
   if(cursor < GC_SUB_STRING_THRESHOLD/*1*/)   /* enable all keys if no char entered */
   {
-    RemoveKeys((char*)Charlist, sizeof(Charlist));
+  //  RemoveKeys((char*)Charlist, sizeof(Charlist));
+    RemoveKeys((char*)Charlist , sizeof(Charlist));
   }
   else
   {
@@ -530,7 +559,7 @@ TCHAR AS_Name[255];
             LKASSERT((k+Offset) < NameLen);
             TCHAR ac = (TCHAR)AS_Name[k+Offset];
             TCHAR bc = (TCHAR)edittext[k];
-            if(  ToUpper(ac) !=   ToUpper(bc) ) /* waypoint has string ?*/
+            if(  toupper(ac) !=   toupper(bc) ) /* waypoint has string ?*/
             {
               CharEqual = false;
             }
@@ -571,7 +600,8 @@ TCHAR AS_Name[255];
         {
      //     StartupStore(_T(". j=%i  MAX_SEL_LIST_SIZE= %i\n"),j,MAX_SEL_LIST_SIZE);
           LKASSERT(NumChar<MAX_SEL_LIST_SIZE);
-          SelList[NumChar++] = newChar;
+          SelList[NumChar++] = toupper(newChar);
+          SelList[NumChar++] = tolower(newChar);
         }
       }
     }
@@ -616,43 +646,53 @@ void RemoveKeys(char *EnabledKeyString, unsigned char size)
 {
 
 bool bA=false, bB=false, bC=false, bD=false, bE=false, bF=false, bG=false, bH=false, bI=false,
-	 bJ=false, bK=false, bL=false, bM=false, bN=false, bO=false, bP=false, bQ=false, bR=false,
-	 bS=false, bT=false, bU=false, bV=false, bW=false, bX=false, bY=false, bZ=false, b0=false,
-	 b1=false, b2=false, b3=false, b4=false, b5=false, b6=false, b7=false, b8=false, b9=false,
-	 bUe=false, bOe=false, bAe=false, bDot=false, bMin=false, bAt=false,  bUn=false,  bSpace=false ;
+     bJ=false, bK=false, bL=false, bM=false, bN=false, bO=false, bP=false, bQ=false, bR=false,
+     bS=false, bT=false, bU=false, bV=false, bW=false, bX=false, bY=false, bZ=false, b0=false,
+     b1=false, b2=false, b3=false, b4=false, b5=false, b6=false, b7=false, b8=false, b9=false,
+
+     b_A=false, b_B=false, b_C=false, b_D=false, b_E=false, b_F=false, b_G=false, b_H=false, b_I=false,
+     b_J=false, b_K=false, b_L=false, b_M=false, b_N=false, b_O=false, b_P=false, b_Q=false, b_R=false,
+     b_S=false, b_T=false, b_U=false, b_V=false, b_W=false, b_X=false, b_Y=false, b_Z=false, b_0=false,
+     b_1=false, b_2=false, b_3=false, b_4=false, b_5=false, b_6=false, b_7=false, b_8=false, b_9=false,
+
+     bUe=false, bOe=false, bAe=false, bDot=false, bMin=false, bAt=false,  bSpace=false ,
+     b_Dot=false, b_Min=false, b_At=false ;
 
 unsigned int i=0;
 
-  for (i = 0; i < size; i++ )
-  {
+
+    if(KeyboardLayout == UPPERCASE)
+    {
+      for (i = 0; i < size; i++ )
+      {
 	switch  (EnabledKeyString[i])
 	{
-	  case 'a': case 'A': bA = true; break;
-	  case 'b': case 'B': bB = true; break;
-	  case 'c': case 'C': bC = true; break;
-	  case 'd': case 'D': bD = true; break;
-	  case 'e': case 'E': bE = true; break;
-	  case 'f': case 'F': bF = true; break;
-	  case 'g': case 'G': bG = true; break;
-	  case 'h': case 'H': bH = true; break;
-	  case 'i': case 'I': bI = true; break;
-	  case 'j': case 'J': bJ = true; break;
-	  case 'k': case 'K': bK = true; break;
-	  case 'l': case 'L': bL = true; break;
-	  case 'm': case 'M': bM = true; break;
-	  case 'n': case 'N': bN = true; break;
-	  case 'o': case 'O': bO = true; break;
-	  case 'p': case 'P': bP = true; break;
-	  case 'q': case 'Q': bQ = true; break;
-	  case 'r': case 'R': bR = true; break;
-	  case 's': case 'S': bS = true; break;
-	  case 't': case 'T': bT = true; break;
-	  case 'u': case 'U': bU = true; break;
-	  case 'v': case 'V': bV = true; break;
-	  case 'w': case 'W': bW = true; break;
-	  case 'x': case 'X': bX = true; break;
-	  case 'y': case 'Y': bY = true; break;
-	  case 'z': case 'Z': bZ = true; break;
+	  case 'A': bA = true; break;
+	  case 'B': bB = true; break;
+	  case 'C': bC = true; break;
+	  case 'D': bD = true; break;
+	  case 'E': bE = true; break;
+	  case 'F': bF = true; break;
+	  case 'G': bG = true; break;
+	  case 'H': bH = true; break;
+	  case 'I': bI = true; break;
+	  case 'J': bJ = true; break;
+	  case 'K': bK = true; break;
+	  case 'L': bL = true; break;
+	  case 'M': bM = true; break;
+	  case 'N': bN = true; break;
+	  case 'O': bO = true; break;
+	  case 'P': bP = true; break;
+	  case 'Q': bQ = true; break;
+	  case 'R': bR = true; break;
+	  case 'S': bS = true; break;
+	  case 'T': bT = true; break;
+	  case 'U': bU = true; break;
+	  case 'V': bV = true; break;
+	  case 'W': bW = true; break;
+	  case 'X': bX = true; break;
+	  case 'Y': bY = true; break;
+	  case 'Z': bZ = true; break;
 /*
 	  case '\xF6': case '\xD6': bUe = true; break;    // ü Ü
 	  case '\xFC': case '\xDC': bOe = true; break;  //ö Ö
@@ -672,15 +712,75 @@ unsigned int i=0;
 	  case '.':  bDot = true; break;
 	  case '-':  bMin = true; break;
 	  case '@':  bAt  = true; break;
-	  case '_':  bUn  = true; break;
 	  case ' ':  bSpace = true; break;
 
 	  default: break;
 	}
-  }
+      }
+    }
+
+    if(KeyboardLayout == LOWERCASE)
+    {
+      for (i = 0; i < size; i++ )
+      {
+        switch  (EnabledKeyString[i])
+        {
+          case 'a': b_A = true; break;
+          case 'b': b_B = true; break;
+          case 'c': b_C = true; break;
+          case 'd': b_D = true; break;
+          case 'e': b_E = true; break;
+          case 'f': b_F = true; break;
+          case 'g': b_G = true; break;
+          case 'h': b_H = true; break;
+          case 'i': b_I = true; break;
+          case 'j': b_J = true; break;
+          case 'k': b_K = true; break;
+          case 'l': b_L = true; break;
+          case 'm': b_M = true; break;
+          case 'n': b_N = true; break;
+          case 'o': b_O = true; break;
+          case 'p': b_P = true; break;
+          case 'q': b_Q = true; break;
+          case 'r': b_R = true; break;
+          case 's': b_S = true; break;
+          case 't': b_T = true; break;
+          case 'u': b_U = true; break;
+          case 'v': b_V = true; break;
+          case 'w': b_W = true; break;
+          case 'x': b_X = true; break;
+          case 'y': b_Y = true; break;
+          case 'z': b_Z = true; break;
+/*
+          case '\xF6': case '\xD6': bUe = true; break;    // ü Ü
+          case '\xFC': case '\xDC': bOe = true; break;  //ö Ö
+          case '\xE4': case '\xC4': bAe = true; break;  // ä Ä
+*/
+          case '?':  b_0 = true; break;
+          case '!':  b_1 = true; break;
+          case '+':  b_2 = true; break;
+          case '$':  b_3 = true; break;
+          case '%':  b_4 = true; break;
+          case '#':  b_5 = true; break;
+          case '/':  b_6 = true; break;
+          case '(':  b_7 = true; break;
+          case ')':  b_8 = true; break;
+          case '=':  b_9 = true; break;
+
+          case ':':  b_Dot = true; break;
+          case '_':  b_Min = true; break;
+          case '*':  b_At  = true; break;
+        /*  case '_':  bUn  = true; break;*/
+          case ' ':  bSpace = true; break;
+
+          default: break;
+        }
+      }
+    }
 
 
   WndButton *wb;
+
 	wb =  (WndButton*) wf->FindByName(TEXT("prpA")); if(wb != NULL) wb->SetVisible(bA);
 	wb =  (WndButton*) wf->FindByName(TEXT("prpB")); if(wb != NULL) wb->SetVisible(bB);
 	wb =  (WndButton*) wf->FindByName(TEXT("prpC")); if(wb != NULL) wb->SetVisible(bC);
@@ -718,15 +818,60 @@ unsigned int i=0;
 	wb =  (WndButton*) wf->FindByName(TEXT("prp7")); if(wb != NULL) wb->SetVisible(b7);
 	wb =  (WndButton*) wf->FindByName(TEXT("prp8")); if(wb != NULL) wb->SetVisible(b8);
 	wb =  (WndButton*) wf->FindByName(TEXT("prp9")); if(wb != NULL) wb->SetVisible(b9);
+        wb =  (WndButton*) wf->FindByName(TEXT("prpDot"))   ; if(wb != NULL) wb->SetVisible(bDot);
+        wb =  (WndButton*) wf->FindByName(TEXT("prpMin"))   ; if(wb != NULL) wb->SetVisible(bMin);
+        wb =  (WndButton*) wf->FindByName(TEXT("prpAt"))    ; if(wb != NULL) wb->SetVisible(bAt);
 
-	wb =  (WndButton*) wf->FindByName(TEXT("prpUe")); if(wb != NULL) wb->SetVisible(bUe);
-	wb =  (WndButton*) wf->FindByName(TEXT("prpOe")); if(wb != NULL) wb->SetVisible(bOe);
-	wb =  (WndButton*) wf->FindByName(TEXT("prpAe")); if(wb != NULL) wb->SetVisible(bAe);
+	/**************************** upercase **********************************************/
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_A")); if(wb != NULL) wb->SetVisible(b_A);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_B")); if(wb != NULL) wb->SetVisible(b_B);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_C")); if(wb != NULL) wb->SetVisible(b_C);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_D")); if(wb != NULL) wb->SetVisible(b_D);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_E")); if(wb != NULL) wb->SetVisible(b_E);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_F")); if(wb != NULL) wb->SetVisible(b_F);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_G")); if(wb != NULL) wb->SetVisible(b_G);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_H")); if(wb != NULL) wb->SetVisible(b_H);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_I")); if(wb != NULL) wb->SetVisible(b_I);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_J")); if(wb != NULL) wb->SetVisible(b_J);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_K")); if(wb != NULL) wb->SetVisible(b_K);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_L")); if(wb != NULL) wb->SetVisible(b_L);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_M")); if(wb != NULL) wb->SetVisible(b_M);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_N")); if(wb != NULL) wb->SetVisible(b_N);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_O")); if(wb != NULL) wb->SetVisible(b_O);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_P")); if(wb != NULL) wb->SetVisible(b_P);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_Q")); if(wb != NULL) wb->SetVisible(b_Q);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_R")); if(wb != NULL) wb->SetVisible(b_R);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_S")); if(wb != NULL) wb->SetVisible(b_S);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_T")); if(wb != NULL) wb->SetVisible(b_T);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_U")); if(wb != NULL) wb->SetVisible(b_U);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_V")); if(wb != NULL) wb->SetVisible(b_V);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_W")); if(wb != NULL) wb->SetVisible(b_W);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_X")); if(wb != NULL) wb->SetVisible(b_X);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_Y")); if(wb != NULL) wb->SetVisible(b_Y);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_Z")); if(wb != NULL) wb->SetVisible(b_Z);
 
-	wb =  (WndButton*) wf->FindByName(TEXT("prpDot"))   ; if(wb != NULL) wb->SetVisible(bDot);
-	wb =  (WndButton*) wf->FindByName(TEXT("prpUn"))    ; if(wb != NULL) wb->SetVisible(bUn);
-	wb =  (WndButton*) wf->FindByName(TEXT("prpSpace")) ; if(wb != NULL) wb->SetVisible(bSpace);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_0")); if(wb != NULL) wb->SetVisible(b_0);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_1")); if(wb != NULL) wb->SetVisible(b_1);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_2")); if(wb != NULL) wb->SetVisible(b_2);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_3")); if(wb != NULL) wb->SetVisible(b_3);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_4")); if(wb != NULL) wb->SetVisible(b_4);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_5")); if(wb != NULL) wb->SetVisible(b_5);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_6")); if(wb != NULL) wb->SetVisible(b_6);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_7")); if(wb != NULL) wb->SetVisible(b_7);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_8")); if(wb != NULL) wb->SetVisible(b_8);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_9")); if(wb != NULL) wb->SetVisible(b_9);
 
-	wb =  (WndButton*) wf->FindByName(TEXT("prpMin"))   ; if(wb != NULL) wb->SetVisible(bMin);
-	wb =  (WndButton*) wf->FindByName(TEXT("prpAt"))    ; if(wb != NULL) wb->SetVisible(bAt);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_Dot"))   ; if(wb != NULL) wb->SetVisible(b_Dot);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_Min"))   ; if(wb != NULL) wb->SetVisible(b_Min);
+        wb =  (WndButton*) wf->FindByName(TEXT("prp_At"))    ; if(wb != NULL) wb->SetVisible(b_At);
+        /***********************************************************************************************/
+
+        wb =  (WndButton*) wf->FindByName(TEXT("prpUe")); if(wb != NULL) wb->SetVisible(bUe);
+        wb =  (WndButton*) wf->FindByName(TEXT("prpOe")); if(wb != NULL) wb->SetVisible(bOe);
+        wb =  (WndButton*) wf->FindByName(TEXT("prpAe")); if(wb != NULL) wb->SetVisible(bAe);
+
+
+//      wb =  (WndButton*) wf->FindByName(TEXT("prpUn"))    ; if(wb != NULL) wb->SetVisible(bUn);
+        wb =  (WndButton*) wf->FindByName(TEXT("prpSpace")) ; if(wb != NULL) wb->SetVisible(bSpace);
+
 }

--- a/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
+++ b/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
@@ -195,7 +195,7 @@ static void OnSpace(WndButton* pWnd) {
     PlayResource(TEXT("IDR_WAV_CLICK"));
     TCHAR Caption = ' ';
 
-    if(WaypointKeyRed == KEYRED_NONE) Caption = '_';
+    if(WaypointKeyRed == KEYRED_NONE) Caption = ' ';
     if (cursor < max_width - 1) {
         edittext[cursor++] = ToUpper(Caption);
     }

--- a/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
+++ b/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
@@ -59,10 +59,14 @@ static void UpdateTextboxProp(void)
   if (wp) {
     wp->SetText(edittext);
 
-    if(WaypointKeyRed > KEYRED_NONE)
-      wp->SetCaption(MsgToken(949));
+    if(WaypointKeyRed == KEYRED_WAYPOINT)
+      wp->SetCaption(MsgToken(1226));
     else
-      wp->SetCaption(TEXT("Text"));
+      if(WaypointKeyRed == KEYRED_AIRSPACE)
+        wp->SetCaption(MsgToken(68));
+      else
+        wp->SetCaption(MsgToken(711));
+
   }
 
 

--- a/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
+++ b/Common/Source/Dialogs/dlgTextEntry_Keyboard.cpp
@@ -46,8 +46,6 @@ char ToUpper(char in)
 	if(in == '\xF6') return '\xD6'; // ö -> Ö
 	if(in == '\xFC') return '\xDC'; // ü -> Ü
 	if(in == '\xE4') return '\xC4'; // ä -> Ä
-	if(in == ' ') return '_';
-	if(in == '_') return '_';
 	return toupper(in);
 }
 
@@ -154,13 +152,31 @@ static void OnKey(WndButton* pWnd) {
     PlayResource(TEXT("IDR_WAV_CLICK"));
     const TCHAR *Caption = pWnd->GetWndText();
     if (cursor < max_width - 1) {
-        edittext[cursor++] = toupper(Caption[0]);
+        edittext[cursor++] = ToUpper(Caption[0]);
     }
     UpdateTextboxProp();
 }
 
 
 
+
+static void OnSpace(WndButton* pWnd) {
+    LKASSERT(pWnd);
+    if(!pWnd) return;
+
+    if (first) {
+        ClearText();
+        first = false;
+    }
+    PlayResource(TEXT("IDR_WAV_CLICK"));
+    TCHAR Caption = ' ';
+
+    if(WaypointKeyRed == KEYRED_NONE) Caption = '_';
+    if (cursor < max_width - 1) {
+        edittext[cursor++] = ToUpper(Caption);
+    }
+    UpdateTextboxProp();
+}
 
 
 static void OnDel(WndButton* pWnd)
@@ -239,6 +255,7 @@ static CallBackTableEntry_t CallBackTable[]={
   ClickNotifyCallbackEntry(OnClear),
   ClickNotifyCallbackEntry(OnOk),
   ClickNotifyCallbackEntry(OnDel),
+  ClickNotifyCallbackEntry(OnSpace),
   ClickNotifyCallbackEntry(OnDate),
   ClickNotifyCallbackEntry(OnTime),
   OnHelpCallbackEntry(OnHelpClicked),
@@ -366,8 +383,8 @@ IdenticalIndex = -1;
           {
             LKASSERT(k < MAX_TEXTENTRY);
             LKASSERT((k+Offset) < NameLen);
-            char ac = (char)WayPointList[i].Name[k+Offset];
-            char bc = (char)edittext[k];
+            TCHAR ac = (TCHAR)WayPointList[i].Name[k+Offset];
+            TCHAR bc = (TCHAR)edittext[k];
             if(  ToUpper(ac) !=   ToUpper(bc) ) /* waypoint has string ?*/
             {
               CharEqual = false;
@@ -433,7 +450,7 @@ IdenticalIndex = -1;
           LKASSERT(IdenticalIndex<=(int)WayPointList.size());
           _stprintf(Found,_T("%s"),WayPointList[IdenticalIndex].Name);
 	  for( i = 0; i < cursor; i++)
-	     Found[i+IdenticalOffset] = toupper(WayPointList[IdenticalIndex].Name[i+IdenticalOffset]);
+	     Found[i+IdenticalOffset] = ToUpper(WayPointList[IdenticalIndex].Name[i+IdenticalOffset]);
           wp->SetText(Found);
         }
       }
@@ -511,8 +528,8 @@ TCHAR AS_Name[255];
           {
             LKASSERT(k < MAX_TEXTENTRY);
             LKASSERT((k+Offset) < NameLen);
-            char ac = (char)AS_Name[k+Offset];
-            char bc = (char)edittext[k];
+            TCHAR ac = (TCHAR)AS_Name[k+Offset];
+            TCHAR bc = (TCHAR)edittext[k];
             if(  ToUpper(ac) !=   ToUpper(bc) ) /* waypoint has string ?*/
             {
               CharEqual = false;
@@ -567,7 +584,7 @@ TCHAR AS_Name[255];
     {
       if(EqCnt ==1)
       {
-        LKASSERT(IdenticalIndex<= (int)WayPointList.size());
+        LKASSERT(IdenticalIndex<= (int)airspaclist.size());
             wp->SetText(IdenticalName  );
       }
       else
@@ -578,8 +595,7 @@ TCHAR AS_Name[255];
 
           _stprintf(Found,_T("%s"),IdenticalName );
           for( i = 0; i < cursor; i++)
-             Found[i+IdenticalOffset] = toupper(IdenticalName[i+IdenticalOffset]);
-          wp->SetText(Found);
+             Found[i+IdenticalOffset] = ToUpper(IdenticalName[i+IdenticalOffset]);
         }
       }
     }
@@ -603,7 +619,7 @@ bool bA=false, bB=false, bC=false, bD=false, bE=false, bF=false, bG=false, bH=fa
 	 bJ=false, bK=false, bL=false, bM=false, bN=false, bO=false, bP=false, bQ=false, bR=false,
 	 bS=false, bT=false, bU=false, bV=false, bW=false, bX=false, bY=false, bZ=false, b0=false,
 	 b1=false, b2=false, b3=false, b4=false, b5=false, b6=false, b7=false, b8=false, b9=false,
-	 bUe=false, bOe=false, bAe=false, bDot=false, bMin=false, bAt=false,  bUn=false ;
+	 bUe=false, bOe=false, bAe=false, bDot=false, bMin=false, bAt=false,  bUn=false,  bSpace=false ;
 
 unsigned int i=0;
 
@@ -657,7 +673,7 @@ unsigned int i=0;
 	  case '-':  bMin = true; break;
 	  case '@':  bAt  = true; break;
 	  case '_':  bUn  = true; break;
-//	  case ' ':  bSpace = true; break;
+	  case ' ':  bSpace = true; break;
 
 	  default: break;
 	}
@@ -709,7 +725,7 @@ unsigned int i=0;
 
 	wb =  (WndButton*) wf->FindByName(TEXT("prpDot"))   ; if(wb != NULL) wb->SetVisible(bDot);
 	wb =  (WndButton*) wf->FindByName(TEXT("prpUn"))    ; if(wb != NULL) wb->SetVisible(bUn);
-	wb =  (WndButton*) wf->FindByName(TEXT("prpSpace")) ; if(wb != NULL) wb->SetVisible(bUn);
+	wb =  (WndButton*) wf->FindByName(TEXT("prpSpace")) ; if(wb != NULL) wb->SetVisible(bSpace);
 
 	wb =  (WndButton*) wf->FindByName(TEXT("prpMin"))   ; if(wb != NULL) wb->SetVisible(bMin);
 	wb =  (WndButton*) wf->FindByName(TEXT("prpAt"))    ; if(wb != NULL) wb->SetVisible(bAt);


### PR DESCRIPTION
new Airspace lookup dialog like waypoints with
-substring filter 
-pictorial
-easy turn off/on
-new Filter for disabled airspaces
-new Upper-/lowercase keyboard layout

comming from this request:
http://www.postfrontal.com/forum/topic.asp?TOPIC_ID=8732
for dense airspaces like netherland really needed!

result:
Note the Altdorf is disabled but can be re-enabled by just one click in the listfield. Both elements of the same airspace are handeled in parallel (due to group acknolage).
![notam_alt2](https://user-images.githubusercontent.com/1188401/36451025-faef734e-168f-11e8-9797-ebeb4111da79.jpg)

sorting out NOTAMs in max. 50km distance
![notamnew](https://user-images.githubusercontent.com/1188401/36644995-a2e8e9d8-1a62-11e8-9631-aee08345d2f4.png)

sorting out the disabled airspaces for easy re-enabling
![disable](https://user-images.githubusercontent.com/1188401/36643772-8fe17736-1a50-11e8-9aa5-ffb137b1f3a8.jpg)

new upper-/lowercase switchable keyboard for all Text inputs
![lowercase](https://user-images.githubusercontent.com/1188401/36760711-3982e83e-1c1c-11e8-8677-2c008fdc4c6a.jpg)
