### PR TITLE
Fixed STF in SIM mode before takeoff

### DIFF
--- a/Common/Source/Calc/NettoVario.cpp
+++ b/Common/Source/Calc/NettoVario.cpp
@@ -13,6 +13,11 @@
 
 void NettoVario(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
 
+  if (!Calculated->Flying) {
+    Calculated->NettoVario = 0.0;
+    return;
+  }
+
   double n;
   // get load factor
   if (Basic->AccelerationAvailable) {

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -868,7 +868,7 @@ goto_bearing:
 		case LK_SPEED_DOLPHIN:
 			value=SPEEDMODIFY*DerivedDrawInfo.VOpt;
 			if (value<0||value>999) value=0; else valid=true;
-			_stprintf(BufferValue, TEXT("%d"),(int)value);
+			_stprintf(BufferValue, TEXT("%d"),(int)round(value));
 			_stprintf(BufferUnit, TEXT("%s"),(Units::GetHorizontalSpeedName()));
 			_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
 			break;


### PR DESCRIPTION
Fix a NettoVario calculation that is wrong before takeoff and gives a wrong value of STF ( useful on the ground for evaluating the performance of a new polar )