### PR TITLE
Terminal Send

### DIFF
--- a/Common/Data/Dialogs/dlgTerminal_L.xml
+++ b/Common/Data/Dialogs/dlgTerminal_L.xml
@@ -7,8 +7,12 @@
     <WndButton Name="cmdSelectStop" Caption="_@M670_" X="158" Y="2" Width="77"  Height="28" Font="2" Tag="3" />
     <WndButton Name="cmdClose" Caption="_@M186_" X="237" Y="2" Width="77"  Height="28" Font="2" Tag="3" />
 
-    <WndListFrame Name="frmTTYList" X="1" Y="32" Width="-1" Height="-1" Font="2" OnListInfo="OnTTYListInfo">
-    <WndOwnerDrawFrame Name="frmTTYListEntry" X="1" Y="1" Width="-1" Height="-1" Font="2"  OnPaint="OnPaintListItem"/>
+    <WndListFrame Name="frmTTYList" X="1" Y="32" Width="-1" Height="160" Font="2" OnListInfo="OnTTYListInfo">
+    <WndOwnerDrawFrame Name="frmTTYListEntry" X="1" Y="1" Width="-1" Height="160" Font="2"  OnPaint="OnPaintListItem"/>
     </WndListFrame>
+    <WndProperty Name="prpSendText" Caption="_@M711_"  X="2" Y="197"  Width="290" Height="22" CaptionWidth="30" Font="2" Keyboard="1">
+      <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s"/>
+    </WndProperty>    
+    <WndButton Name="cmdSendButton" Caption="_@M2155_" X="300" Y="197" Width="77"  Height="22" Font="2" Tag="3" />    
   </WndForm>
 </PMML>

--- a/Common/Data/Dialogs/dlgTerminal_P.xml
+++ b/Common/Data/Dialogs/dlgTerminal_P.xml
@@ -7,8 +7,12 @@
     <WndButton Name="cmdSelectStop" Caption="_@M670_" X="125" Y="2" Width="57"  Height="28" Font="2" Tag="3" />
     <WndButton Name="cmdClose" Caption="_@M186_" X="183" Y="2" Width="57"  Height="28" Font="2" Tag="3" />
 
-    <WndListFrame Name="frmTTYList" X="1" Y="32" Width="-1" Height="-1" Font="2" OnListInfo="OnTTYListInfo">
-    <WndOwnerDrawFrame Name="frmTTYListEntry" X="1" Y="1" Width="-1" Height="-1" Font="2"  OnPaint="OnPaintListItem"/>
+    <WndListFrame Name="frmTTYList" X="1" Y="32" Width="-1" Height="270" Font="2" OnListInfo="OnTTYListInfo">
+    <WndOwnerDrawFrame Name="frmTTYListEntry" X="1" Y="1" Width="-1" Height="270" Font="2"  OnPaint="OnPaintListItem"/>
     </WndListFrame>
+    <WndProperty Name="prpSendText" Caption="_@M711_"  X="2" Y="310"  Width="180" Height="22" CaptionWidth="30" Font="2" Keyboard="1">
+      <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s"/>
+    </WndProperty>    
+    <WndButton Name="cmdSendButton" Caption="_@M2155_" X="185" Y="310" Width="50"  Height="22" Font="2" Tag="3" />       
   </WndForm>
 </PMML>


### PR DESCRIPTION
added send Line with text edit to Terminal window.
If entered text is a NMEA String (starting with $) the checksumm is added automatically.
This makes sense with the new keyboard only, otherwise we can not enter special caracters as needed for NMEA sentences.

![terminal](https://user-images.githubusercontent.com/1188401/46492566-3c34f100-c80e-11e8-8a28-26661daa183f.jpg)
