### PR TITLE
Translate Android Key Codes into Unicode characters

### DIFF
--- a/Common/Source/xcs/Android/EventBridge.cpp
+++ b/Common/Source/xcs/Android/EventBridge.cpp
@@ -29,6 +29,8 @@ Copyright_License {
 #include "Compiler.h"
 #include <jni.h>
 
+#define ANDROID_KEYCODE_FIX
+
 /**
  * @see http://developer.android.com/reference/android/view/KeyEvent.html
  */
@@ -47,6 +49,7 @@ static constexpr unsigned KEYCODE_DPAD_DOWN = 0x14;
 static unsigned
 TranslateKeyCode(unsigned key_code)
 {
+#ifndef ANDROID_KEYCODE_FIX
   if (key_code == KEYCODE_BACK)
     /* the "back" key acts as escape */
     return KEYCODE_ESCAPE;
@@ -60,6 +63,9 @@ TranslateKeyCode(unsigned key_code)
     return 'A' + (key_code - KEYCODE_A);
 
   return key_code;
+#else
+  return key_code;
+#endif
 }
 
 constexpr

--- a/android/src/org/LK8000/NativeView.java
+++ b/android/src/org/LK8000/NativeView.java
@@ -531,7 +531,13 @@ class NativeView extends SurfaceView
   public void exitApp() {
   }
 
-  private final int translateKeyCode(int keyCode) {
+  /**
+   * Translate the Android Key Code to a Unicode character.
+   * @param keyCode The Android Key Code
+   * @param event The KeyEvent
+   * @return an int representing the Unicode character
+   */
+  private final int translateKeyCode(int keyCode, final KeyEvent event) {
     if (!hasKeyboard) {
       /* map the volume keys to cursor up/down if the device has no
          hardware keys */
@@ -545,16 +551,31 @@ class NativeView extends SurfaceView
       }
     }
 
-    return keyCode;
+    /* the "back" key acts as escape */
+    if(keyCode == KeyEvent.KEYCODE_BACK)
+      return KeyEvent.KEYCODE_ESCAPE;
+
+    /* return upper-case character, because InputEvents::findKey()
+       calls ToUpperASCII() */
+    int character = Character.toUpperCase(event.getUnicodeChar(event.getMetaState()));
+
+    /* If either shift or control is pressed and nothing else */
+    if(character == 0 && (event.isShiftPressed() || event.isCtrlPressed()))
+        return 0x11;
+
+    if(character == 0)
+      return keyCode;
+    else
+      return character;
   }
 
   @Override public boolean onKeyDown(int keyCode, final KeyEvent event) {
-    EventBridge.onKeyDown(translateKeyCode(keyCode));
+    EventBridge.onKeyDown(translateKeyCode(keyCode, event));
     return true;
   }
 
   @Override public boolean onKeyUp(int keyCode, final KeyEvent event) {
-    EventBridge.onKeyUp(translateKeyCode(keyCode));
+    EventBridge.onKeyUp(translateKeyCode(keyCode, event));
     return true;
   }
 


### PR DESCRIPTION
In general, Android Key Codes should not be used directly. Change translateKeyCode in NativeView.java to translate the Android Key Codes into Unicode characters. EventBridge.cpp also has a translateKeyCode function. Whatever it was doing was wrong and it should now be unnecessary.

I've been creating a custom controller with Arduino and this was necessary to get the minimap to move right with the space key. I've tested all of the buttons on my controller and they work correctly now. There is a little bit of functionality that is still not working correctly, but this gets it 90% of the way there.