### PR TITLE
now make 8.33kHz Radio as default

### DIFF
--- a/Common/Source/lk8000.cpp
+++ b/Common/Source/lk8000.cpp
@@ -335,6 +335,7 @@ bool Startup(const TCHAR* szCmdLine) {
   RadioPara.Enabled = false; //devIsRadio(devA()) || devIsRadio(devB());
   RadioPara.ActiveFrequency  = 118.00;
   RadioPara.PassiveFrequency = 118.00;
+  RadioPara.Enabled8_33      = true;
 #endif  // RADIO_ACTIVE
 
   // Initialise main blackboard data


### PR DESCRIPTION
since 1.1.2018, 8.33kHz spacing is mandatory in europe. So we enable it as default. Old 25KHz still possible.