### PR TITLE
Exclude Airspaces outside Terrain

### DIFF
--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -1717,7 +1717,7 @@ void CAirspaceManager::FillAirspacesFromOpenAir(ZZIP_FILE *fp) {
                             _stprintf(sTmp, TEXT("Parse error at line %d\r\n\"%s\"\r\nLine skipped."), linecount, p);
                             // LKTOKEN  _@M68_ = "Airspace"
                             if(!InsideMap) {
-                              if (RasterTerrain::WaypointIsInTerrainRange(CenterX,CenterY)) {
+                              if (RasterTerrain::WaypointIsInTerrainRange(CenterY,CenterX)) {
                                 InsideMap = true;
                               }
                             }
@@ -1732,7 +1732,7 @@ void CAirspaceManager::FillAirspacesFromOpenAir(ZZIP_FILE *fp) {
                             _stprintf(sTmp, TEXT("Parse error at line %d\r\n\"%s\"\r\nLine skipped."), linecount, p);
                             // LKTOKEN  _@M68_ = "Airspace"
                             if(!InsideMap) {
-                              if (RasterTerrain::WaypointIsInTerrainRange(CenterX,CenterY)) {
+                              if (RasterTerrain::WaypointIsInTerrainRange(CenterY,CenterX)) {
                                 InsideMap = true;
                               }
                             }
@@ -1745,11 +1745,11 @@ void CAirspaceManager::FillAirspacesFromOpenAir(ZZIP_FILE *fp) {
                         p++;
                         Radius = StrToDouble(p, NULL);
                         Radius = (Radius * NAUTICALMILESTOMETRES);
-                        Latitude = CenterX;
-                        Longitude = CenterY;
+                    //    Latitude = CenterX;
+                   //     Longitude = CenterY;
 
                         if(!InsideMap) {
-                          if (RasterTerrain::WaypointIsInTerrainRange(Latitude,Longitude)) {
+                          if (RasterTerrain::WaypointIsInTerrainRange(CenterY,CenterX)) {
                             InsideMap = true;
                           } 
                         }
@@ -1759,7 +1759,7 @@ void CAirspaceManager::FillAirspacesFromOpenAir(ZZIP_FILE *fp) {
                         p++;
                         p++; // skip P and space
                         if (ReadCoords(p, &lon, &lat)) {
-                            if(InsideMap == false) {
+                            if(!InsideMap) {
                               if (RasterTerrain::WaypointIsInTerrainRange(lat,lon))  {
                                 InsideMap = true;
                               } 

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -3897,6 +3897,7 @@ int ival;
     if (WaypointsOutOfRange != wp->GetDataField()->GetAsInteger()) {
       WaypointsOutOfRange = wp->GetDataField()->GetAsInteger();
       WAYPOINTFILECHANGED= true;
+      AIRSPACEFILECHANGED = true;
     }
   }
 

--- a/Common/Source/Terrain/RasterTerrain.cpp
+++ b/Common/Source/Terrain/RasterTerrain.cpp
@@ -21,10 +21,12 @@ bool RasterMap::GetMapCenter(double *lat, double *lon) const {
 }
 
 bool RasterMap::IsInside(double lat, double lon) const {
-  return ((lat <= TerrainInfo.Top) &&
-          (lat >= TerrainInfo.Bottom) &&
-          (lon <= TerrainInfo.Right) &&
-          (lon >= TerrainInfo.Left));
+  double dlat = fabs( TerrainInfo.Top- TerrainInfo.Bottom) * 0.05f;
+  double dlon = fabs( TerrainInfo.Right- TerrainInfo.Left) * 0.05f;
+  return ((lat <= TerrainInfo.Top   + dlat) &&
+          (lat >= TerrainInfo.Bottom- dlat) &&
+          (lon <= TerrainInfo.Right +dlon) &&
+          (lon >= TerrainInfo.Left  -dlon));
 }
 
 


### PR DESCRIPTION
When waypoint filter is set to exclude now airspaces outside Terrain (OpenAir and OpenAIP) are also excluded.
Maybe we should rename "Exlude Wpt" to "Exlude Data"
The terrain filter area is a bit extended by 5% in each direction to guarantee all airspaces "on the edges" not to be removed.

Very helpfull on bigger countries with lots of airspaces. It gives a bigger performance by removing the uninteresting airspaces outside the dedicated flying area/terrain as implemented here:
https://github.com/LK8000/LK8000/pull/1191

Terrain Filter include (as before):
![terrainfilter_off](https://user-images.githubusercontent.com/1188401/39969243-3b4e064c-56d9-11e8-9a6d-2ffc67268e00.jpg)


Terrain Filter exclude:
![terrainfilter_on](https://user-images.githubusercontent.com/1188401/39969197-f31e64f2-56d8-11e8-8467-3068286d73ca.jpg)
