### PR TITLE
fix EfficiencyReq calculation bug for alternate landables.

### DIFF
--- a/Common/Source/Draw/CalculateWaypointReachable.cpp
+++ b/Common/Source/Draw/CalculateWaypointReachable.cpp
@@ -121,7 +121,7 @@ void MapWindow::LKCalculateWaypointReachable(const bool forced)
 	WayPointCalc[i].Distance=waypointDistance; 
 	WayPointCalc[i].Bearing=waypointBearing;
 
-	CalculateGlideRatio(waypointDistance,
+	WayPointCalc[i].GR = CalculateGlideRatio(waypointDistance,
 		 DerivedDrawInfo.NavAltitude - WayPointList[i].Altitude - GetSafetyAltitude(i));
 
 


### PR DESCRIPTION
fix EfficiencyReq calculation bug for alternate landables.
(This was a very old bug, no one ever noticed)