### PR TITLE
Different BuildType on Android  use different configuration folder 

### DIFF
--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -139,8 +139,16 @@
 #define LKD_DEFAULT_POLAR   "Default.plr"
 #define LKD_DEFAULT_LANGUAGE   "ENGLISH.LNG"
 
-
+#ifdef ANDROID_VARIANT_BETA
+#define LKD_CONF	"_Configuration_beta"
+#else
+#ifdef ANDROID_VARIANT_DEBUG
+#define LKD_CONF	"_Configuration_debug"
+#else
 #define LKD_CONF	"_Configuration"
+#endif
+#endif
+
 #define LKD_TASKS	"_Tasks"
 #define LKD_WAYPOINTS	"_Waypoints"
 #define LKD_POLARS	"_Polars"

--- a/android-studio/app/build.gradle
+++ b/android-studio/app/build.gradle
@@ -153,6 +153,14 @@ android {
             debuggable true
             jniDebuggable true
             renderscriptDebuggable true
+
+            externalNativeBuild {
+                cmake {
+                    cFlags "-DANDROID_VARIANT_DEBUG"
+                    cppFlags "-DANDROID_VARIANT_DEBUG"
+                }
+            }
+
         }
         beta {
             initWith(buildTypes.release)
@@ -167,6 +175,13 @@ android {
                     res.srcDirs = ["src/main/res",
                                    "../../android/res",
                                    "../../android/res_beta"]
+                }
+            }
+
+            externalNativeBuild {
+                cmake {
+                    cFlags "-DANDROID_VARIANT_BETA"
+                    cppFlags "-DANDROID_VARIANT_BETA"
                 }
             }
         }

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name" translatable="false">LK8000</string>
-  <string name="app_name_beta" translatable="false">LK8000-testing</string>
+  <string name="app_name_beta" translatable="false">LK8000-beta</string>
   <string name="app_name_debug" translatable="false">LK8000-debug</string>
 </resources>

--- a/android/res/values/strings.xml
+++ b/android/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name" translatable="false">LK8000</string>
-  <string name="app_name_beta" translatable="false">LK8000-beta</string>
+  <string name="app_name_beta" translatable="false">LK8000-testing</string>
   <string name="app_name_debug" translatable="false">LK8000-debug</string>
 </resources>


### PR DESCRIPTION
On Android devices different BuildType can be installed simultaneously by pilots ( release o beta ) o developer ( debug).
Therefore there could be backward incompatibility with configuration files with differet version of the APP. This commit separate each build type into a different configuration folder.