### PR TITLE
Multi contest

### DIFF
--- a/Common/Data/Dialogs/dlgConfiguration_L.xml
+++ b/Common/Data/Dialogs/dlgConfiguration_L.xml
@@ -489,6 +489,9 @@
       <WndProperty Name="prpEngineeringMenu" Caption="_@M260_"  X="2" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H213_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
+      <WndProperty Name="prpAdditionalContestRule" Caption="_@M2279_"  X="2" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1299_">
+        <DataField Name="" DataType="enum"/>
+      </WndProperty>
     </WndFrame>
     <WndFrame Name="frmSpecials2" X="70" Y="0" Width="-1" Height="222" Font="2">
       <WndProperty Name="prpPGClimbZoom" Caption="_@M170_" X="2" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H214_">

--- a/Common/Data/Dialogs/dlgConfiguration_P.xml
+++ b/Common/Data/Dialogs/dlgConfiguration_P.xml
@@ -491,6 +491,9 @@
       <WndProperty Name="prpEngineeringMenu" Caption="_@M260_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H213_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
+      <WndProperty Name="prpAdditionalContestRule" Caption="_@M2279_"  X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H1299_">
+        <DataField Name="" DataType="enum"/>
+      </WndProperty>
     </WndFrame>
     <WndFrame Name="frmSpecials2" X="1" Y="0" Width="-1" Height="222" Font="2">
       <WndProperty Name="prpPGClimbZoom" Caption="_@M170_" X="0" Y="-1" Width="-1" Height="22" CaptionWidth="150" Font="2" Help="_@H214_">

--- a/Common/Data/Language/DEFAULT_MENU.TXT
+++ b/Common/Data/Language/DEFAULT_MENU.TXT
@@ -818,8 +818,8 @@ location=7
 mode=Display2
 type=key
 data=9
-event=Service OPTIMODE
-label=_@M2251_
+event=Service DRAWXC
+label=$(AC41)
 location=8
 
 mode=Display2

--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -1512,12 +1512,67 @@ This is not MacCready STF (neither MC=0) that on the contrary tend to minimize t
 Use this speed if you want to maximize efficiency and glide distance
 
 @934
-[Target Req. Efficicency]
+[Target Req. Efficiency]
 Required efficiency to the current target
 
 @935
 [Altitude QNE]
 QNE refers to the indicated altitude at the landing runway threshold when 1013.25 mbar or 29.92 inHg is set in the altimeter's Kollsman window
+
+@937
+[XC FREE Flight distance]
+Free distance over 3 turnpoints.
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@938
+[XC FREE Flight score]
+Score of Free flight with 3 turnpoints.
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@939
+[XC FREE Triangle distance]
+Triangle distance which do not conform to FAI triangle specification.
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@940
+[XC FREE Triangle score]
+Score of FREE Triangle ( NOT FAI ).
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@941
+[XC FAI Triangle distance]
+Triangle distance conform to the FAI definition (the shortest leg of the triangle must be at least 28% of the total triangle).
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@942
+[XC FAI Triangle score]
+Score of FAI Triangle.
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@943
+[XC combined distance]
+Distance of the best scored contest ( FAI Triangle,FREE Triangle, FREE Flight) .
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@944
+[XC combined score]
+Maximum score of all contest ( FAI Triangle,FREE Triangle, FREE Flight).
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@945
+[XC Triangle closure distance]
+Distance to close the best scored contest triangle ( FAI or FREE )  in km
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@946
+[XC Triangle closure %]
+Distance to close the best scored contest triangle ( FAI or FREE ) in percentage
+This data is available only if the additional Contest Engine is activate in System menu n 22
+
+@947
+[XC Triangle predicted distance]
+Distance to close the best scored contest triangle ( FAI or FREE ) in km
+This data is available only if the additional Contest Engine is activate in System menu n 22
 
 #
 # END INFOBOXES 800 - 1199
@@ -1892,8 +1947,13 @@ in flight only:
 tracking starts after takeoff and ends after landing detection.
 permanent:
 tracking as long as LK8000 runs and has a valid GPS signal.
-We recomend in flight only because it transfers the takeoff and landing information for a correct log. (default)
+We recommend in flight only because it transfers the takeoff and landing information for a correct log. (default)
 while permanent can be used to test your tracking settings on ground. (Note: Tracking need a falid GPS fix)
+
+@1299
+[Additional Contest Rules]
+Select the scoring rule for the Cross Country Contest (XC). If OFF no contest other than OLC will be evaluated and available in the XC infoboxes.
+
 
 @9999
 No help available on this item!

--- a/Common/Data/Language/ENG_HELP.TXT
+++ b/Common/Data/Language/ENG_HELP.TXT
@@ -1379,29 +1379,35 @@ No help available on this item!
 
 @890
 [OLC CLASSIC] distance
-Current distance calculated around 5 turnpoints. 
+Current distance calculated around 5 turnpoints.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @891
 [FAI TRIANGLE] distance
 FAI triangle maximum distance achieved so far.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @892
 [OLC LEAGUE] distance
 Max distance calculated around 3 turnpoints, made in 2.5 hours.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @893
 [FAI 3TPs] distance
 Current distance calculated around 3 turnpoints. 
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @894
 [OLC CLASSIC] predicted distance
 Current distance calculated around 5 turnpoints assuming the last one
 will be the starting point.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @895
 [FAI TRIANGLE] predicted distance
 FAI triangle maximum distance achieved so far, assuming the last point
 will be the starting point.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @896
 [FAI 3TPs] predicted distance
@@ -1410,53 +1416,69 @@ will be the starting point.
 
 @897
 [OLC CLASSIC] speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @898
 [FAI TRIANGLE] speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @899
 [OLC LEAGUE] speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @900
 [FAI 3TPs] speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @901
 [OLC CLASSIC] predicted speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @902
 [FAI TRIANGLE] predicted speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @903
 [FAI 3TPs] predicted speed
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @904
 [OLC CLASSIC] score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @905
 [FAI TRIANGLE] score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @906
 [OLC LEAGUE] score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @907
 [FAI 3TPs] score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @908
 [OLC CLASSIC] predicted score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @909
 [FAI TRIANGLE] predicted score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @910
 [FAI 3TPs] predicted score
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @911
 [OLC PLUS] score
 The sum of OLC Classic score and FAI triangle score.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @912
 [OLC PLUS] predicted score
 The sum of OLC Classic predicted score and FAI triangle predicted score.
+This data is available only if the OLC Engine is activate in System menu n 22
 
 @913
 [FLAP SETTINGS]
@@ -1522,57 +1544,63 @@ QNE refers to the indicated altitude at the landing runway threshold when 1013.2
 @937
 [XC FREE Flight distance]
 Free distance over 3 turnpoints.
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @938
 [XC FREE Flight score]
 Score of Free flight with 3 turnpoints.
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @939
 [XC FREE Triangle distance]
 Triangle distance which do not conform to FAI triangle specification.
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @940
 [XC FREE Triangle score]
 Score of FREE Triangle ( NOT FAI ).
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @941
 [XC FAI Triangle distance]
 Triangle distance conform to the FAI definition (the shortest leg of the triangle must be at least 28% of the total triangle).
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @942
 [XC FAI Triangle score]
 Score of FAI Triangle.
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @943
-[XC combined distance]
+[XC best distance]
 Distance of the best scored contest ( FAI Triangle,FREE Triangle, FREE Flight) .
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @944
-[XC combined score]
+[XC best score]
 Maximum score of all contest ( FAI Triangle,FREE Triangle, FREE Flight).
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @945
 [XC Triangle closure distance]
 Distance to close the best scored contest triangle ( FAI or FREE )  in km
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @946
 [XC Triangle closure %]
 Distance to close the best scored contest triangle ( FAI or FREE ) in percentage
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
 
 @947
 [XC Triangle predicted distance]
 Distance to close the best scored contest triangle ( FAI or FREE ) in km
-This data is available only if the additional Contest Engine is activate in System menu n 22
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@948
+[XC mean speed]
+Cross country mean speed calculated on three turnpoints
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
 
 #
 # END INFOBOXES 800 - 1199
@@ -1952,7 +1980,7 @@ while permanent can be used to test your tracking settings on ground. (Note: Tra
 
 @1299
 [Additional Contest Rules]
-Select the scoring rule for the Cross Country Contest (XC). If OFF no contest other than OLC will be evaluated and available in the XC infoboxes.
+Select the scoring rule for the Cross Country Contest (XC). If OFF no contest will be evaluated and available in the XC or OLC infoboxes.
 
 
 @9999

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -2289,6 +2289,7 @@ _@M2346_ "are identical"
 _@M2347_ "airspaces excluded!"
 _@M2348_ "Outside terrain"
 
+_@M2349_ "Target up"
 
 
 # Multimap symbols
@@ -2334,9 +2335,8 @@ _@M2384_ "✈"  # traffic
 _@M2385_ "Map Symbols"
 _@M2386_ "UTF8" # no need to translate 
 _@M2387_ "GND"  # instead of SFC, no need to translate
-_@M2388_ "Target up" 
 
+_@M2388_ "Draw XC\nOFF"
+_@M2389_ "Draw XC\nON"
+_@M2290_ "Toggle Draw XC"
 
-_@M2401_ "Draw XC\nOFF"
-_@M2402_ "Draw XC\nON"
-_@M2403_ "Toggle Draw XC"

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -2194,6 +2194,35 @@ _@M2253_ "AUTO THERMALLING"
 _@M2254_ "FULL AUTO"
 
 
+_@M2255_ "XC FREE Fligth distance"
+_@M2256_ "XC FREE Fligth score"
+_@M2257_ "XC FREE Triangle distance"
+_@M2258_ "XC FREE Triangle score"
+_@M2259_ "XC FAI Triangle distance"
+_@M2260_ "XC FAI Triangle score"
+_@M2261_ "XC combined distance"
+_@M2262_ "XC combined score"
+_@M2263_ "XC Triangle closing distance"
+_@M2264_ "XC Triangle closing %"
+_@M2265_ "XC Triangle predicted distance"
+_@M2277_ "XC Mean Speed"
+
+_@M2266_ "FRE Dis"
+_@M2267_ "FRE Scr"
+_@M2268_ "TRI Dis"
+_@M2269_ "TRI Scr"
+_@M2270_ "FAI Dis"
+_@M2271_ "FAI Scr"
+_@M2272_ "XC Dis"
+_@M2273_ "XC Scr"
+_@M2274_ "XC C"
+_@M2275_ "XC C%"
+_@M2276_ "XC Dis*"
+_@M2278_ "XC Spd"
+
+
+_@M2279_ "XC Contest Rules"
+
 # MAX 2500! 
 # (Reserved for custom menus up to 2300!)
 # Note for developers: remember LKLanguage MAX_MESSAGE limit (2500)

--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -2200,8 +2200,8 @@ _@M2257_ "XC FREE Triangle distance"
 _@M2258_ "XC FREE Triangle score"
 _@M2259_ "XC FAI Triangle distance"
 _@M2260_ "XC FAI Triangle score"
-_@M2261_ "XC combined distance"
-_@M2262_ "XC combined score"
+_@M2261_ "XC Best distance"
+_@M2262_ "XC Best score"
 _@M2263_ "XC Triangle closing distance"
 _@M2264_ "XC Triangle closing %"
 _@M2265_ "XC Triangle predicted distance"
@@ -2221,7 +2221,7 @@ _@M2276_ "XC Dis*"
 _@M2278_ "XC Spd"
 
 
-_@M2279_ "XC Contest Rules"
+_@M2279_ "Contest"
 
 # MAX 2500! 
 # (Reserved for custom menus up to 2300!)
@@ -2335,3 +2335,8 @@ _@M2385_ "Map Symbols"
 _@M2386_ "UTF8" # no need to translate 
 _@M2387_ "GND"  # instead of SFC, no need to translate
 _@M2388_ "Target up" 
+
+
+_@M2401_ "Draw XC\nOFF"
+_@M2402_ "Draw XC\nON"
+_@M2403_ "Toggle Draw XC"

--- a/Common/Data/Language/ToDo.TXT
+++ b/Common/Data/Language/ToDo.TXT
@@ -420,6 +420,8 @@ _@M2322_ "Enable Radar"
 _@M2336_
 ICAO Code 
 
+----------- after v7 ---------
+
 _@M2252_ "MANUAL"
 _@M2253_ "AUTO THERMALLING"
 _@M2254_ "FULL AUTO"
@@ -445,6 +447,19 @@ _@M2387_ "GND"   former SFC, normaly no need to translate
 _@M2388_ "Draw XC\nOFF"
 _@M2389_ "Draw XC\nON"
 _@M2290_ "Toggle Draw XC"
+
+_@M2255_ "XC FREE Fligth distance"
+_@M2256_ "XC FREE Fligth score"
+_@M2257_ "XC FREE Triangle distance"
+_@M2258_ "XC FREE Triangle score"
+_@M2259_ "XC FAI Triangle distance"
+_@M2260_ "XC FAI Triangle score"
+_@M2261_ "XC Best distance"
+_@M2262_ "XC Best score"
+_@M2263_ "XC Triangle closing distance"
+_@M2264_ "XC Triangle closing %"
+_@M2265_ "XC Triangle predicted distance"
+_@M2277_ "XC Mean Speed"
 
 HELP FILE
 
@@ -485,3 +500,63 @@ OFF don't display any value (see help)
 
 @1293
 Text has been modified for accounting new customization mechanism
+
+@937
+[XC FREE Flight distance]
+Free distance over 3 turnpoints.
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@938
+[XC FREE Flight score]
+Score of Free flight with 3 turnpoints.
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@939
+[XC FREE Triangle distance]
+Triangle distance which do not conform to FAI triangle specification.
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@940
+[XC FREE Triangle score]
+Score of FREE Triangle ( NOT FAI ).
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@941
+[XC FAI Triangle distance]
+Triangle distance conform to the FAI definition (the shortest leg of the triangle must be at least 28% of the total triangle).
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@942
+[XC FAI Triangle score]
+Score of FAI Triangle.
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@943
+[XC best distance]
+Distance of the best scored contest ( FAI Triangle,FREE Triangle, FREE Flight) .
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@944
+[XC best score]
+Maximum score of all contest ( FAI Triangle,FREE Triangle, FREE Flight).
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@945
+[XC Triangle closure distance]
+Distance to close the best scored contest triangle ( FAI or FREE )  in km
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@946
+[XC Triangle closure %]
+Distance to close the best scored contest triangle ( FAI or FREE ) in percentage
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@947
+[XC Triangle predicted distance]
+Distance to close the best scored contest triangle ( FAI or FREE ) in km
+This data is available only if an additional XC Contest Engine is activate in System menu n 22
+
+@948
+[XC mean speed]
+Cross country mean speed calculated on three turnpoints
+This data is available only if an additional XC Contest Engine is activate in System menu n 22

--- a/Common/Data/Language/ToDo.TXT
+++ b/Common/Data/Language/ToDo.TXT
@@ -436,11 +436,15 @@ _@M2345_ "and"
 _@M2346_ "are identical" 
 _@M2347_ "airspaces excluded!"
 _@M2348_ "Outside terrain"
+_@M2349_ "Target up"
 
 _@M2385_ "Map Symbols"
 _@M2386_ "UTF8"  no need to translate
 _@M2387_ "GND"   former SFC, normaly no need to translate
-_@M2388_ "Target up"
+
+_@M2388_ "Draw XC\nOFF"
+_@M2389_ "Draw XC\nON"
+_@M2290_ "Toggle Draw XC"
 
 HELP FILE
 

--- a/Common/Header/ContestMgr.h
+++ b/Common/Header/ContestMgr.h
@@ -255,7 +255,7 @@ private:
 
   TriangleLeg* GetFAIAssistantMaxLeg() {return _maxFAILeg;};
   TriangleLeg* GetFAIAssistantLeg(int i) {return &_faiAssistantTriangleLegs[i];};
-  bool LooksLikeAFAITriangle() { return _bLooksLikeAFAITriangle;};
+  bool LooksLikeAFAITriangleAttempt() { return _bLooksLikeAFAITriangle;};
   int isFAITriangleClockwise() { return _dFAITriangleClockwise;};
   bool hasValidPath(TType type);
   static CContestMgr &Instance() { return _instance; }

--- a/Common/Header/ContestMgr.h
+++ b/Common/Header/ContestMgr.h
@@ -9,6 +9,8 @@
 #ifndef __CONTESTMGR_H__
 #define __CONTESTMGR_H__
 
+//#define FIVEPOINT_OPTIMIZER
+
 #include "Trace.h"
 #include <map>
 #include <memory>
@@ -39,6 +41,7 @@ public:
   /** 
    * @brief The type of contest
    */
+
   enum TType {
     TYPE_OLC_CLASSIC,                             /**< @brief OLC-Classic part of OLC-Plus */
     TYPE_OLC_FAI,                                 /**< @brief FAI-OLC part of OLC-Plus */
@@ -54,10 +57,38 @@ public:
 #ifdef   FIVEPOINT_OPTIMIZER
     TYPE_FAI_TRIANGLE5,                            /**< @brief FAI triangle 2 turnpoints predicted for returning to start */
 #endif
-    TYPE_NUM,                                     /**< @brief Do not use it! */
+    TYPE_XC_FREE_TRIANGLE,                         /**< @brief XC Free Triangle evalueted only in PG mode */
+    TYPE_XC_FAI_TRIANGLE,                          /**< @brief XC FAI Triangle evalueted only in PG mode for score only */
+    TYPE_XC_FREE_FLIGHT ,                          /**< @brief XC Free Flight evaluated only in PG mode for score only */
+    TYPE_XC ,                                       /**< @brief XC total scoring evaluated only in PG mode for score only */
+    TYPE_NUM,                                      /**< @brief Do not use it! */
     TYPE_INVALID = TYPE_NUM
+  } ;
+
+  enum XCFlightType {
+    XC_FREE_TRIANGLE,
+    XC_FAI_TRIANGLE,
+    XC_FREE_FLIGHT,
+    XC_INVALID
   };
-  
+
+  enum ContestRule {                              // Should exactly be equal to  prpAdditionalContestRule enum in dlgConfiguration.cpp
+    NONE,
+    XContest2018,
+    XContest2019,
+    CFD,
+    LEONARDO_XC,
+    UK_NATIONAL_LEAGUE,
+    NUM_OF_XC_RULES
+  };
+
+  enum XCTriangleStatus {
+    INVALID,
+    VALID,
+    CLOSED
+  };
+
+
   /**
    * @brief Contest Result
    * 
@@ -67,7 +98,9 @@ public:
     friend class CContestMgr;
     TType          _type;                         /**< @brief The type of the contest (TYPE_INVALID if result invalid) */
     bool           _predicted;                    /**< @brief @c true if a result is based on prediction */
-    unsigned       _distance;                     /**< @brief Contest covered distance */
+    unsigned       _distance;                     /**< @brief Contest covered distance in meters 0 for XC if invalid triangle*/
+    unsigned       _current_distance;             /**< @brief Contest covered current distance in meters even if invalid*/
+    unsigned       _predicted_distance;           /**< @brief Contest closed maximum distance in meters */
     float          _score;                        /**< @brief Contest score (if exists) */
     unsigned       _duration;                     /**< @brief Contest duration */
     float          _speed;                        /**< @brief Contest speed */
@@ -77,15 +110,31 @@ public:
   public:
     CResult();
     CResult(TType type, bool predicted, unsigned distance, float score, const CPointGPSArray &pointArray);
+    CResult(TType type, bool predicted, unsigned distance, unsigned current_distance, unsigned predicted_distance ,float score, const CPointGPSArray &pointArray);
     CResult(TType type, const CResult &ref);
     CResult(const CResult &ref, bool fillArray);
     TType Type() const         { return _type; }
     bool Predicted() const     { return _predicted; }
     unsigned Distance() const  { return _distance; }
+    unsigned PredictedDistance() const  { return _predicted_distance; }
+    unsigned CurrentDistance() const  { return _current_distance; }
     float Score() const        { return _score; }
     unsigned Duration() const  { return _duration; }
     float Speed() const        { return _speed; }
     const CPointGPSArray &PointArray() const { return _pointArray; }
+    void UpdateDistance(double current_distance) {
+      _current_distance=current_distance;
+      _duration = _pointArray.empty() ? 0 : (_pointArray.back().TimeDelta(_pointArray.front()));
+      _speed = _pointArray.empty() ? 0 : ((float)current_distance / _duration);
+    }
+    void UpdateDistancesAndArray( unsigned current_distance, unsigned predicted_distance, const CPointGPSArray &pointArray ){
+      _current_distance=current_distance;
+      _predicted_distance=predicted_distance;
+      _pointArray = CPointGPSArray(pointArray);
+      _duration = _pointArray.empty() ? 0 : (_pointArray.back().TimeDelta(_pointArray.front()));
+      _speed = _pointArray.empty() ? 0 : ((float)_current_distance / _duration);
+    };
+
   };
   
   typedef std::vector<CResult> CResultArray;
@@ -114,33 +163,45 @@ private:
 
   // Other
   static const unsigned DEFAULT_HANDICAP = 100;
-  
 
-  static CContestMgr _instance;                   /**< @brief Singleton */
-  unsigned _handicap;                             /**< @brief Glider handicap */
-  CTracePtr _trace;                               /**< @brief Main trace */
-  CTracePtr _traceSprint;                         /**< @brief Trace for OLC-League */
-  CTracePtr _traceLoop;                           /**< @brief Trace for OLC-League */
-  std::unique_ptr<CPointGPS> _prevFAIFront;         /**< @brief Last reviewed OLC-FAI loop end points */
-  std::unique_ptr<CPointGPS> _prevFAIBack;          /**< @brief Last reviewed OLC-FAI loop end points */
-  std::unique_ptr<CPointGPS> _prevFAIPredictedFront;/**< @brief Last reviewed OLC-FAI Predicted loop end points */
-  std::unique_ptr<CPointGPS> _prevFAIPredictedBack; /**< @brief Last reviewed OLC-FAI Predicted loop end points */
-  CResultArray _resultArray;                      /**< @brief Array of results */
-  
+  static CContestMgr _instance;                       /**< @brief Singleton */
+  unsigned _handicap;                                 /**< @brief Glider handicap */
+  CTracePtr _trace;                                   /**< @brief Main trace */
+  CTracePtr _traceSprint;                             /**< @brief Trace for OLC-League */
+  CTracePtr _traceFreeTriangle;                       /**< @brief Trace for XContest Free Triangle */
+  CTracePtr _traceLoop;                               /**< @brief Trace for OLC-League */
+  std::unique_ptr<CPointGPS> _prevFAIFront;           /**< @brief Last reviewed OLC-FAI loop end points */
+  std::unique_ptr<CPointGPS> _prevFAIBack;            /**< @brief Last reviewed OLC-FAI loop end points */
+  std::unique_ptr<CPointGPS> _prevFAIPredictedFront;  /**< @brief Last reviewed OLC-FAI Predicted loop end points */
+  std::unique_ptr<CPointGPS> _prevFAIPredictedBack;   /**< @brief Last reviewed OLC-FAI Predicted loop end points */
+  std::unique_ptr<CPointGPS> _prevFreeTriangleFront;  /**< @brief Last reviewed XContest Free Triangle loop end points */
+  std::unique_ptr<CPointGPS> _prevFreeTriangleBack;   /**< @brief Last reviewed XContest Free Triangle loop end points */
+  CResultArray _resultArray;                          /**< @brief Array of results */
+
+  CResult _resultFREETriangle;                        /**< @brief private results for  XContest Free Triangle */
+  XCFlightType     _bestXCType;                        /**< @brief the XC type that has maximum scoring */
+  XCFlightType     _bestXCTriangleType;               // Best triangle type ( FAI and FT )
+  XCTriangleStatus  _XCFAIStatus;
+  XCTriangleStatus  _XCFTStatus;
+
+  double _XCTriangleClosurePercentage;
+  double _XCTriangleClosureDistance;
+  double _XCTriangleDistance;
+  double _XCMeanSpeed;
+
   CPointGPS _pgpsClosePoint;
   CPointGPS _pgpsBestClosePoint;
   CPointGPS _pgpsNearPoint;
-  /*
-  double _pgpsNearPoint_lat ;
-  double _pgpsNearPoint_lon ;
-  double _pgpsNearPoint_Alt ;
-*/
+
+  CPointGPS _pgpsFreeTriangleClosePoint;                /**< @brief Point to close the Free Triangle un track*/
+  CPointGPS _pgpsFreeTriangleBestClosePoint;            /**< @brief the point that gave the closest poit to close  the Free Triangle into _pgpsFreeTriangleClosePoint*/
+
   double _fTogo     ;                          /**< @brief current closing distance */
   double _fBestTogo ;                          /**< @brief best minimal closing distance */
   double _uiFAIDist ;
   BOOL   _bFAI;                                /**< @brief Is FAI triangle? */
-
-
+  double _fFreeTriangleTogo     ;              /**< @brief current closing distance for XContest FREE TRIANGLE*/
+  double _fFreeTriangleBestTogo ;
   mutable Mutex _mainCS;               /**< @brief Main critical section that prevents Reset() and Add() at the same time */
   mutable Mutex _traceCS;              /**< @brief Main trace critical section for returning _trace points */
   mutable Mutex _resultsCS;            /**< @brief Contests results critical section for returning results */
@@ -151,22 +212,44 @@ private:
   bool FAITriangleEdgeCheck(unsigned length1, unsigned length2, unsigned length3) const;
   void PointsResult(TType type, const CTrace &traceResult);
   void SolvePoints(const CTrace &trace, bool sprint, bool predicted);
-  void SolveTriangle(const CTrace &trace, const CPointGPS *prevFront, const CPointGPS *prevBack, bool predicted);
+  void SolveFAITriangle(const CTrace &trace,
+                        const CPointGPS *prevFront,
+                        const CPointGPS *prevBack,
+                        bool predicted);
+  void SolveFREETriangle(const CTrace &trace,
+                         const CPointGPS *prevFront,
+                         const CPointGPS *prevBack);
   void SolveOLCPlus(bool predicted);
-  
 
-public:
+  void SolveXC();
+  double ScoreXC(double current_distance,double total_distance ,XCFlightType type, bool update_status);
+  double ScoreXContest2018(double current_distance, double total_distance_, XCFlightType type, bool update_status);
+  double ScoreXContest2019(double current_distance, double total_distance_, XCFlightType type, bool update_status);
+  double ScoreCDF(double current_distance,double total_distance ,XCFlightType type, bool update_status);
+  double ScoreLEONARDO_XC(double current_distance,double total_distance ,XCFlightType type, bool update_status);
+  double ScoreUK_NATIONAL_LEAGUE(double current_distance,double total_distance ,XCFlightType type, bool update_status);
+  bool FREETriangleEdgeCheck(unsigned length1, unsigned length2, unsigned length3)  const;
+
+ public:
 
   void RefreshFAIOptimizer(void);
   static CContestMgr &Instance() { return _instance; }
   static const TCHAR *TypeToString(TType type);
-  
+  static const TCHAR *XCRuleToString(int type);
+
   CPointGPS GetClosingPoint(void )         {return _pgpsClosePoint;};
   CPointGPS GetBestNearClosingPoint(void ) {return _pgpsNearPoint;};
   CPointGPS GetBestClosingPoint(void )     {return _pgpsBestClosePoint;};
 
   double GetClosingPointDist(void) { return _fTogo/*_trace->Back()->GPS().Distance(_pgpsBestClosePoint)*/;};
   double GetBestClosingPointDist(void) { return  _fBestTogo /*return min(_fTogo,_fBestTogo)*/;};
+
+  double GetFreeTriangleClosingPointDist(void) { return _fFreeTriangleTogo;};
+  double GetFreeTriangleBestClosingPointDist(void) { return  _fFreeTriangleBestTogo ;};
+
+  CPointGPS GetFreeTriangleClosingPoint(void )         {return _pgpsFreeTriangleClosePoint;};
+  CPointGPS GetFreeTriangleBestClosingPoint(void )         {return _pgpsFreeTriangleBestClosePoint;};
+
   BOOL FAI(void) {return _bFAI;};
   CContestMgr();
   
@@ -175,6 +258,19 @@ public:
 
   CResult Result(TType type, bool fillArray) const;
   void Trace(CPointGPSArray &array) const;
+
+  CContestMgr::XCFlightType GetBestXCType() {return _bestXCType;};
+  CContestMgr::XCFlightType GetbestXCTriangleType() {return _bestXCTriangleType;};
+  CContestMgr::XCTriangleStatus  GetFTTriangleStatus() { return _XCFTStatus;}
+  CContestMgr::XCTriangleStatus  GetFAITriangleStatus() { return _XCFAIStatus;}
+
+
+  double GetXCTriangleClosureDistance(){return _XCTriangleClosureDistance;};
+  double GetXCTriangleClosurePercentuage(){return _XCTriangleClosurePercentage;};
+  double GetXCTriangleDistance(){return _XCTriangleDistance;};
+  double GetXCMeanSpeed(){return _XCMeanSpeed;};
+
+
 };
 
 
@@ -185,7 +281,7 @@ public:
  * Constructor to create dummy invalid contest result object.
  */
 inline CContestMgr::CResult::CResult():
-  _type(TYPE_INVALID), _predicted(0), _distance(0), _score(0), _duration(0), _speed(0)
+  _type(TYPE_INVALID), _predicted(0), _distance(0), _current_distance(0), _predicted_distance(0), _score(0), _duration(0), _speed(0)
 
 {
 }
@@ -201,7 +297,7 @@ inline CContestMgr::CResult::CResult():
  * @param pointArray The list of contest result points
  */
 inline CContestMgr::CResult::CResult(TType type, bool predicted, unsigned distance, float score, const CPointGPSArray &pointArray):
-  _type(type), _predicted(predicted), _distance(distance), _score(score),
+  _type(type), _predicted(predicted), _distance(distance),  _current_distance(0), _predicted_distance(0),_score(score),
   _duration(pointArray.empty() ? 0 : (pointArray.back().TimeDelta(pointArray.front()))),
   _speed(pointArray.empty() ? 0 : ((float)_distance / _duration)),
   _pointArray(pointArray)
@@ -210,6 +306,25 @@ inline CContestMgr::CResult::CResult(TType type, bool predicted, unsigned distan
 }
 
 
+/**
+ * @brief  constructor for XContest
+ *
+ * @param type The type of the contest
+ * @param predicted @c true if a result is based on prediction
+ * @param distance Contest covered distance
+ * @param total distance of the clsed triagle
+ * @param score Contest score (if exists)
+ * @param pointArray The list of contest result points
+ */
+inline CContestMgr::CResult::CResult(TType type, bool predicted, unsigned distance,unsigned current_distance, unsigned predicted_distance, float score, const CPointGPSArray &pointArray):
+    _type(type), _predicted(predicted), _distance(distance),  _current_distance(current_distance),_predicted_distance(predicted_distance),_score(score),
+    _duration(pointArray.empty() ? 0 : (pointArray.back().TimeDelta(pointArray.front()))),
+    _speed(pointArray.empty() ? 0 : ((float)_distance / _duration)),
+    _pointArray(pointArray)
+
+{
+}
+
 /** 
  * @brief "Copy" constructor
  * 
@@ -217,7 +332,7 @@ inline CContestMgr::CResult::CResult(TType type, bool predicted, unsigned distan
  * @param ref The results data to copy (beside type)
  */
 inline CContestMgr::CResult::CResult(TType type, const CResult &ref):
-  _type(type), _predicted(ref._predicted), _distance(ref._distance),
+  _type(type), _predicted(ref._predicted), _distance(ref._distance), _current_distance(0),_predicted_distance(0),
   _score(ref._score), _duration(ref._duration), _speed(ref._speed),
   _pointArray(ref._pointArray)
 {
@@ -231,11 +346,12 @@ inline CContestMgr::CResult::CResult(TType type, const CResult &ref):
  * @param fillArray When @c true GPS points will be copied
  */
 inline CContestMgr::CResult::CResult(const CResult &ref, bool fillArray):
-  _type(ref._type), _predicted(ref._predicted), _distance(ref._distance),
+  _type(ref._type), _predicted(ref._predicted), _distance(ref._distance), _current_distance(ref._current_distance) , _predicted_distance(ref._predicted_distance),
   _score(ref._score), _duration(ref._duration), _speed(ref._speed),
   _pointArray(fillArray ? ref._pointArray : CPointGPSArray())
 {
 }
+
 
 
 /** 
@@ -263,3 +379,5 @@ inline CContestMgr::CResult CContestMgr::Result(TType type, bool fillArray) cons
 }
 
 #endif /* __CONTESTMGR_H__ */
+
+

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -705,7 +705,6 @@
 
 #define LK_OLC_FAI_CLOSE			125
 #define LK_OLC_FAI_CLOSE_PERCENT	126
-#define LK_OLC_FAI_CLOSE_PERCENT	126
 #define LK_BANK_ANGLE                   127
 #define LK_ALTERN1_RAD                  128
 #define LK_ALTERN2_RAD                  129

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -705,6 +705,7 @@
 
 #define LK_OLC_FAI_CLOSE			125
 #define LK_OLC_FAI_CLOSE_PERCENT	126
+#define LK_OLC_FAI_CLOSE_PERCENT	126
 #define LK_BANK_ANGLE                   127
 #define LK_ALTERN1_RAD                  128
 #define LK_ALTERN2_RAD                  129
@@ -717,41 +718,46 @@
 #define LK_QNE           135		// Barometric QNE Altitude
 #define LK_NEXT_DIST_RADIUS   136	  // Distance to Next turnpoint minus turnpoint cylindre radius (center for line and sector turnpoint)
 
+
+#define LK_XC_FF_DIST       137     // Additional Contest FREE Flight distance
+#define LK_XC_FF_SCORE      138     // Additional Contest FREE Flight score
+#define LK_XC_FT_DIST       139     // Additional Contest FREE Triangle distance
+#define LK_XC_FT_SCORE      140     // Additional Contest FREE Triangle score
+#define LK_XC_FAI_DIST      141     // Additional Contest FAI Triangle distance
+#define LK_XC_FAI_SCORE     142     // Additional Contest FAI Triangle score
+#define LK_XC_DIST          143     // Additional Contest combined distance
+#define LK_XC_SCORE         144     // Additional Contest combined score
+#define LK_XC_CLOSURE_DIST       145     // Additional Contest combined closure distance
+#define LK_XC_CLOSURE_PERC       146     // Additional Contest combined closure %
+#define LK_XC_PREDICTED_DIST     147     // Additional Contest combined closure distance
+#define LK_XC_MEAN_SPEED     148     // Additional Contest mean speed
+
+
 // The following values are not available for custom configuration
 
-#define LK_WIND			141		//
-#define LK_FIN_ALTDIFF0		142		// final (task) altitude difference at MC=0
-#define LK_LKFIN_ETE		143		// real ETE
-#define LK_NEXT_ALTDIFF0	144		//
-#define LK_TIME_LOCALSEC	145		// with seconds displayed
+#define LK_WIND			    233		//
+#define LK_FIN_ALTDIFF0		234		// final (task) altitude difference at MC=0
+#define LK_LKFIN_ETE		235		// real ETE
+#define LK_NEXT_ALTDIFF0	236		//
+#define LK_TIME_LOCALSEC	237		// with seconds displayed
 // Target infos
-#define LK_TARGET_DIST		146		//
-#define LK_TARGET_TO		147		//
-#define LK_TARGET_BEARING	148		//
-#define LK_TARGET_SPEED		149		//
-#define LK_TARGET_ALT		150		//
-#define LK_TARGET_ALTDIFF	151		//
-#define LK_TARGET_VARIO		152		//
-#define LK_TARGET_AVGVARIO	153		//
-#define LK_TARGET_ALTARRIV	154		//
-#define LK_TARGET_GR		155		//
-#define LK_TARGET_EIAS		156		//
+#define LK_TARGET_DIST		238		//
+#define LK_TARGET_TO		239		//
+#define LK_TARGET_BEARING	240		//
+#define LK_TARGET_SPEED		241		//
+#define LK_TARGET_ALT		242		//
+#define LK_TARGET_ALTDIFF	243		//
+#define LK_TARGET_VARIO		244		//
+#define LK_TARGET_AVGVARIO	245		//
+#define LK_TARGET_ALTARRIV	246		//
+#define LK_TARGET_GR		247		//
+#define LK_TARGET_EIAS		248		//
 // Time gates
-#define LK_START_DIST		157		//
+#define LK_START_DIST		249		//
 
-// overtarget values  UNUSED
-// #define LK_ALT1_DIST		158		//
-// #define LK_ALT2_DIST		159		//
-// #define LK_BALT_DIST		160		//
-// #define LK_ALT1_BRGDIFF		161		//
-// #define LK_ALT2_BRGDIFF		162		//
-// #define LK_BALT_BRGDIFF		163		//
-// #define LK_LASTTHERMAL_DIST	164		//
-// #define LK_LASTTHERMAL_BRGDIFF	165		//
-
-#define LK_NEXT_CENTER_ALTDIFF 166  // Same As  LK_NEXT_ALTDIFF but always with Waypoint center
-#define LK_NEXT_CENTER_GR	167	// Same as LK_NEXT_GR but always with Waypoint center
-#define LK_START_SPEED		168	// Requiered speed for reach Start of task at Gate Time !
+#define LK_NEXT_CENTER_ALTDIFF 250  // Same As  LK_NEXT_ALTDIFF but always with Waypoint center
+#define LK_NEXT_CENTER_GR	251	// Same as LK_NEXT_GR but always with Waypoint center
+#define LK_START_SPEED		252	// Requiered speed for reach Start of task at Gate Time !
 
 
 // Service values

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -835,9 +835,10 @@
 #define OVT_HOME        5
 #define OVT_THER        6	// last thermal
 #define OVT_MATE        7	// team mate
-#define OVT_FLARM       8	// target flarm in LK mode
-#define OVT_MARK        9	// marked location
-#define OVT_PASS        10	// closer mountain pass
+#define OVT_XC          8	// target XC Closing triangle point
+#define OVT_FLARM       9	// target flarm in LK mode
+#define OVT_MARK        10	// marked location
+#define OVT_PASS        11	// closer mountain pass
 // this is not the number of modes, because 0 is not accounted, remember
 // Also, this is used for dimensioning array.
 #define OVT_MAXMODE	OVT_PASS

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -728,6 +728,9 @@ GEXTERN int LiveTrackerInterval;
 GEXTERN bool LiveTrackerRadar_config;  // feed FLARM with Livetrack24 livedata only in PG/HG mode
 GEXTERN int LiveTrackerStart_config;  // Livetracking only in flight or always
 
+GEXTERN int AdditionalContestRule;  	// Enum to Rules to use for the addition contest CContestMgr::ContestRule
+
+
 GEXTERN short TerrainContrast;
 GEXTERN short TerrainBrightness;
 GEXTERN short TerrainRamp;

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -890,7 +890,7 @@ GEXTERN int  Multimap_SizeY[MP_TOP+1];
 // Global, not saved to profile
 GEXTERN bool Flags_DrawTask;
 GEXTERN bool Flags_DrawFAI;
-GEXTERN unsigned int FAI_OptimizerMode;
+GEXTERN unsigned int Flags_DrawXC;
 
 GEXTERN unsigned int Trip_Moving_Time;
 GEXTERN unsigned int Trip_Steady_Time;

--- a/Common/Header/LKInterface.h
+++ b/Common/Header/LKInterface.h
@@ -102,7 +102,7 @@ typedef enum{
 	ckMapOrient,
 	ckResetComm,
 	ckDspMode,
-	ckOtimizerPointsToggle,
+	ckDrawXCToggle,
 	ckAirspaceLookup,
 	ckTOP,
 } CustomKeyMode_t;

--- a/Common/Header/LKProfiles.h
+++ b/Common/Header/LKProfiles.h
@@ -442,6 +442,7 @@ char szRegistryOverlay_LeftDown[]       = "Overlay_LeftDown";
 char szRegistryOverlay_RightTop[]       = "Overlay_RightTop";
 char szRegistryOverlay_RightMid[]       = "Overlay_RightMid";
 char szRegistryOverlay_RightBottom[]       = "Overlay_RightBottom";
+char szRegistryAdditionalContestRule[]       = "Additional_Contest_Rule";
 #ifdef _WGS84
 char szRegistry_earth_model_wgs84[] = "earth_model_wgs84";
 #endif
@@ -795,6 +796,7 @@ extern const char szRegistryOverlay_LeftDown[];
 extern const char szRegistryOverlay_RightTop[];
 extern const char szRegistryOverlay_RightMid[];
 extern const char szRegistryOverlay_RightBottom[];
+extern const char szRegistryAdditionalContestRule[];
 
 #ifdef _WGS84
 extern const char szRegistry_earth_model_wgs84[];

--- a/Common/Header/LKProfiles.h
+++ b/Common/Header/LKProfiles.h
@@ -425,7 +425,7 @@ char szRegistryGearMode[]         = "GearMode";
 char szRegistryGearAltitude[]     = "GearAltitude";
 char szRegistryBottomMode[]       = "ActiveBottomBar";
 char szRegistryBigFAIThreshold[]  = "FAI_28_45_Threshold";
-char szRegistryFAIOptiMode[]      = "FAI_OptimizerMode";
+char szRegistryDrawXC[]      = "DrawXC";
 
 char szRegistryScreenSize[]       = "ScreenSize";
 char szRegistryScreenSizeX[]      = "ScreenSizeX";
@@ -779,7 +779,7 @@ extern const char szRegistryGearMode[];
 extern const char szRegistryGearAltitude[];
 extern const char szRegistryBottomMode[];
 extern const char szRegistryBigFAIThreshold[];
-extern const char szRegistryFAIOptiMode[];
+extern const char szRegistryDrawXC[];
 
 extern const char szRegistryScreenSize[];
 extern const char szRegistryScreenSizeX[];

--- a/Common/Header/MapWindow.h
+++ b/Common/Header/MapWindow.h
@@ -605,6 +605,7 @@ class MapWindow {
   static void DrawTask(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft);
   static void DrawTaskSectors(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj) ;
   static void DrawFAIOptimizer(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft) ;
+  static void DrawXCBestTriangle(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft);
   static void DrawThermalEstimate(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj);
   static void DrawThermalEstimateMultitarget(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj);
   static void DrawTaskAAT(LKSurface& Surface, const RECT& rc);

--- a/Common/Header/MapWindow.h
+++ b/Common/Header/MapWindow.h
@@ -605,7 +605,7 @@ class MapWindow {
   static void DrawTask(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft);
   static void DrawTaskSectors(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj) ;
   static void DrawFAIOptimizer(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft) ;
-  static void DrawXCBestTriangle(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft);
+  static void DrawXC(LKSurface &Surface, const RECT &rc, const ScreenProjection &_Proj, const POINT &Orig_Aircraft);
   static void DrawThermalEstimate(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj);
   static void DrawThermalEstimateMultitarget(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj);
   static void DrawTaskAAT(LKSurface& Surface, const RECT& rc);

--- a/Common/Header/RGB.h
+++ b/Common/Header/RGB.h
@@ -11,7 +11,7 @@
 #define RGB_BLACK	LKColor(0,0,0)
 #define RGB_WHITE	LKColor(255,255,255)
 #define RGB_WHITENOREV	LKColor(254,254,254)		// this color will not be reversed
-	#define RGB_BLUE	LKColor(0x00,0x00,0xff)
+#define RGB_BLUE	LKColor(0x00,0x00,0xff)
 #define RGB_LIGHTBLUE	LKColor(179,179,255)
 #define RGB_GREY	LKColor(0x99,0x99,0x99)
 #define RGB_LIGHTGREY	LKColor(0xcc,0xcc,0xcc)

--- a/Common/Header/Sizes.h
+++ b/Common/Header/Sizes.h
@@ -17,7 +17,7 @@
 #endif // _MSC_VER > 1000
 
 // Number of InfoBoxes
-#define NUMDATAOPTIONS_MAX                      140
+#define NUMDATAOPTIONS_MAX                      149
 
 
 #define DISTANCE_ROUNDING 20.0

--- a/Common/Header/Statistics.h
+++ b/Common/Header/Statistics.h
@@ -122,6 +122,7 @@ class Statistics {
     static void RenderTask(LKSurface& Surface, const RECT& rc, const bool olcmode);
     static void RenderContest(LKSurface& Surface, const RECT& rc);
     static void RenderFAIOptimizer(LKSurface& Surface, const RECT& rc);
+    static void RenderFAIAssistant(LKSurface& Surface, const RECT& rc);
     static int  RenderFAISector (LKSurface& Surface, const RECT& rc , double lat1, double lon1, double lat2, double lon2, double lat_c, double lon_c , int iOpposite , const LKColor& fillcolor);
     static void RenderSpeed(LKSurface& Surface, const RECT& rc);
 };

--- a/Common/Source/Calc/ContestMgr.cpp
+++ b/Common/Source/Calc/ContestMgr.cpp
@@ -12,10 +12,11 @@
 #include "ContestMgr.h"
 #include <memory>
 #include "NavFunctions.h"
+#include "RasterTerrain.h"
+
 
 //#define MAX_EARTH_DIST_IN_M   40000000.0
 CContestMgr CContestMgr::_instance;
-
 
 /** 
  * @brief Returns the string representation of contest type
@@ -36,20 +37,41 @@ const TCHAR *CContestMgr::TypeToString(TType type)
     _T("OLC-League"),
     _T("FAI 3 TPs"),
     _T("FAI 3 TPs (P)"),
- //   _T("FAI start on turnpoint (P)"),
- //   _T("FAI start on leg (P)"),
- //   _T("FAI mercedes star (P)"),
     MsgToken(1297) ,   //    _@M1297_ "FAI Start on turnpoint"
     MsgToken(1298)  ,  //    _@M1298_ "FAI Start on leg"
-    MsgToken(1299)  ,  //    _@M1299_ "FAI Mercedes star"
-    _T("FAI Mercedes star (P)"),
-    _T("[invalid]") 
+#ifdef   FIVEPOINT_OPTIMIZER
+  MsgToken(1299)  ,  //    _@M1299_ "FAI Mercedes star"
+#endif
+    _T("XC FREE Triangle") ,
+    _T("XC FAI Triangle"),
+    _T("XC FREE Fligth"),
+    _T("XC Total"),
+    _T("[invalid]")
   };
   return typeStr[type];
 }
 
 
-
+/**
+ * @brief Returns the string representation of current contest rule
+ *
+ * @param rule ID
+ *
+ * @return String representation of current contest rule . No need to translate here
+ */
+const TCHAR *CContestMgr::XCRuleToString(int rule)
+{
+  const TCHAR *typeStr[] = {
+      _T("OFF"),                      // Onlt OLC evalueted
+      _T("XContest 2018"),
+      _T("XContest 2019"),
+      _T("French CFD ligue"),
+      _T("Leonardo XC"),
+      _T("UK National League"),
+      _T("[INVALID]")                 // Never use this. Used for iterate over rules
+  };
+  return typeStr[rule];
+}
 
 /** 
  * @brief Constructor
@@ -58,25 +80,33 @@ CContestMgr::CContestMgr():
   _handicap(DEFAULT_HANDICAP),
   _trace(new CTrace(TRACE_FIX_LIMIT, 0, COMPRESSION_ALGORITHM)),
   _traceSprint(new CTrace(TRACE_SPRINT_FIX_LIMIT, TRACE_SPRINT_TIME_LIMIT, COMPRESSION_ALGORITHM)),
+  _traceFreeTriangle(new CTrace(TRACE_TRIANGLE_FIX_LIMIT, 0, COMPRESSION_ALGORITHM)),
   _traceLoop(new CTrace(TRACE_TRIANGLE_FIX_LIMIT, 0, COMPRESSION_ALGORITHM)),
   _prevFAIFront(), _prevFAIBack(),
   _prevFAIPredictedFront(), _prevFAIPredictedBack(),
   _pgpsClosePoint(0,0,0,0),
   _pgpsBestClosePoint(0,0,0,0),
-  _pgpsNearPoint(0,0,0,0)
+  _pgpsNearPoint(0,0,0,0),
+  _pgpsFreeTriangleClosePoint(0,0,0,0),
+  _pgpsFreeTriangleBestClosePoint(0,0,0,0)
 {
-
-	  _fTogo     =  0;
-	  _fBestTogo =  0;
-
-	  _uiFAIDist  =0;
-	  _bFAI              =false;
+  _fTogo     =  0;
+  _fBestTogo =  0;
+  _uiFAIDist  =0;
+  _bFAI              =false;
+  _resultFREETriangle = CResult();
+  _bestXCTriangleType = XCFlightType::XC_INVALID;
+  _bestXCType = XCFlightType::XC_INVALID;
+  _XCFAIStatus= XCTriangleStatus::INVALID;
+  _XCFTStatus= XCTriangleStatus::INVALID;
+  _XCTriangleClosurePercentage = 0;
+  _XCTriangleDistance = 0;
+  _XCMeanSpeed = 0;
 
   ScopeLock guard(_resultsCS);
   for(unsigned i=0; i<TYPE_NUM; i++)
     _resultArray.push_back(CResult());
 }
-
 
 /** 
  * @brief Resets Contest Manager
@@ -93,21 +123,24 @@ void CContestMgr::Reset(unsigned handicap)
   }
   _traceSprint.reset(new CTrace(TRACE_SPRINT_FIX_LIMIT, TRACE_SPRINT_TIME_LIMIT, COMPRESSION_ALGORITHM));
   _traceLoop.reset(new CTrace(TRACE_TRIANGLE_FIX_LIMIT, 0, COMPRESSION_ALGORITHM));
+  _traceFreeTriangle.reset(new CTrace(TRACE_TRIANGLE_FIX_LIMIT, 0, COMPRESSION_ALGORITHM));
   _prevFAIFront.reset(0);
   _prevFAIBack.reset(0);
   _prevFAIPredictedFront.reset(0);
   _prevFAIPredictedBack.reset(0);
+  _prevFreeTriangleFront.reset(0);
+  _prevFreeTriangleBack.reset(0);
   _bFAI = false;
   _uiFAIDist =0;
   _fTogo     = 0;
   _fBestTogo = 0;
+  _resultFREETriangle = CResult();
   {
     ScopeLock Resultguard(_resultsCS);
     for(unsigned i=0; i<TYPE_NUM; i++)
       _resultArray[i] = CResult();
   }
 }
-
 
 /** 
  * @brief Searches the trace for biggest allowed closed loop
@@ -251,6 +284,48 @@ bool CContestMgr::FAITriangleEdgeCheck(unsigned length1, unsigned length2, unsig
   }
 }
 
+/**
+ * @brief Verifies if provided edges form a valid FLAT triangle
+ *
+ * @param length1 First edge
+ * @param length2 Second edge
+ * @param length3 Third edge
+ *
+ * @return @c true if a valid FAI triangle can be constructed from provided edges
+ */
+bool CContestMgr::FREETriangleEdgeCheck(unsigned length1, unsigned length2, unsigned length3) const
+{
+  bool valid = false;
+
+  switch (AdditionalContestRule) {
+    case XContest2018:
+      valid= true;            // No constrain on edge here
+      break;
+    case XContest2019:
+      valid= true;            // No constrain on edge here
+      break;
+    case CFD:
+      valid= true;            // No constrain on edge here
+      break;
+    case LEONARDO_XC:
+      valid= true;            // No constrain on edge here
+      break;
+    case UK_NATIONAL_LEAGUE:
+      valid= true;            // and check
+      const unsigned length = length1 + length2 + length3;
+      const unsigned lengthMin = std::min(length1, std::min(length2, length3));
+      if ( lengthMin * 3 < length * 20 ) {    // 15%
+        valid = false;
+      }
+      else  {
+        const unsigned lengthMax = std::max(length1, std::max(length2, length3));
+        if ( lengthMax * 9 > length * 20 )   // 45%
+          valid = false;
+      }
+      break;
+  }
+  return valid;
+}
 
 /** 
  * @brief Sets a result for points based contests
@@ -466,45 +541,37 @@ else*/
 		oldFAIDist=_uiFAIDist;
 	}
 
+    if ( ! AdditionalContestRule) {       // If XC is active RESWP_FAIOPTIMIZED is set by the XCSolve function
 
-	if(_bFAI)
-	{
-	  needfilling_notriangle=true;
-	  WayPointList[RESWP_FAIOPTIMIZED].Latitude=_pgpsClosePoint.Latitude();
-	  WayPointList[RESWP_FAIOPTIMIZED].Longitude=_pgpsClosePoint.Longitude();
-	  WayPointList[RESWP_FAIOPTIMIZED].Altitude=_pgpsClosePoint.Altitude();
-	  if (WayPointList[RESWP_FAIOPTIMIZED].Altitude==0) WayPointList[RESWP_FAIOPTIMIZED].Altitude=0.001;
-	  WayPointList[RESWP_FAIOPTIMIZED].Reachable=TRUE;
-	  WayPointList[RESWP_FAIOPTIMIZED].Visible=TRUE;
+      if(_bFAI)
+      {
+        needfilling_notriangle=true;
+        WayPointList[RESWP_FAIOPTIMIZED].Latitude=_pgpsClosePoint.Latitude();
+        WayPointList[RESWP_FAIOPTIMIZED].Longitude=_pgpsClosePoint.Longitude();
+        WayPointList[RESWP_FAIOPTIMIZED].Altitude=_pgpsClosePoint.Altitude();
+        if (WayPointList[RESWP_FAIOPTIMIZED].Altitude==0) WayPointList[RESWP_FAIOPTIMIZED].Altitude=0.001;
+        WayPointList[RESWP_FAIOPTIMIZED].Reachable=TRUE;
+        WayPointList[RESWP_FAIOPTIMIZED].Visible=TRUE;
 
-	#if 0 // REMOVE
-	  if(_bFAI)
-	#endif
+        if(needfilling_yestriangle) {
+          _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("%-.1f %s %s"),_uiFAIDist *DISTANCEMODIFY,Units::GetDistanceName(), MsgToken(1816)); // FAI triangle closing point
+          needfilling_yestriangle=false;
+        }
 
-	  if(needfilling_yestriangle) {
-	    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("%-.1f %s %s"),_uiFAIDist *DISTANCEMODIFY,Units::GetDistanceName(), MsgToken(1816)); // FAI triangle closing point
-		needfilling_yestriangle=false;
-	  }
-
-	#if 0 // THIS CANNOT HAPPEN
-	  else
-		_stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("%-.1f %s %s"),fDist      *DISTANCEMODIFY,Units::GetDistanceName(), MsgToken(1817)); // JoJo closing point
-	#endif
-
-
-	}
-	else
-	{
-	  //WayPointList[RESWP_FAIOPTIMIZED].Latitude=RESWP_INVALIDNUMBER;
-	  //WayPointList[RESWP_FAIOPTIMIZED].Longitude=RESWP_INVALIDNUMBER;
-	  WayPointList[RESWP_FAIOPTIMIZED].Altitude=RESWP_INVALIDNUMBER;
-	  WayPointList[RESWP_FAIOPTIMIZED].Reachable=false;
-	  WayPointList[RESWP_FAIOPTIMIZED].Visible=false;
-	  if (needfilling_notriangle) {
-	     _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("no triangle closing point found!"));
-	     needfilling_notriangle=false;
-          }
-	}
+      }
+      else
+      {
+        //WayPointList[RESWP_FAIOPTIMIZED].Latitude=RESWP_INVALIDNUMBER;
+        //WayPointList[RESWP_FAIOPTIMIZED].Longitude=RESWP_INVALIDNUMBER;
+        WayPointList[RESWP_FAIOPTIMIZED].Altitude=RESWP_INVALIDNUMBER;
+        WayPointList[RESWP_FAIOPTIMIZED].Reachable=false;
+        WayPointList[RESWP_FAIOPTIMIZED].Visible=false;
+        if (needfilling_notriangle) {
+          _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("no triangle closing point found!"));
+          needfilling_notriangle=false;
+        }
+      }
+    }
   }
 }
 
@@ -517,7 +584,10 @@ else*/
  * @param prevBack Loop back point of previous iteration
  * @param predicted @c true if a predicted path to the trace start should be calculated
  */
-void CContestMgr::SolveTriangle(const CTrace &trace, const CPointGPS *prevFront, const CPointGPS *prevBack, bool predicted)
+void CContestMgr::SolveFAITriangle(const CTrace &trace,
+                                   const CPointGPS *prevFront,
+                                   const CPointGPS *prevBack,
+                                   bool predicted)
 {
   TType type = predicted ? TYPE_OLC_FAI_PREDICTED : TYPE_OLC_FAI;
   CResult bestResult = _resultArray[type];
@@ -645,6 +715,116 @@ void CContestMgr::SolveTriangle(const CTrace &trace, const CPointGPS *prevFront,
   }
 }
 
+/**
+ * @brief Solves XContest Free Triangle based contest
+ * Tony 2018
+ * @param trace The trace to use
+ * @param prevFront Loop front point of previous iteration
+ * @param prevBack Loop back point of previous iteration
+ * @param predicted @c true if a predicted path to the trace start should be calculated
+ */
+void CContestMgr::SolveFREETriangle(const CTrace &trace,
+                                    const CPointGPS *prevFront,
+                                    const CPointGPS *prevBack) {
+  if (trace.Size() > 2) {
+    // check for every trace point
+    const CTrace::CPoint *point1st = trace.Front();
+    while (point1st) {
+      // check if all edges should be analysed
+      bool skip1 = prevFront && prevBack;
+      if (skip1 && (point1st->GPS() < *prevFront || point1st->GPS() > *prevBack))
+        skip1 = false;
+
+      // create a map of points that may form first edge of a better triangle
+      CDistanceMap distanceMap1st;
+      const CTrace::CPoint *next = 0;
+      for (next = point1st->Next(); next; next = next->Next()) {
+        unsigned dist = point1st->GPS().DistanceXYZ(next->GPS());
+
+        distanceMap1st.insert(std::make_pair(dist, next));
+      }
+
+      // check all possible first edges of the triangle
+      for (CDistanceMap::reverse_iterator it1st = distanceMap1st.rbegin(); it1st != distanceMap1st.rend(); ++it1st) {
+        bool skip2 = skip1;
+        if (skip2 && (it1st->second->GPS() < *prevFront || it1st->second->GPS() > *prevBack))
+          skip2 = false;
+
+        unsigned dist1st = it1st->first;
+        // create a map of points that may form second edge of a better triangle
+        CDistanceMap distanceMap2nd;
+        const CTrace::CPoint *point2nd = it1st->second;
+        for (next = point2nd->Next(); next; next = next->Next()) {
+          bool skip3 = skip2;
+          if (skip3 && (next->GPS() < *prevFront || next->GPS() > *prevBack))
+            skip3 = false;
+          if (skip3)
+            // that triangle was analysed already
+            continue;
+
+          unsigned dist = point2nd->GPS().DistanceXYZ(next->GPS());
+          distanceMap2nd.insert(std::make_pair(dist, next));
+        }
+
+        // check all possible second and third edges of the triangle
+        for (CDistanceMap::reverse_iterator it2nd = distanceMap2nd.rbegin(); it2nd != distanceMap2nd.rend(); ++it2nd) {
+          unsigned dist2nd = it2nd->first;
+
+          const CTrace::CPoint *point3rd = it2nd->second;
+          unsigned dist3rd = point3rd->GPS().DistanceXYZ(point1st->GPS());
+          unsigned total_distance = dist1st + dist2nd + dist3rd;
+
+          if ( !FREETriangleEdgeCheck(dist1st, dist2nd, dist3rd) )
+            break;
+
+          double fFreeTriangleBestTogo = 100e100; // PC does not compile  DBL_MAX;
+          double fAngle = 0;
+          CPointGPS pgpsBestClose(0,0,0,0) ;
+          CPointGPS pgpsClose(0,0,0,0) ;
+          double closure;
+          if (_resultFREETriangle.PointArray().size() > 0) {
+            const CTrace::CPoint *p = trace.Front();
+            while (p && p->GPS().Time() <= _resultFREETriangle.PointArray()[1].Time()) {
+              DistanceBearing(GPS_INFO.Latitude, GPS_INFO.Longitude, p->GPS().Latitude(), p->GPS().Longitude(), &closure, &fAngle);
+              // Find best closure point
+              if (closure < fFreeTriangleBestTogo) {
+                pgpsBestClose = CPointGPS(GPS_INFO.Time,GPS_INFO.Latitude,GPS_INFO.Longitude,GPS_INFO.Altitude);
+                pgpsClose =  CPointGPS(p->GPS().Time(),p->GPS().Latitude(),p->GPS().Longitude(),p->GPS().Altitude());
+                fFreeTriangleBestTogo = closure;
+              }
+              p = p->Next();
+            }
+            _fFreeTriangleTogo = fFreeTriangleBestTogo;
+          }
+          if (total_distance <= _resultFREETriangle.PredictedDistance()) {   // just update distance to go with current triangle if necessary
+            if (_fFreeTriangleTogo < _fFreeTriangleBestTogo) {   // need only to update result
+              _fFreeTriangleBestTogo = _fFreeTriangleTogo;
+              _pgpsFreeTriangleBestClosePoint =  pgpsBestClose;
+              _pgpsFreeTriangleClosePoint = pgpsClose;
+              _resultFREETriangle.UpdateDistance(_resultFREETriangle.PredictedDistance() - _fFreeTriangleBestTogo);
+            }
+          }
+          else {  // bigger triangle found. Store it into pointArray
+            _fFreeTriangleBestTogo = _fFreeTriangleTogo;
+            const double current_distance = total_distance - _fFreeTriangleBestTogo;
+            CPointGPSArray pointArray;
+            pointArray.push_back(trace.Front()->GPS());
+            pointArray.push_back(point1st->GPS());
+            pointArray.push_back(point2nd->GPS());
+            pointArray.push_back(point3rd->GPS());
+            pointArray.push_back(trace.Back()->GPS());
+            _pgpsFreeTriangleBestClosePoint =  pgpsBestClose;
+            _pgpsFreeTriangleClosePoint = pgpsClose;
+
+            _resultFREETriangle.UpdateDistancesAndArray(current_distance, total_distance, pointArray);
+            }
+        }
+      }
+      point1st = point1st->Next();
+    }
+  }
+
+}
 
 /** 
  * @brief Sets dummy OLC-Plus results data
@@ -664,7 +844,6 @@ void CContestMgr::SolveOLCPlus(bool predicted)
             0, classic.Score() + fai.Score(), CPointGPSArray());
 }
 
-
 /** 
  * @brief Adds a new GPS fix to analysis
  * 
@@ -674,8 +853,12 @@ void CContestMgr::Add(unsigned time, double lat, double lon, int alt)
 {
   static CPointGPS lastGps(0, 0, 0, 0);
   static unsigned step = 0;
-  const unsigned STEPS_NUM = 7;
-  
+  unsigned STEPS_NUM;
+  if ( AdditionalContestRule == 0 ) // No additional Contest
+    STEPS_NUM = 7;
+  else
+    STEPS_NUM = 9;
+
   const CPointGPSSmart gps = make_CPointGPSSmart(time, lat, lon, alt);
   
   // filter out GPS fix repeats
@@ -706,7 +889,7 @@ void CContestMgr::Add(unsigned time, double lat, double lon, int alt)
   if(step % STEPS_NUM == 2) {
     // Solve FAI-OLC
     if(_traceLoop->Size()) {
-      SolveTriangle(*_traceLoop, _prevFAIFront.get(), _prevFAIBack.get(), false);
+      SolveFAITriangle(*_traceLoop, _prevFAIFront.get(), _prevFAIBack.get(), false);
       _prevFAIFront.reset(_traceLoop->Size() ? new CPointGPS(_traceLoop->Front()->GPS()) : 0);
       _prevFAIBack.reset(_traceLoop->Size() ? new CPointGPS(_traceLoop->Back()->GPS()) : 0);
       SolveOLCPlus(false);
@@ -727,7 +910,7 @@ void CContestMgr::Add(unsigned time, double lat, double lon, int alt)
   if(step % STEPS_NUM == 5) {
     // Solve FAI-OLC for predicted path
     if(_traceLoop->Size()) {
-      SolveTriangle(*_traceLoop, _prevFAIPredictedFront.get(), _prevFAIPredictedBack.get(), true);
+      SolveFAITriangle(*_traceLoop, _prevFAIPredictedFront.get(), _prevFAIPredictedBack.get(), true);
       _prevFAIPredictedFront.reset(_traceLoop->Size() ? new CPointGPS(_traceLoop->Front()->GPS()) : 0);
       _prevFAIPredictedBack.reset(_traceLoop->Size() ? new CPointGPS(_traceLoop->Back()->GPS()) : 0);
     }
@@ -743,9 +926,30 @@ void CContestMgr::Add(unsigned time, double lat, double lon, int alt)
     // Solve OLC-Sprint
     SolvePoints(*_traceSprint, true, false);
   }
-  
+
+  if ( AdditionalContestRule ) {
+
+    if (step % STEPS_NUM == 7) {
+      // Update XContest Free Triangle trace
+      _traceFreeTriangle->Clear();
+      if (!BiggestLoopFind(*_trace, *_traceFreeTriangle, true))
+        _traceFreeTriangle->Clear();
+    }
+
+    if (step % STEPS_NUM == 8) {
+
+      if (_traceFreeTriangle->Size()) {
+        SolveFREETriangle(*_traceFreeTriangle,_prevFreeTriangleFront.get(), _prevFreeTriangleBack.get());
+        _prevFreeTriangleFront.reset(_traceFreeTriangle->Size() ? new CPointGPS(_traceFreeTriangle->Front()->GPS()) : 0);
+        _prevFreeTriangleBack.reset(_traceFreeTriangle->Size() ? new CPointGPS(_traceFreeTriangle->Back()->GPS()) : 0);
+      }
+      SolveXC();
+    }
+  }
+
   step++;
 }
+
 
 
 /** 
@@ -764,4 +968,430 @@ void CContestMgr::Trace(CPointGPSArray &array) const
     point = point->Next();
   }
 }
+
+/**
+ * @brief Sets all dummy  Contest results data
+ *
+ * @param
+ */
+void CContestMgr::SolveXC() {
+
+  ScopeLock guard(_resultsCS);
+
+  // FAI
+  CResult &resfai = _resultArray[TYPE_OLC_FAI_PREDICTED];
+  const double predicted_distance_fai = resfai.Distance();
+  const double togo_distance_fai =  _fBestTogo;
+  const double current_distance_fai = predicted_distance_fai - togo_distance_fai;
+  const double score_fai = ScoreXC(current_distance_fai,predicted_distance_fai,XCFlightType::XC_FAI_TRIANGLE,true);
+  _resultArray[TYPE_XC_FAI_TRIANGLE] =  CResult(TYPE_XC_FAI_TRIANGLE,_XCFAIStatus!=XCTriangleStatus::CLOSED,
+                                                _XCFAIStatus==XCTriangleStatus::INVALID?0:current_distance_fai,
+                                                current_distance_fai,predicted_distance_fai,score_fai,
+                                                CPointGPSArray(_resultArray[TYPE_OLC_FAI_PREDICTED].PointArray()));
+
+  // Free Triangle
+  const double predicted_distance_ft = (double)_resultFREETriangle.PredictedDistance();
+  const double current_distance_ft = (double)_resultFREETriangle.CurrentDistance();
+  const double score_ft =  ScoreXC(current_distance_ft,predicted_distance_ft,XCFlightType::XC_FREE_TRIANGLE,true);
+  _resultArray[TYPE_XC_FREE_TRIANGLE] =  CResult(TYPE_XC_FREE_TRIANGLE,_XCFTStatus!=XCTriangleStatus::CLOSED,
+                                                 _XCFTStatus==XCTriangleStatus::INVALID?0:current_distance_ft,
+                                                 current_distance_ft,predicted_distance_ft,score_ft,
+                                                 CPointGPSArray(_resultFREETriangle.PointArray()));
+
+  // Free flight
+  CResult resff = _resultArray[TYPE_FAI_3_TPS];
+  const double current_distance_ff  = resff.Distance();;
+  const double score_ff = ScoreXC(current_distance_ff,current_distance_ff,XCFlightType::XC_FREE_FLIGHT,true);
+  _resultArray[TYPE_XC_FREE_FLIGHT] =  CResult(TYPE_XC_FREE_FLIGHT,false,current_distance_ff,current_distance_ff,
+                                               current_distance_ff,score_ff,
+                                               CPointGPSArray(_resultArray[TYPE_FAI_3_TPS].PointArray()));
+
+  // Combined Result
+  if ( (score_fai >= score_ff) && (score_fai >= score_ft) ) {  // FAI
+    _bestXCType = CContestMgr::XC_FAI_TRIANGLE;
+    _resultArray[TYPE_XC] = CResult( _resultArray[TYPE_XC_FAI_TRIANGLE]);
+  }
+  else if ( (score_ff >= score_fai) && (score_ff >= score_ft) ) {   // Free Flight
+    _bestXCType = CContestMgr::XC_FREE_FLIGHT;
+    _resultArray[TYPE_XC] = CResult( _resultArray[TYPE_XC_FREE_FLIGHT]);
+  }
+  else {   // Free Triangle
+    _bestXCType = CContestMgr::XC_FREE_TRIANGLE;
+    _resultArray[TYPE_XC] = CResult( _resultArray[TYPE_XC_FREE_TRIANGLE]);
+  }
+
+  // Best Triangle data
+  _bestXCTriangleType = XCFlightType::XC_INVALID;
+  double predicted_score_fai = ScoreXC(predicted_distance_fai,predicted_distance_fai,XCFlightType::XC_FAI_TRIANGLE,false);
+  double predicted_score_ft = ScoreXC(predicted_distance_ft,predicted_distance_ft,XCFlightType::XC_FREE_TRIANGLE,false);
+  if (predicted_score_fai > 0 && predicted_score_fai>=predicted_score_ft) {
+    _bestXCTriangleType = XCFlightType::XC_FAI_TRIANGLE;
+    _XCTriangleClosurePercentage = 100. * ( (predicted_distance_fai-current_distance_fai) / predicted_distance_fai ) ;
+    _XCTriangleClosureDistance = predicted_distance_fai - current_distance_fai;
+    _XCTriangleDistance = predicted_distance_fai;
+
+  }
+  else if (predicted_score_ft > 0) {
+    _bestXCTriangleType = XCFlightType::XC_FREE_TRIANGLE;
+    _XCTriangleClosurePercentage = 100. * ( (predicted_distance_ft-current_distance_ft) / predicted_distance_ft ) ;
+    _XCTriangleClosureDistance = predicted_distance_ft - current_distance_ft;
+    _XCTriangleDistance = predicted_distance_ft;
+  }
+
+  // Mean Speed
+  if ( resff.Duration() != 0 ) {
+    _XCMeanSpeed = resff.Distance() / resff.Duration();
+  }
+
+  // Set the RESWP_FAIOPTIMIZED
+  if ( _bestXCTriangleType == XCFlightType::XC_FAI_TRIANGLE) {
+    short Alt = 0;
+    RasterTerrain::Lock();
+    RasterTerrain::SetTerrainRounding(0,0);
+    Alt = RasterTerrain::GetTerrainHeight(_pgpsClosePoint.Latitude(),
+                                          _pgpsClosePoint.Longitude());
+    RasterTerrain::Unlock();
+    WayPointList[RESWP_FAIOPTIMIZED].Latitude=_pgpsClosePoint.Latitude();
+    WayPointList[RESWP_FAIOPTIMIZED].Longitude=_pgpsClosePoint.Longitude();
+    WayPointList[RESWP_FAIOPTIMIZED].Altitude=Alt;
+    if (WayPointList[RESWP_FAIOPTIMIZED].Altitude==0) WayPointList[RESWP_FAIOPTIMIZED].Altitude=0.001;
+    WayPointList[RESWP_FAIOPTIMIZED].Reachable=TRUE;
+    WayPointList[RESWP_FAIOPTIMIZED].Visible=TRUE;
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("Current FAI triangle closing point"));
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Name,_T("FAI Close"));
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Code,_T("FAI"));
+
+  }
+  else if ( _bestXCTriangleType == XCFlightType::XC_FREE_TRIANGLE) {
+    short Alt = 0;
+    RasterTerrain::Lock();
+    RasterTerrain::SetTerrainRounding(0,0);
+    Alt = RasterTerrain::GetTerrainHeight(_pgpsFreeTriangleClosePoint.Latitude(),
+                                          _pgpsFreeTriangleClosePoint.Longitude());
+    RasterTerrain::Unlock();
+    WayPointList[RESWP_FAIOPTIMIZED].Latitude=_pgpsFreeTriangleClosePoint.Latitude();
+    WayPointList[RESWP_FAIOPTIMIZED].Longitude=_pgpsFreeTriangleClosePoint.Longitude();
+    WayPointList[RESWP_FAIOPTIMIZED].Altitude=Alt;
+    if (WayPointList[RESWP_FAIOPTIMIZED].Altitude==0) WayPointList[RESWP_FAIOPTIMIZED].Altitude=0.001;
+    WayPointList[RESWP_FAIOPTIMIZED].Reachable=TRUE;
+    WayPointList[RESWP_FAIOPTIMIZED].Visible=TRUE;
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("Current Free triangle closing point"));
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Name,_T("TRI Close"));
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Code,_T("TRI"));
+  }
+  else {
+    WayPointList[RESWP_FAIOPTIMIZED].Altitude=RESWP_INVALIDNUMBER;
+    WayPointList[RESWP_FAIOPTIMIZED].Reachable=false;
+    WayPointList[RESWP_FAIOPTIMIZED].Visible=false;
+    _stprintf(WayPointList[RESWP_FAIOPTIMIZED].Comment,_T("no triangle closing point found!"));
+  }
+
+}
+
+/**
+ * @brief Score the Flight
+ *
+ * @param current_distance distance flight so far
+ * @param total_distance Second edge
+ * @param type Type of flight
+ *
+ * @return @c return score
+ */
+double CContestMgr::ScoreXC(double current_distance,double total_distance ,CContestMgr::XCFlightType type, bool update_status) {
+
+  double score = 0;
+
+  switch (AdditionalContestRule) {
+    case XContest2018:
+      score =  ScoreXContest2018(current_distance, total_distance, type, update_status);
+      break;
+    case XContest2019:
+      score =  ScoreXContest2019(current_distance, total_distance, type, update_status);
+      break;
+    case CFD:
+      score =   ScoreCDF(current_distance, total_distance, type, update_status);
+      break;
+    case LEONARDO_XC:
+      score =   ScoreLEONARDO_XC(current_distance, total_distance, type, update_status);
+      break;
+    case UK_NATIONAL_LEAGUE:
+      score =   ScoreUK_NATIONAL_LEAGUE(current_distance, total_distance, type, update_status);
+      break;
+  }
+  return score;
+}
+
+// XContest 2018
+// A flight may be scored as a triangle, when the distance between start point and
+// finish point (= closing distance) is less than 20% of the entire distance as given by the 3 turn points.
+double CContestMgr::ScoreXContest2018(double current_distance, double total_distance, CContestMgr::XCFlightType type, bool update_status) {
+
+  if (type == CContestMgr::XCFlightType::XC_FAI_TRIANGLE ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double togo_distance = total_distance - current_distance;
+    const double C = (togo_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::VALID;
+      return (current_distance/1000.) * 1.4;
+    }
+  }
+  else if (type == CContestMgr::XCFlightType::XC_FREE_TRIANGLE  ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double C = (total_distance - current_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::VALID;
+      return (current_distance/1000.) *   1.2;
+    }
+  }
+  else  if (type == CContestMgr::XCFlightType::XC_FREE_FLIGHT ) {
+    return current_distance/1000.;
+  }
+
+  if (update_status)  {
+    _XCFTStatus = XCTriangleStatus::INVALID;
+    _XCFAIStatus = XCTriangleStatus::INVALID;
+  }
+
+  return 0;
+}
+
+
+// XContest 2019
+// A flight may be scored as a triangle, when the distance between start point and
+// finish point (= closing distance) is less than 20% of the entire distance as given by the 3 turn points.
+// A flight is considered closed if closing distance is less than 5%. Coefficients from XContest World Rules 2019
+double CContestMgr::ScoreXContest2019(double current_distance, double total_distance, CContestMgr::XCFlightType type, bool update_status) {
+
+  if (type == CContestMgr::XCFlightType::XC_FAI_TRIANGLE ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double togo_distance = total_distance - current_distance;
+    const double C = (togo_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (C < 0.05) {
+        if (update_status)  _XCFAIStatus = XCTriangleStatus::CLOSED;
+        return (current_distance/1000.) * 1.6;
+      }
+      else {
+        if (update_status)  _XCFAIStatus = XCTriangleStatus::VALID;
+        return (current_distance/1000.) * 1.4;
+      }
+    }
+  }
+  else if (type == CContestMgr::XCFlightType::XC_FREE_TRIANGLE  ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double C = (total_distance - current_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (C < 0.05) {
+        if (update_status)  _XCFTStatus = XCTriangleStatus::CLOSED;
+        return (current_distance/1000.) * 1.4;
+      }
+      else {
+        if (update_status)  _XCFTStatus = XCTriangleStatus::VALID;
+        return (current_distance/1000.) *   1.2;
+      }
+    }
+  }
+  else  if (type == CContestMgr::XCFlightType::XC_FREE_FLIGHT ) {
+    return current_distance/1000.;
+  }
+
+  if (update_status)  {
+    _XCFTStatus = XCTriangleStatus::INVALID;
+    _XCFAIStatus = XCTriangleStatus::INVALID;
+  }
+
+  return 0;
+}
+
+// CDF
+// A flight may be scored as a triangle, when the distance between start point and
+// finish point (= closing distance) is less than 5% ( VALID ) or 3 km ( CLOSED) of the entire distance as given by the 3 turn points.
+// Pour tous les types de vol, l a distance minimale de vol prise en compte est de 15 kilomètres
+double CContestMgr::ScoreCDF(double current_distance,double total_distance,CContestMgr::XCFlightType type, bool update_status) {
+
+  if (type == CContestMgr::XCFlightType::XC_FAI_TRIANGLE ) {
+    if (total_distance <  15000 ) {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double togo_distance = total_distance - current_distance;
+    if ((togo_distance / total_distance) >= 0.05 && togo_distance >= 3000) {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    } else {
+      if (togo_distance < 3000) {
+        if (update_status)  _XCFAIStatus = XCTriangleStatus::CLOSED;
+        return (current_distance * 1.4 / 1000.);
+      } else {
+        if (update_status)  _XCFAIStatus = XCTriangleStatus::VALID;
+        return (total_distance / 1000.) * 1.4;
+      }
+    }
+  }
+  else if (type == CContestMgr::XCFlightType::XC_FREE_TRIANGLE  ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double togo_distance = total_distance - current_distance;
+    if ((togo_distance / total_distance) >= 0.05 && togo_distance >= 3000) {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    } else {
+      if (togo_distance < 3000) {
+        if (update_status)  _XCFTStatus = XCTriangleStatus::CLOSED;
+        return (current_distance * 1.2 / 1000.);
+      } else {
+        if (update_status)  _XCFTStatus = XCTriangleStatus::VALID;
+        return (total_distance / 1000.) * 1.2;
+      }
+    }
+  } else if (type == CContestMgr::XCFlightType::XC_FREE_FLIGHT ) {
+    return current_distance / 1000.;
+  }
+
+  if (update_status)  {
+    _XCFTStatus = XCTriangleStatus::INVALID;
+    _XCFAIStatus = XCTriangleStatus::INVALID;
+  }
+
+  return 0;
+}
+
+// Leonardo XC servers  (https://www.dhv-xc.de/leonardo/ , http://www.paraglidingforum.com/leonardo/tracks/world/alltimes/ )
+// A flight may be scored as a triangle, when the distance between start point and
+// finish point (= closing distance) is less than 20% of the entire distance as given by the 3 turn points.
+double CContestMgr::ScoreLEONARDO_XC(double current_distance, double total_distance, CContestMgr::XCFlightType type, bool update_status) {
+
+  if (type == CContestMgr::XCFlightType::XC_FAI_TRIANGLE ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double togo_distance = total_distance - current_distance;
+    const double C = (togo_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::VALID;
+      return (current_distance/1000.) * 2.0;
+    }
+  }
+  else if (type == CContestMgr::XCFlightType::XC_FREE_TRIANGLE  ) {
+    if (total_distance == 0 ) {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double C = (total_distance - current_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+
+      if (update_status)  _XCFTStatus = XCTriangleStatus::VALID;
+      return (current_distance/1000.) *   1.75;
+
+    }
+  }
+  else  if (type == CContestMgr::XCFlightType::XC_FREE_FLIGHT ) {
+    return (current_distance/1000.) *   1.50 ;
+  }
+
+  if (update_status)  {
+    _XCFTStatus = XCTriangleStatus::INVALID;
+    _XCFAIStatus = XCTriangleStatus::INVALID;
+  }
+
+  return 0;
+}
+
+// UK NATIONAL LEAGUE  (http://www.xcleague.com/xc/info/rules-leagues.html)
+// A flight may be scored as a triangle, when the distance between start point and
+// finish point (= closing distance) is less than 20% of the entire distance as given by the 3 turn points.
+// Flat triangles has a 15% minimum edge additional constrain and coefficient depends on total_distance
+double CContestMgr::ScoreUK_NATIONAL_LEAGUE(double current_distance, double total_distance, CContestMgr::XCFlightType type, bool update_status) {
+
+  if (type == CContestMgr::XCFlightType::XC_FAI_TRIANGLE ) {
+    if (total_distance < 15000 ) {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double togo_distance = total_distance - current_distance;
+    const double C = (togo_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (update_status)  _XCFAIStatus = XCTriangleStatus::VALID;
+      if ( total_distance < 25000 )
+        return (current_distance/1000.) * 1.7;
+      else
+        return (current_distance/1000.) * 2.0;
+    }
+  }
+  else if (type == CContestMgr::XCFlightType::XC_FREE_TRIANGLE  ) {
+    if (total_distance  < 15000 ) {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    const double C = (total_distance - current_distance) / total_distance;
+    if ( C >= 0.2 )  {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::INVALID;
+      return 0;
+    }
+    else {
+      if (update_status)  _XCFTStatus = XCTriangleStatus::VALID;
+      if ( total_distance < 35000 )
+        return (current_distance/1000.) *   1.3;
+      else
+        return (current_distance/1000.) *   1.7;
+    }
+  }
+  else  if (type == CContestMgr::XCFlightType::XC_FREE_FLIGHT ) {
+    return ( current_distance/1000.) * 1.3  ;
+  }
+
+  if (update_status)  {
+    _XCFTStatus = XCTriangleStatus::INVALID;
+    _XCFAIStatus = XCTriangleStatus::INVALID;
+  }
+
+  return 0;
+}
+
+
+
+
 

--- a/Common/Source/Calc/DoCalculations.cpp
+++ b/Common/Source/Calc/DoCalculations.cpp
@@ -70,6 +70,10 @@ bool DoCalculations(NMEA_INFO *Basic, DERIVED_INFO *Calculated)
     DoAlternates(Basic,Calculated,RESWP_FLARMTARGET);
     DoAlternates(Basic,Calculated,HomeWaypoint);
 
+    if ( OvertargetMode == OVT_XC ) {
+      DoAlternates(Basic, Calculated, RESWP_FAIOPTIMIZED);    // In Contest mode the Triangle closing point is our Goal.
+    }
+
     if (DoOptimizeRoute() || ACTIVE_WP_IS_AAT_AREA) {
       DoAlternates(Basic, Calculated, RESWP_OPTIMIZED);
     }

--- a/Common/Source/DataOptions.cpp
+++ b/Common/Source/DataOptions.cpp
@@ -309,9 +309,21 @@ void FillDataOptions()
 	SetDataOption(135, ugAltitude,TEXT("_@M2323_"), TEXT("_@M2324_"));  // Altitude QNE
 	SetDataOption(135, ugAltitude,TEXT("_@M2323_"), TEXT("_@M2324_"));  // Altitude QNE
 	SetDataOption(LK_NEXT_DIST_RADIUS, ugDistance, TEXT("_@M2190_"), TEXT("_@M2191_")); // Dist to next Cylinder turnpoint
-
+	SetDataOption(LK_XC_FF_DIST, ugDistance, TEXT("_@M2255_"), TEXT("_@M2266_"));		// AdditionalContest FREE Fligth distance
+	SetDataOption(LK_XC_FF_SCORE, ugNone, TEXT("_@M2256_"), TEXT("_@M2267_"));		// AdditionalContest FREE Fligth score
+	SetDataOption(LK_XC_FT_DIST, ugDistance, TEXT("_@M2257_"), TEXT("_@M2268_"));		// AdditionalContest FREE Triangle distance
+	SetDataOption(LK_XC_FT_SCORE, ugNone, TEXT("_@M2258_"), TEXT("_@M2269_"));		// AdditionalContest FREE Triangle score
+	SetDataOption(LK_XC_FAI_DIST, ugDistance, TEXT("_@M2259_"), TEXT("_@M2270_"));		// AdditionalContest FAI Triangle distance
+	SetDataOption(LK_XC_FAI_SCORE, ugNone, TEXT("_@M2260_"), TEXT("_@M2271_"));		// AdditionalContest FAI Triangle score
+    SetDataOption(LK_XC_DIST, ugDistance, TEXT("_@M2261_"), TEXT("_@M2272_"));		// AdditionalContest combined distance
+    SetDataOption(LK_XC_SCORE, ugNone, TEXT("_@M2262_"), TEXT("_@M2273_"));		// AdditionalContest combined score
+    SetDataOption(LK_XC_CLOSURE_DIST, ugDistance, TEXT("_@M2263_"), TEXT("_@M2274_"));		   // AdditionalContest combined closure distance
+    SetDataOption(LK_XC_CLOSURE_PERC, ugDistance, TEXT("_@M2264_"), TEXT("_@M2275_"));		// AdditionalContest combined closure %
+    SetDataOption(LK_XC_PREDICTED_DIST, ugDistance, TEXT("_@M2265_"), TEXT("_@M2276_"));		   // Additional Contest combined distance
+	SetDataOption(LK_XC_MEAN_SPEED, ugDistance, TEXT("_@M2277_"), TEXT("_@M2278_"));		   // Additional Contest combined distance
+  
 	//Before adding new items, consider changing NUMDATAOPTIONS_MAX
-  static_assert(LK_NEXT_DIST_RADIUS < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
+  static_assert(LK_XC_MEAN_SPEED < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
 
 
     // Fill all null string pointer with empty string, avoid to check all time is used.

--- a/Common/Source/Dialogs/AddCustomKeyList.cpp
+++ b/Common/Source/Dialogs/AddCustomKeyList.cpp
@@ -102,7 +102,7 @@ void AddCustomKeyList( DataField* dfe) {
     dfe->addEnumTextNoLF(MsgToken(2038)); // Map Orient
     dfe->addEnumTextNoLF(MsgToken(928)); //Restarting Comm Ports
     dfe->addEnumTextNoLF(MsgToken(2249)); // DspMode , not to be translated
-    dfe->addEnumTextNoLF(MsgToken(2251)); // Optimizer Mode
+    dfe->addEnumTextNoLF(MsgToken(2403)); // Toggle Draw XC
     dfe->addEnumTextNoLF(MsgToken(2337)); // Airspace lookup
 
     dfe->Sort(0);

--- a/Common/Source/Dialogs/Analysis/RenderContest.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderContest.cpp
@@ -17,249 +17,192 @@ CContestMgr::TType contestType = CContestMgr::TYPE_OLC_CLASSIC;
  * Alpha Lima splitted RenderContest from Render Task for CC
  * adding FAI Sector display
  ****************************************************************/
-void Statistics::RenderContest(LKSurface& Surface, const RECT& rc)
-{
-if((contestType == CContestMgr::TYPE_FAI_TRIANGLE)
-   || (contestType == CContestMgr::TYPE_FAI_TRIANGLE4)
-#ifdef  FIVEPOINT_OPTIMIZER
-   || (contestType == CContestMgr::TYPE_FAI_TRIANGLE5)
-#endif
-  )
-{
+void Statistics::RenderContest(LKSurface &Surface, const RECT &rc) {
+
+  if (contestType == CContestMgr::TYPE_FAI_ASSISTANT) {
     RenderFAIOptimizer(Surface, rc);
-}
-else
-{
-  double fXY_Scale = 1.0;
+  } else {
+    double fXY_Scale = 1.0;
 
 
-  double lat1 = 0;
-  double lon1 = 0;
-  double lat2 = 0;
-  double lon2 = 0;
-  double  x1, y1, x2=0, y2=0;
-  double lat_c, lon_c;
+    double lat1 = 0;
+    double lon1 = 0;
+    double lat2 = 0;
+    double lon2 = 0;
+    double x1, y1, x2 = 0, y2 = 0;
+    double lat_c, lon_c;
 
-  ResetScale();
-
-
-  CContestMgr::CResult result = CContestMgr::Instance().Result(contestType, true);
-  const CPointGPSArray &points = result.PointArray();
+    ResetScale();
 
 
-  // find center
-
-  CPointGPSArray trace;
-  CContestMgr::Instance().Trace(trace);
-  for(unsigned ui=0; ui<trace.size(); ui++)
-  {
-    lat1 = trace[ui].Latitude();
-    lon1 = trace[ui].Longitude();
-    ScaleYFromValue(rc, lat1);
-    ScaleXFromValue(rc, lon1);
-  }
-
-  const auto hfOldU = Surface.SelectObject(LK8PanelUnitFont);
-  lat_c = (y_max+y_min)/2;
-  lon_c = (x_max+x_min)/2;
+    CContestMgr::CResult result = CContestMgr::Instance().Result(contestType, true);
+    const CPointGPSArray &points = result.PointArray();
 
 
-  // find scale
-  ResetScale();
+    // find center
 
-  lat1 = GPS_INFO.Latitude;
-  lon1 = GPS_INFO.Longitude;
-  x1 = (lon1-lon_c)*fastcosine(lat1);
-  y1 = (lat1-lat_c);
-  ScaleXFromValue(rc, x1*fXY_Scale);
-  ScaleYFromValue(rc, y1*fXY_Scale);
-  for(unsigned ui=0; ui<trace.size(); ui++)
-  {
-    lat1 = trace[ui].Latitude();
-    lon1 = trace[ui].Longitude();
-    x1 = (lon1-lon_c)*fastcosine(lat1);
-    y1 = (lat1-lat_c);
-    ScaleXFromValue(rc, x1*fXY_Scale);
-    ScaleYFromValue(rc, y1*fXY_Scale);
-  }
-
-  ScaleMakeSquare(rc);
-
-
-
-  // draw track
-  if(!trace.empty()) {
-    for(unsigned ui=0; trace.size() && ui<trace.size()-1; ui++) {
+    CPointGPSArray trace;
+    CContestMgr::Instance().Trace(trace);
+    for (unsigned ui = 0; ui < trace.size(); ui++) {
       lat1 = trace[ui].Latitude();
       lon1 = trace[ui].Longitude();
-      lat2 = trace[ui+1].Latitude();
-      lon2 = trace[ui+1].Longitude();
-      x1 = (lon1-lon_c)*fastcosine(lat1);
-      y1 = (lat1-lat_c);
-      x2 = (lon2-lon_c)*fastcosine(lat2);
-      y2 = (lat2-lat_c);
-      DrawLine(Surface, rc,  x1, y1, x2, y2, STYLE_MEDIUMBLACK);
+      ScaleYFromValue(rc, lat1);
+      ScaleXFromValue(rc, lon1);
     }
-  }
-  // Draw aircraft on top
-double  lat_p = GPS_INFO.Latitude;
-double  lon_p = GPS_INFO.Longitude;
-double  xp = (lon_p-lon_c)*fastcosine(lat_p);
-double  yp = (lat_p-lat_c);
 
-  int style_lastEdge = result.Predicted() ? STYLE_BLUETHIN : STYLE_REDTHICK;;
-  if(result.Type() == contestType && !points.empty())
-  {
-    for(unsigned ui=0; ui<points.size()-1; ui++)
-    {
-        
-      if ((result.Type() == CContestMgr::TYPE_XC_FAI_TRIANGLE ||
-               result.Type() == CContestMgr::TYPE_XC_FREE_TRIANGLE) &&
-            (ui == 0 || ui == 3))
-        continue;
-        
-      lat1 = points[ui].Latitude();
-      lon1 = points[ui].Longitude();
-      lat2 = points[ui+1].Latitude();
-      lon2 = points[ui+1].Longitude();
+    const auto hfOldU = Surface.SelectObject(LK8PanelUnitFont);
+    lat_c = (y_max + y_min) / 2;
+    lon_c = (x_max + x_min) / 2;
 
-      x1 = (lon1-lon_c)*fastcosine(lat1);
-      y1 = (lat1-lat_c);
-      x2 = (lon2-lon_c)*fastcosine(lat2);
-      y2 = (lat2-lat_c);
-      int style = STYLE_REDTHICK;
-      if((result.Type() == CContestMgr::TYPE_OLC_FAI ||
-          result.Type() == CContestMgr::TYPE_OLC_FAI_PREDICTED) &&
-         (ui==0 || ui==3))
-      {
-        // triangle start and finish
-        style = STYLE_DASHGREEN;
+
+    // find scale
+    ResetScale();
+
+    lat1 = GPS_INFO.Latitude;
+    lon1 = GPS_INFO.Longitude;
+    x1 = (lon1 - lon_c) * fastcosine(lat1);
+    y1 = (lat1 - lat_c);
+    ScaleXFromValue(rc, x1 * fXY_Scale);
+    ScaleYFromValue(rc, y1 * fXY_Scale);
+    for (unsigned ui = 0; ui < trace.size(); ui++) {
+      lat1 = trace[ui].Latitude();
+      lon1 = trace[ui].Longitude();
+      x1 = (lon1 - lon_c) * fastcosine(lat1);
+      y1 = (lat1 - lat_c);
+      ScaleXFromValue(rc, x1 * fXY_Scale);
+      ScaleYFromValue(rc, y1 * fXY_Scale);
+    }
+
+    ScaleMakeSquare(rc);
+
+
+
+    // draw track
+    if (!trace.empty()) {
+      for (unsigned ui = 0; trace.size() && ui < trace.size() - 1; ui++) {
+        lat1 = trace[ui].Latitude();
+        lon1 = trace[ui].Longitude();
+        lat2 = trace[ui + 1].Latitude();
+        lon2 = trace[ui + 1].Longitude();
+        x1 = (lon1 - lon_c) * fastcosine(lat1);
+        y1 = (lat1 - lat_c);
+        x2 = (lon2 - lon_c) * fastcosine(lat2);
+        y2 = (lat2 - lat_c);
+        DrawLine(Surface, rc, x1, y1, x2, y2, STYLE_MEDIUMBLACK);
       }
-      else if(result.Predicted() &&
-              (result.Type() == CContestMgr::TYPE_OLC_FAI_PREDICTED ||
+    }
+    // Draw aircraft on top
+    double lat_p = GPS_INFO.Latitude;
+    double lon_p = GPS_INFO.Longitude;
+    double xp = (lon_p - lon_c) * fastcosine(lat_p);
+    double yp = (lat_p - lat_c);
+
+
+    if (result.Type() == contestType && !points.empty()) {
+      for (unsigned ui = 0; ui < points.size() - 1; ui++) {
+        lat1 = points[ui].Latitude();
+        lon1 = points[ui].Longitude();
+        lat2 = points[ui + 1].Latitude();
+        lon2 = points[ui + 1].Longitude();
+
+        x1 = (lon1 - lon_c) * fastcosine(lat1);
+        y1 = (lat1 - lat_c);
+        x2 = (lon2 - lon_c) * fastcosine(lat2);
+        y2 = (lat2 - lat_c);
+        int style = STYLE_REDTHICK;
+        if ((result.Type() == CContestMgr::TYPE_OLC_FAI ||
+            result.Type() == CContestMgr::TYPE_OLC_FAI_PREDICTED) &&
+            (ui == 0 || ui == 3)) {
+          // triangle start and finish
+          style = STYLE_DASHGREEN;
+        } else if (result.Predicted() &&
+            (result.Type() == CContestMgr::TYPE_OLC_FAI_PREDICTED ||
                 result.Type() == CContestMgr::TYPE_XC_FAI_TRIANGLE ||
                 result.Type() == CContestMgr::TYPE_XC_FREE_TRIANGLE ||
-               ui == points.size() - 2))
-      {
-        // predicted edge
-        style = STYLE_BLUETHIN;
+                result.Type() == CContestMgr::TYPE_FAI_ASSISTANT ||
+                ui == points.size() - 2)) {
+          // predicted edge
+          style = STYLE_BLUETHIN;
+        }
+
+        if ((result.Type() == CContestMgr::TYPE_FAI_3_TPS) ||// TYPE_FAI_3_TPS_PREDICTED
+            (result.Type() == CContestMgr::TYPE_FAI_3_TPS_PREDICTED)) {
+        }
+
+        if ((contestType != CContestMgr::TYPE_FAI_ASSISTANT))
+          DrawLine(Surface, rc, x1, y1, x2, y2, style);
       }
 
-      if((result.Type() == CContestMgr::TYPE_FAI_3_TPS) ||// TYPE_FAI_3_TPS_PREDICTED
-       (result.Type() == CContestMgr::TYPE_FAI_3_TPS_PREDICTED) )
-      {
-      }
-      if ((result.Predicted() &&                         // XContest not valid triangle
-            (result.Type() == CContestMgr::TYPE_XC_FAI_TRIANGLE ||
-                result.Type() == CContestMgr::TYPE_XC_FREE_TRIANGLE))
-            && result.Score() == 0) {
-          style = STYLE_THINDASHPAPER;
-          style_lastEdge = STYLE_THINDASHPAPER;
-      }
 
-      if((contestType != CContestMgr::TYPE_FAI_TRIANGLE) )
-        DrawLine(Surface, rc, x1, y1, x2, y2, style);
-    }
-
-
-  if(result.Type() == CContestMgr::TYPE_OLC_FAI ||
-     result.Type() == CContestMgr::TYPE_OLC_FAI_PREDICTED||
+      if (result.Type() == CContestMgr::TYPE_OLC_FAI ||
+          result.Type() == CContestMgr::TYPE_OLC_FAI_PREDICTED ||
           result.Type() == CContestMgr::TYPE_XC_FREE_TRIANGLE ||
-          result.Type() == CContestMgr::TYPE_XC_FAI_TRIANGLE)
-  {
-    // draw the last edge of a triangle
-    lat1 = points[1].Latitude();
-    lon1 = points[1].Longitude();
-    lat2 = points[3].Latitude();
-    lon2 = points[3].Longitude();
-    x1 = (lon1-lon_c)*fastcosine(lat1);
-    y1 = (lat1-lat_c);
-    x2 = (lon2-lon_c)*fastcosine(lat2);
-    y2 = (lat2-lat_c);
+          result.Type() == CContestMgr::TYPE_XC_FAI_TRIANGLE ||
+          result.Type() == CContestMgr::TYPE_FAI_ASSISTANT) {
+        // draw the last edge of a triangle
+        lat1 = points[1].Latitude();
+        lon1 = points[1].Longitude();
+        lat2 = points[3].Latitude();
+        lon2 = points[3].Longitude();
+        x1 = (lon1 - lon_c) * fastcosine(lat1);
+        y1 = (lat1 - lat_c);
+        x2 = (lon2 - lon_c) * fastcosine(lat2);
+        y2 = (lat2 - lat_c);
 
-    DrawLine(Surface, rc, x1, y1, x2, y2, result.Predicted() ? STYLE_BLUETHIN : STYLE_REDTHICK);
+        DrawLine(Surface, rc, x1, y1, x2, y2, result.Predicted() ? STYLE_BLUETHIN : STYLE_REDTHICK);
 
-  }
+      }
 
-  DrawXGrid(Surface, rc, 1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
-  DrawYGrid(Surface, rc, 1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
+      DrawXGrid(Surface, rc, 1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
+      DrawYGrid(Surface, rc, 1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
 
-  Surface.SelectObject(hfOldU);
-  #ifndef DITHER
-  Surface.SetTextColor(RGB_MAGENTA);
-  #else
-  Surface.SetTextColor(RGB_BLACK);
-  #endif
-  Surface.SetBackgroundTransparent();
-  DrawLabel(Surface, rc, TEXT("O"), xp, yp);
-  
-  // Render XContest Closure
-  if (result.Type() == CContestMgr::TYPE_XC_FAI_TRIANGLE) {
-    lat2 = CContestMgr::Instance().GetBestClosingPoint().Latitude();
-    lon2 = CContestMgr::Instance().GetBestClosingPoint().Longitude();
-    x1 = (lon2 - lon_c) * fastcosine(lat2);
-    y1 = (lat2 - lat_c);
-    DrawLine(Surface, rc, xp, yp, x1, y1, STYLE_REDTHICK);
-  } else if (result.Type() == CContestMgr::TYPE_XC_FREE_TRIANGLE) {
-    lat1 = CContestMgr::Instance().GetFreeTriangleClosingPoint().Latitude();
-    lon1 = CContestMgr::Instance().GetFreeTriangleClosingPoint().Longitude();
-    lat2 = CContestMgr::Instance().GetFreeTriangleBestClosingPoint().Latitude();;
-    lon2 = CContestMgr::Instance().GetFreeTriangleBestClosingPoint().Longitude();
-    x1 = (lon2 - lon_c) * fastcosine(lat2);
-    y1 = (lat2 - lat_c);
-    x2 = (lon1 - lon_c) * fastcosine(lat1);
-    y2 = (lat1 - lat_c);
-    DrawLine(Surface, rc, x1, y1, x2, y2, STYLE_REDTHICK);
+      Surface.SelectObject(hfOldU);
+#ifndef DITHER
+      Surface.SetTextColor(RGB_MAGENTA);
+#else
+      Surface.SetTextColor(RGB_BLACK);
+#endif
+      Surface.SetBackgroundTransparent();
+      DrawLabel(Surface, rc, TEXT("O"), xp, yp);
+    }
   }
 }
-}
-}
-
-
-
 
 
 /*****************************************************************
  * Alpha Lima splitted RenderContest from Render Task for CC
  * adding FAI Sector display
  ****************************************************************/
-void Statistics::RenderFAIOptimizer(LKSurface& Surface, const RECT& rc)
-{
+void Statistics::RenderFAIOptimizer(LKSurface &Surface, const RECT &rc) {
 
-unsigned int ui;
-double fXY_Scale = 2.6;
-double lat0 = 0;
-double lon0 = 0;
-double lat1 = 0;
-double lon1 = 0;
-double lat2 = 0;
-double lon2 = 0;
-double x0, y0, x1, y1, x2=0, y2=0;
-double lat_c, lon_c;
-double  lat_p = GPS_INFO.Latitude;
-double  lon_p = GPS_INFO.Longitude;
-BOOL bFlat = false;
+  unsigned int ui;
+  double fXY_Scale = 2.6;
+  double lat1 = 0;
+  double lon1 = 0;
+  double lat2 = 0;
+  double lon2 = 0;
+  double x1, y1, x2 = 0, y2 = 0;
+  double lat_c, lon_c;
+  double lat_p = GPS_INFO.Latitude;
+  double lon_p = GPS_INFO.Longitude;
 #define DRAWPERCENT
 #ifdef DRAWPERCENT
-double fTotalPercent = 1.0;
+  double fTotalPercent = 1.0;
 #endif
 
-ResetScale();
-static FAI_Sector ContestFAISector[10];
+  ResetScale();
+  static FAI_Sector ContestFAISector[4];
 
 
-  CContestMgr::CResult result = CContestMgr::Instance().Result( CContestMgr::TYPE_FAI_TRIANGLE, true);
-  const CPointGPSArray &points = result.PointArray();
-//  if(contestType == CContestMgr::TYPE_FAI_TRIANGLE)
-     fXY_Scale = 2.5;
+  CContestMgr::CResult result = CContestMgr::Instance().Result(CContestMgr::TYPE_FAI_ASSISTANT, true);
+  fXY_Scale = 2.5;
 
   // find center
   double fTotalDistance = result.Distance();
- if (fTotalDistance < 1) fTotalDistance =1;
+  if (fTotalDistance < 1) fTotalDistance = 1;
   CPointGPSArray trace;
   CContestMgr::Instance().Trace(trace);
-  for(ui=0; ui<trace.size(); ui++)
-  {
+  for (ui = 0; ui < trace.size(); ui++) {
     lat1 = trace[ui].Latitude();
     lon1 = trace[ui].Longitude();
     ScaleYFromValue(rc, lat1);
@@ -268,219 +211,163 @@ static FAI_Sector ContestFAISector[10];
 
 
   const auto hfOldU = Surface.SelectObject(LK8PanelUnitFont);
-  BOOL bFAITri =  CContestMgr::Instance().FAI();
+  BOOL bFAITri = CContestMgr::Instance().FAI();
   double fDist, fAngle;
-  lat_c = (y_max+y_min)/2;
-  lon_c = (x_max+x_min)/2;
+  lat_c = (y_max + y_min) / 2;
+  lon_c = (x_max + x_min) / 2;
 
-  double  xp = (lon_p-lon_c)*fastcosine(lat_p);
-  double  yp = (lat_p-lat_c);
+  double xp = (lon_p - lon_c) * fastcosine(lat_p);
+  double yp = (lat_p - lat_c);
 
   // find scale
   ResetScale();
 
   lat1 = GPS_INFO.Latitude;
   lon1 = GPS_INFO.Longitude;
-  x1 = (lon1-lon_c)*fastcosine(lat1);
-  y1 = (lat1-lat_c);
-  ScaleXFromValue(rc, x1*fXY_Scale);
-  ScaleYFromValue(rc, y1*fXY_Scale);
-  for(ui=0; ui<trace.size(); ui++)
-  {
+  x1 = (lon1 - lon_c) * fastcosine(lat1);
+  y1 = (lat1 - lat_c);
+  ScaleXFromValue(rc, x1 * fXY_Scale);
+  ScaleYFromValue(rc, y1 * fXY_Scale);
+  for (ui = 0; ui < trace.size(); ui++) {
     lat1 = trace[ui].Latitude();
     lon1 = trace[ui].Longitude();
-    x1 = (lon1-lon_c)*fastcosine(lat1);
-    y1 = (lat1-lat_c);
-    ScaleXFromValue(rc, x1*fXY_Scale);
-    ScaleYFromValue(rc, y1*fXY_Scale);
+    x1 = (lon1 - lon_c) * fastcosine(lat1);
+    y1 = (lat1 - lat_c);
+    ScaleXFromValue(rc, x1 * fXY_Scale);
+    ScaleYFromValue(rc, y1 * fXY_Scale);
   }
 
   ScaleMakeSquare(rc);
 
 
+  // Draw FAI sectors
+  const CContestMgr::TriangleLeg *max_leg = CContestMgr::Instance().GetFAIAssistantMaxLeg();
+  if ( max_leg != nullptr && max_leg->LegDist >= FAI_MIN_DISTANCE_THRESHOLD) {
 
+    const CContestMgr::TriangleLeg *leg0 = CContestMgr::Instance().GetFAIAssistantLeg(0);
+    const CContestMgr::TriangleLeg *leg1 = CContestMgr::Instance().GetFAIAssistantLeg(1);
+    const CContestMgr::TriangleLeg *leg2 = CContestMgr::Instance().GetFAIAssistantLeg(2);
+    const double distance = leg0->LegDist + leg1->LegDist + leg2->LegDist;
 
-  if(result.Type() ==  CContestMgr::TYPE_FAI_TRIANGLE && !points.empty())
-  {
-    for(ui=0; ui<points.size()-1; ui++)
-    {
-      lat1 = points[ui].Latitude();
-      lon1 = points[ui].Longitude();
-      lat2 = points[ui+1].Latitude();
-      lon2 = points[ui+1].Longitude();
-
-      x1 = (lon1-lon_c)*fastcosine(lat1);
-      y1 = (lat1-lat_c);
-      x2 = (lon2-lon_c)*fastcosine(lat2);
-      y2 = (lat2-lat_c);
-      DistanceBearing(lat1, lon1, lat2, lon2, &fDist, &fAngle);
-
-      if( (ui <points.size()-2) && !bFlat && ((fDist / fTotalDistance ) > 0.05) )
-      {
-		if(fDist > 5000)
-		{
-                  #ifndef DITHER
-		  LKColor rgbCol = RGB_BLUE;
-		  switch(ui)
-		  {
-			case 0: rgbCol = RGB_LIGHTYELLOW; break;
-			case 1: rgbCol = RGB_LIGHTCYAN  ; break;
-			case 2: rgbCol = RGB_LIGHTGREEN ; break;
-			default:
-			break;
-		  }
-                  #else
-                  LKColor rgbCol = RGB_DARKBLUE;
-                  switch(ui)
-                  {
-                      case 0: rgbCol = RGB_LIGHTGREY; break;
-                      case 1: rgbCol = RGB_GREY  ; break;
-                      case 2: rgbCol = RGB_MIDDLEGREY ; break;
-                      default:
-                      break;
-                  }
-                  #endif
-            if(ui < 5)
-            {
-
-            double fTic,fDist_c, fAngle ;
-            DistanceBearing(lat1, lon1, lat2, lon2, &fDist_c, &fAngle);
-			fTic= 10/DISTANCEMODIFY;
-			if(fDist_c > 5/DISTANCEMODIFY)   fTic = 20/DISTANCEMODIFY;
-			if(fDist_c > 50/DISTANCEMODIFY)  fTic = 50/DISTANCEMODIFY;
-			if(fDist_c > 100/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
-			//  if(fDist_c > 200/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
-			if(fDist_c > 500/DISTANCEMODIFY) fTic = 250/DISTANCEMODIFY;
-
-
-			ContestFAISector[2*ui].CalcSectorCache(lat1,  lon1,  lat2,  lon2, fTic, 1);
-			ContestFAISector[2*ui].AnalysisDrawFAISector ( Surface, rc,  GeoPoint(lat_c,lon_c) , rgbCol) ;
-			ContestFAISector[2*ui+1].CalcSectorCache(lat1,  lon1,  lat2,  lon2, fTic, 0);
-			ContestFAISector[2*ui+1].AnalysisDrawFAISector ( Surface, rc,  GeoPoint(lat_c,lon_c) , rgbCol) ;
-            }
-		}
+    double fTic;
+    if (!CContestMgr::Instance().LooksLikeAFAITriangle()) {
+      // Does not look like a FAI attempt. Just draw both FAI sectors on longest leg.
+      fTic = 10 / DISTANCEMODIFY;
+      if (max_leg->LegDist > 5 / DISTANCEMODIFY) fTic = 20 / DISTANCEMODIFY;
+      if (max_leg->LegDist > 50 / DISTANCEMODIFY) fTic = 50 / DISTANCEMODIFY;
+      if (max_leg->LegDist > 100 / DISTANCEMODIFY) fTic = 100 / DISTANCEMODIFY;
+      //  if(fDist_c > 200/DISTANCEMODIFY) fTic = 100/DISTANCEMODIFY;
+      if (max_leg->LegDist > 500 / DISTANCEMODIFY) fTic = 250 / DISTANCEMODIFY;
+      ContestFAISector[0].CalcSectorCache(max_leg->Lat1, max_leg->Lon1, max_leg->Lat2, max_leg->Lon2, fTic, 0);
+      ContestFAISector[0].AnalysisDrawFAISector(Surface, rc, GeoPoint(lat_c, lon_c), RGB_LIGHTYELLOW);
+      ContestFAISector[1].CalcSectorCache(max_leg->Lat1, max_leg->Lon1, max_leg->Lat2, max_leg->Lon2, fTic, 1);
+      ContestFAISector[1].AnalysisDrawFAISector(Surface, rc, GeoPoint(lat_c, lon_c), RGB_LIGHTYELLOW);
+    } else {
+      if (CContestMgr::Instance().GetFAIAssistantLeg(0)->LegDist > FAI_MIN_DISTANCE_THRESHOLD) {
+        fTic = 10 / DISTANCEMODIFY;
+        if (leg0->LegDist > 5 / DISTANCEMODIFY) fTic = 20 / DISTANCEMODIFY;
+        if (leg0->LegDist > 50 / DISTANCEMODIFY) fTic = 50 / DISTANCEMODIFY;
+        if (leg0->LegDist > 100 / DISTANCEMODIFY) fTic = 100 / DISTANCEMODIFY;
+        // Draw the yellow sector on the best current direction.
+        ContestFAISector[1].CalcSectorCache(leg0->Lat1, leg0->Lon1, leg0->Lat2, leg0->Lon2, fTic, CContestMgr::Instance().isFAITriangleClockwise());
+        ContestFAISector[1].AnalysisDrawFAISector(Surface, rc, GeoPoint(lat_c, lon_c), RGB_YELLOW);
       }
-      if((fDist / fTotalDistance ) > 0.45) /* prevent drawing almost same sectors */
-	bFlat = true;
-    }
-
-    // draw track
-    for(ui=0; trace.size() && ui<trace.size()-1; ui++)
-    {
-      lat1 = trace[ui].Latitude();
-      lon1 = trace[ui].Longitude();
-      lat2 = trace[ui+1].Latitude();
-      lon2 = trace[ui+1].Longitude();
-      x1 = (lon1-lon_c)*fastcosine(lat1);
-      y1 = (lat1-lat_c);
-      x2 = (lon2-lon_c)*fastcosine(lat2);
-      y2 = (lat2-lat_c);
-      DrawLine(Surface, rc,  x1, y1, x2, y2, STYLE_MEDIUMBLACK);
-    }
-
-
-
-	for(ui=0; ui<points.size()-1; ui++)
-	{
-	  lat1 = points[ui].Latitude();
-	  lon1 = points[ui].Longitude();
-	  lat2 = points[ui+1].Latitude();
-	  lon2 = points[ui+1].Longitude();
-
-	  x1 = (lon1-lon_c)*fastcosine(lat1);
-	  y1 = (lat1-lat_c);
-	  x2 = (lon2-lon_c)*fastcosine(lat2);
-	  y2 = (lat2-lat_c);
-	  int style = STYLE_REDTHICK;
-
-	  if((ui > 0) && (ui < 3))
-	  {
-		style = STYLE_BLUETHIN;
-		DistanceBearing(lat1, lon1, lat2, lon2, &fDist, &fAngle);
-	#ifdef DRAWPERCENT
-
-		if((result.Distance()> 5000) && bFAITri)
-		{
-		  TCHAR text[180];
-		  SIZE tsize;
-		  fTotalPercent -= fDist/result.Distance();
-		  _stprintf(text, TEXT("%3.1f%%"), (fDist/result.Distance()*100.0));
-		  Surface.GetTextSize(text, &tsize);
-                  #ifndef DITHER
-		  Surface.SetTextColor(RGB_BLUE);
-                  #else
-		  Surface.SetTextColor(RGB_BLACK);
-                  #endif
-	      Surface.DrawText(ScaleX(rc, x1 +( x2-x1)/2)-tsize.cx/2,   ScaleY(rc,y1 + (y2-y1)/2), text);
-	    }
-	#endif
-
-	    DrawLine(Surface, rc, x1, y1, x2, y2, style);
-	  }
-	}
-
-    if(bFAITri)
-    {
-	  if(points.size() >3)
-	  {
-
-        if(ISPARAGLIDER)
-        {
-		  lat0 = CContestMgr::Instance().GetBestNearClosingPoint().Latitude();
-		  lon0 = CContestMgr::Instance().GetBestNearClosingPoint().Longitude();
-		  lat1 = CContestMgr::Instance().GetBestClosingPoint().Latitude();
-		  lon1 = CContestMgr::Instance().GetBestClosingPoint().Longitude();
-		  x1 = (lon0-lon_c)*fastcosine(lat0);
-		  y1 = (lat0-lat_c);
-		  x2 = (lon1-lon_c)*fastcosine(lat1);
-		  y2 = (lat1-lat_c);
-		  DrawLine(Surface, rc, x1, y1, x2, y2, STYLE_ORANGETHIN ); //result.Predicted() ? STYLE_BLUETHIN : STYLE_REDTHICK);
+      // If a valid second leg (or a leg that belong to the current best FAI triangle ) draw it in the correct direction
+      if (leg1->LegDist > distance * 0.25) {
+        fTic = 10 / DISTANCEMODIFY;
+        if (leg1->LegDist > 5 / DISTANCEMODIFY) fTic = 20 / DISTANCEMODIFY;
+        if (leg1->LegDist > 50 / DISTANCEMODIFY) fTic = 50 / DISTANCEMODIFY;
+        if (leg1->LegDist > 100 / DISTANCEMODIFY) fTic = 100 / DISTANCEMODIFY;
+        ContestFAISector[3].CalcSectorCache(leg1->Lat1, leg1->Lon1, leg1->Lat2, leg1->Lon2, fTic, CContestMgr::Instance().isFAITriangleClockwise());
+        ContestFAISector[3].AnalysisDrawFAISector(Surface, rc, GeoPoint(lat_c, lon_c), RGB_CYAN);
+        if (leg2->LegDist > distance * 0.25) {
+          fTic = 10 / DISTANCEMODIFY;
+          if (leg2->LegDist > 5 / DISTANCEMODIFY) fTic = 20 / DISTANCEMODIFY;
+          if (leg2->LegDist > 50 / DISTANCEMODIFY) fTic = 50 / DISTANCEMODIFY;
+          if (leg2->LegDist > 100 / DISTANCEMODIFY) fTic = 100 / DISTANCEMODIFY;
+          ContestFAISector[3].CalcSectorCache(leg2->Lat1, leg2->Lon1, leg2->Lat2, leg2->Lon2, fTic, CContestMgr::Instance().isFAITriangleClockwise());
+          ContestFAISector[3].AnalysisDrawFAISector(Surface, rc, GeoPoint(lat_c, lon_c), RGB_GREEN);
         }
+      }
 
-	    lat1 = points[1].Latitude();
-	    lon1 = points[1].Longitude();
-	    lat2 = points[3].Latitude();
-	    lon2 = points[3].Longitude();
-	    x1 = (lon1-lon_c)*fastcosine(lat1);
-	    y1 = (lat1-lat_c);
-	    x2 = (lon2-lon_c)*fastcosine(lat2);
-	    y2 = (lat2-lat_c);
-
-	    DrawLine(Surface, rc, x1, y1, x2, y2, STYLE_THINDASHPAPER ); //result.Predicted() ? STYLE_BLUETHIN : STYLE_REDTHICK);
-#ifdef DRAWPERCENT
-	    TCHAR text[180];
-	    SIZE tsize;
-	    _stprintf(text, TEXT("%3.1f%%"), (fTotalPercent*100.0));
-	    Surface.GetTextSize(text, &tsize);
-            #ifndef DITHER
-	    Surface.SetTextColor(RGB_LIGHTBLUE);
-            #else
-	    Surface.SetTextColor(RGB_RED);
-            #endif
-	    Surface.DrawText(ScaleX(rc, x1 +( x2-x1)/2)-tsize.cx/2,   ScaleY(rc,y1 + (y2-y1)/2), text);
-#endif
-
-	    lat0 = CContestMgr::Instance().GetClosingPoint().Latitude();
-	    lon0 = CContestMgr::Instance().GetClosingPoint().Longitude();
-	    x0 = (lon0-lon_c)*fastcosine(lat0);
-	    y0 = (lat0-lat_c);
-	    DrawLine(Surface, rc, xp, yp, x0, y0, STYLE_REDTHICK);
-	  }
     }
+    // draw triangle
+    for (ui = 0; ui < 3; ui++) {
+      lat1 = CContestMgr::Instance().GetFAIAssistantLeg(ui)->Lat1;
+      lon1 = CContestMgr::Instance().GetFAIAssistantLeg(ui)->Lon1;
+      lat2 = CContestMgr::Instance().GetFAIAssistantLeg(ui)->Lat2;
+      lon2 = CContestMgr::Instance().GetFAIAssistantLeg(ui)->Lon2;
+      x1 = (lon1 - lon_c) * fastcosine(lat1);
+      y1 = (lat1 - lat_c);
+      x2 = (lon2 - lon_c) * fastcosine(lat2);
+      y2 = (lat2 - lat_c);
+
+      int style = STYLE_BLUETHIN;
+      DistanceBearing(lat1, lon1, lat2, lon2, &fDist, &fAngle);
+#ifdef DRAWPERCENT
+      if ((result.Distance() > 5000) && bFAITri) {
+        TCHAR text[180];
+        SIZE tsize;
+        fTotalPercent -= fDist / result.Distance();
+        _stprintf(text, TEXT("%3.1f%%"), (fDist / result.Distance() * 100.0));
+        Surface.GetTextSize(text, &tsize);
+#ifndef DITHER
+        Surface.SetTextColor(RGB_BLUE);
+#else
+        Surface.SetTextColor(RGB_BLACK);
+#endif
+        Surface.DrawText(ScaleX(rc, x1 + (x2 - x1) / 2) - tsize.cx / 2, ScaleY(rc, y1 + (y2 - y1) / 2), text);
+      }
+#endif
+      DrawLine(Surface, rc, x1, y1, x2, y2, style);
+    }
+
+    // Draw closing segment
+    if (CContestMgr::Instance().FAI()) {
+      lat1 = CContestMgr::Instance().GetFreeTriangleClosingPoint().Latitude();
+      lon1 = CContestMgr::Instance().GetFreeTriangleClosingPoint().Longitude();
+      x1 = (lon1 - lon_c) * fastcosine(lat1);
+      y1 = (lat1 - lat_c);
+      DrawLine(Surface, rc, x1, y1, xp, yp, STYLE_REDTHICK);
+    }
+
+
+  }
+
+
+
+  // draw track
+  for (ui = 0; trace.size() && ui < trace.size() - 1; ui++) {
+    lat1 = trace[ui].Latitude();
+    lon1 = trace[ui].Longitude();
+    lat2 = trace[ui + 1].Latitude();
+    lon2 = trace[ui + 1].Longitude();
+    x1 = (lon1 - lon_c) * fastcosine(lat1);
+    y1 = (lat1 - lat_c);
+    x2 = (lon2 - lon_c) * fastcosine(lat2);
+    y2 = (lat2 - lat_c);
+    DrawLine(Surface, rc, x1, y1, x2, y2, STYLE_MEDIUMBLACK);
   }
 
 
 
 
-DrawXGrid(Surface, rc, 1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
-DrawYGrid(Surface, rc, 1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
-Surface.SetBackgroundTransparent();
+  DrawXGrid(Surface, rc,
+            1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
+  DrawYGrid(Surface, rc,
+            1.0, 0, STYLE_THINDASHPAPER, 1.0, false);
+  Surface.
+      SetBackgroundTransparent();
 #ifndef DITHER
-Surface.SetTextColor(RGB_MAGENTA);
+  Surface.
+      SetTextColor(RGB_MAGENTA
+  );
 #else
-Surface.SetTextColor(RGB_BLACK);
+  Surface.SetTextColor(RGB_BLACK);
 #endif
-DrawLabel(Surface, rc, TEXT("O"), xp, yp);
-Surface.SelectObject(hfOldU);
+  DrawLabel(Surface, rc,
+            TEXT("O"), xp, yp);
+  Surface.
+      SelectObject(hfOldU);
 
 }

--- a/Common/Source/Dialogs/Analysis/RenderContest.cpp
+++ b/Common/Source/Dialogs/Analysis/RenderContest.cpp
@@ -250,7 +250,7 @@ void Statistics::RenderFAIOptimizer(LKSurface &Surface, const RECT &rc) {
     const double distance = leg0->LegDist + leg1->LegDist + leg2->LegDist;
 
     double fTic;
-    if (!CContestMgr::Instance().LooksLikeAFAITriangle()) {
+    if (!CContestMgr::Instance().LooksLikeAFAITriangleAttempt()) {
       // Does not look like a FAI attempt. Just draw both FAI sectors on longest leg.
       fTic = 10 / DISTANCEMODIFY;
       if (max_leg->LegDist > 5 / DISTANCEMODIFY) fTic = 20 / DISTANCEMODIFY;

--- a/Common/Source/Dialogs/Analysis/dlgStatistics.cpp
+++ b/Common/Source/Dialogs/Analysis/dlgStatistics.cpp
@@ -44,8 +44,13 @@ void Statistics::Reset() {
   Altitude_Ceiling.Reset();
   Task_Speed.Reset();
   Altitude_Terrain.Reset();
-  for(int j=0;j<MAXTASKPOINTS;j++) {
+  for (int j = 0; j < MAXTASKPOINTS; j++) {
     LegStartTime[j] = -1;
+  }
+
+  if (AdditionalContestRule) {  // If there is an additional contest activated we start with this.
+    contestType = CContestMgr::TYPE_XC_FREE_TRIANGLE;
+    analysis_page = ANALYSIS_PAGE_CONTEST;
   }
 }
 
@@ -233,6 +238,7 @@ static void OnCalcClicked(WndButton* pWnd){
     pForm->SetVisible(true);
   }
   if (analysis_page==ANALYSIS_PAGE_CONTEST) {
+
     // Rotate presented contest
     switch(contestType) {
     case CContestMgr::TYPE_OLC_CLASSIC:
@@ -256,7 +262,6 @@ static void OnCalcClicked(WndButton* pWnd){
 #endif
       contestType = CContestMgr::TYPE_OLC_FAI;
       break;
-
     case CContestMgr::TYPE_OLC_FAI:
       contestType = CContestMgr::TYPE_OLC_CLASSIC_PREDICTED;
       break;
@@ -273,11 +278,25 @@ static void OnCalcClicked(WndButton* pWnd){
       contestType = CContestMgr::TYPE_FAI_3_TPS_PREDICTED;
       break;
     case CContestMgr::TYPE_FAI_3_TPS_PREDICTED:
-      contestType = CContestMgr::TYPE_OLC_CLASSIC;
+      if ( !AdditionalContestRule)
+        contestType = CContestMgr::TYPE_OLC_CLASSIC;
+      else
+        contestType = CContestMgr::TYPE_XC_FREE_TRIANGLE;
       break;
-
+      case  CContestMgr::TYPE_XC_FREE_TRIANGLE:
+      contestType = CContestMgr::TYPE_XC_FAI_TRIANGLE;
+      break;
+    case  CContestMgr::TYPE_XC_FAI_TRIANGLE:
+        contestType = CContestMgr::TYPE_XC_FREE_FLIGHT;
+        break;
+    case  CContestMgr::TYPE_XC_FREE_FLIGHT:
+        contestType = CContestMgr::TYPE_OLC_CLASSIC;
+        break;
     default:
-      contestType = CContestMgr::TYPE_OLC_CLASSIC;
+      if ( !AdditionalContestRule)
+        contestType = CContestMgr::TYPE_OLC_CLASSIC;
+      else
+        contestType = CContestMgr::TYPE_XC_FAI_TRIANGLE;
     }
   }
 

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -2079,7 +2079,7 @@ DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(484));
 	// LKTOKEN  _@M481_ = "North Smart" 
     dfe->addEnumText(MsgToken(481)); // 100417
-    // LKTOKEN  _@M22349_"Target up"
+    // LKTOKEN  _@M2349_"Target up"
     dfe->addEnumText(MsgToken(2349));
 
     dfe->Set(DisplayOrientation_Config);

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -32,6 +32,7 @@
 #include "Sound/Sound.h"
 #include "resource.h"
 #include "LKStyle.h"
+#include "ContestMgr.h"
 
 #ifdef ANDROID
 #include <jni.h>
@@ -3250,6 +3251,18 @@ DataField* dfe = wp->GetDataField();
     wp->RefreshDisplay();
   }
 
+  wp = (WndProperty*)wf->FindByName(TEXT("prpAdditionalContestRule"));
+  if (wp)
+  {
+    DataField* dfe = wp->GetDataField();
+    for (int i=0; i<CContestMgr::NUM_OF_XC_RULES; i++) {
+      dfe->addEnumText(CContestMgr::XCRuleToString(i));
+    }
+    dfe->Set(AdditionalContestRule);
+    wp->RefreshDisplay();
+  }
+
+
 #if 0  // no gear warning, just in case
 {
 GearWarningMode =0;
@@ -4551,6 +4564,12 @@ int ival;
     }
 
   }
+
+  wp = (WndProperty*)wf->FindByName(TEXT("prpAdditionalContestRule"));
+  if (wp) {
+      AdditionalContestRule = wp->GetDataField()->GetAsInteger();
+  }
+
   wp = (WndProperty*)wf->FindByName(TEXT("prpAlarmGearAltitude"));
   if (wp) {
 	  unsigned tmp = iround( (wp->GetDataField()->GetAsInteger()/ALTITUDEMODIFY) *1000.0);

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -3255,7 +3255,7 @@ DataField* dfe = wp->GetDataField();
   if (wp)
   {
     DataField* dfe = wp->GetDataField();
-    for (int i=0; i<CContestMgr::NUM_OF_XC_RULES; i++) {
+    for (int i=0; i<static_cast<int>(CContestMgr::ContestRule::NUM_OF_XC_RULES); i++) {
       dfe->addEnumText(CContestMgr::XCRuleToString(i));
     }
     dfe->Set(AdditionalContestRule);

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -2079,8 +2079,8 @@ DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(484));
 	// LKTOKEN  _@M481_ = "North Smart" 
     dfe->addEnumText(MsgToken(481)); // 100417
-    // LKTOKEN  _@M22388_"Target up"
-    dfe->addEnumText(MsgToken(2388));
+    // LKTOKEN  _@M22349_"Target up"
+    dfe->addEnumText(MsgToken(2349));
 
     dfe->Set(DisplayOrientation_Config);
     wp->RefreshDisplay();

--- a/Common/Source/Draw/DrawFAIOpti.cpp
+++ b/Common/Source/Draw/DrawFAIOpti.cpp
@@ -788,11 +788,13 @@ int iCnt = 0;
 return true;
 }
 
-void MapWindow::DrawXCBestTriangle(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft) {
+
+// Draw the current FAI ( or FREE under XC rules ) Cross Country triangle
+void MapWindow::DrawXC(LKSurface &Surface, const RECT &rc, const ScreenProjection &_Proj, const POINT &Orig_Aircraft) {
 
   const GeoToScreen<ScreenPoint> ToScreen(_Proj);
 
-  CContestMgr::XCFlightType fType = CContestMgr::Instance().GetbestXCTriangleType();
+  CContestMgr::XCFlightType fType = CContestMgr::Instance().GetBestXCTriangleType();
   CContestMgr::XCTriangleStatus fStatus ;
   if (fType == CContestMgr::XCFlightType::XC_INVALID )
     return;
@@ -805,206 +807,133 @@ void MapWindow::DrawXCBestTriangle(LKSurface& Surface, const RECT& rc, const Scr
   } else {
     type = CContestMgr::TType::TYPE_XC_FREE_TRIANGLE;
     fStatus = CContestMgr::Instance().GetFTTriangleStatus();
-
   }
   CContestMgr::CResult result = CContestMgr::Instance().Result( type, true);
   const CPointGPSArray &points = result.PointArray();
   unsigned int iSize = points.size();
 
-  if (iSize != 5 ) return;
+  if (iSize != 5 )    // Should never be unless not yet calculated
+    return;
 
   std::vector<ScreenPoint> triangle_polyline;
 
-  for ( int i = 1 ; i< iSize-1 ; i++ ) {
+  for ( unsigned int i = 1 ; i< iSize-1 ; i++ ) {
     const ScreenPoint Pos = ToScreen(points[i].Latitude(), points[i].Longitude());
     triangle_polyline.push_back(Pos);
   }
   const ScreenPoint Pos = ToScreen(points[1].Latitude(), points[1].Longitude());
   triangle_polyline.push_back(Pos);
 
+  double nextXCRadius = 0;   // the next circle radius to get a better XC scoring coefficient. 0 if we can not increase the scoring coefficient.
+  LKColor nextXCRadiusColor = RGB_BLACK;
   if ( fStatus == CContestMgr::XCTriangleStatus::INVALID ) {
-    LKPen hpPen_invalid(PEN_SOLID, IBLSCALE(2),  RGB_SBLACK );
+    nextXCRadius = CContestMgr::Instance().GetXCValidRadius();
+    nextXCRadiusColor = IsDithered()?RGB_BLACK:RGB_GREEN;
+    LKPen hpPen_invalid(PEN_SOLID, IBLSCALE(2),  IsDithered()?RGB_BLACK:RGB_ORANGE);
     const auto hpOldPen = Surface.SelectObject(hpPen_invalid);
     Surface.Polyline(triangle_polyline.data(), triangle_polyline.size(), rc);
     Surface.SelectObject(hpOldPen);
     hpPen_invalid.Release();
   }
   else if ( fStatus == CContestMgr::XCTriangleStatus::VALID   ) {
-    LKPen hpPen_valid(PEN_SOLID, IBLSCALE(3),  RGB_GREEN );
+    nextXCRadius = CContestMgr::Instance().GetXCClosedRadius();
+    nextXCRadiusColor = IsDithered()?RGB_BLACK:RGB_RED;
+    LKPen hpPen_valid(PEN_SOLID, IBLSCALE(2),  IsDithered()?RGB_BLACK:RGB_GREEN );
     const auto hpOldPen = Surface.SelectObject(hpPen_valid);
     Surface.Polyline(triangle_polyline.data(), triangle_polyline.size(), rc);
     Surface.SelectObject(hpOldPen);
     hpPen_valid.Release();
   }
   else {      // fStatus == CContestMgr::XCTriangleStatus::CLOSED
-    LKPen hpPen_closed(PEN_SOLID, IBLSCALE(4),  RGB_RED );
+    LKPen hpPen_closed(PEN_SOLID, IBLSCALE(2),  IsDithered()?RGB_BLACK:RGB_RED );
     const auto hpOldPen = Surface.SelectObject(hpPen_closed);
     Surface.Polyline(triangle_polyline.data(), triangle_polyline.size(), rc);
     Surface.SelectObject(hpOldPen);
     hpPen_closed.Release();
   }
 
+  if (  nextXCRadius > 0 ) {
+    const double lat_CP = CContestMgr::Instance().GetXCTriangleClosingPoint().Latitude();
+    const double lon_CP = CContestMgr::Instance().GetXCTriangleClosingPoint().Longitude();
+    if ( lat_CP !=0 && lon_CP!= 0) {
+      const ScreenPoint Pos = ToScreen(lat_CP, lon_CP);
+      int iRadius = (int) (nextXCRadius * zoom.ResScaleOverDistanceModify());
+
+      double fDist,fAngle;
+      DistanceBearing(lat_CP, lon_CP, GPS_INFO.Latitude, GPS_INFO.Longitude, &fDist, &fAngle);
+      if ( OvertargetMode ==  OVT_XC ) {
+        LKPen hpSectorPen(PEN_SOLID, IBLSCALE(2), nextXCRadiusColor);
+        const auto hOldPen = Surface.SelectObject(hpSectorPen);
+        Surface.DrawArc(Pos.x, Pos.y, iRadius, rc, fAngle - 20 - DisplayAngle, fAngle + 20 - DisplayAngle);
+        Surface.SelectObject(hOldPen);
+      }
+      else {
+        LKPen hpSectorPen(PEN_SOLID, IBLSCALE(1), nextXCRadiusColor);
+        const auto hOldPen = Surface.SelectObject(hpSectorPen);
+        Surface.DrawCircle(Pos.x, Pos.y, iRadius, rc, false);
+        Surface.SelectObject(hOldPen);
+      }
+    }
+  }
 }
 
+void MapWindow::DrawFAIOptimizer(LKSurface &Surface, const RECT &rc, const ScreenProjection &_Proj, const POINT &Orig_Aircraft) {
 
-void MapWindow::DrawFAIOptimizer(LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj, const POINT &Orig_Aircraft)
-{
+  static FAI_Sector FAI_SectorCache[5];
+  const GeoToScreen<ScreenPoint> ToScreen(_Proj);
+  CContestMgr::CResult result = CContestMgr::Instance().Result(CContestMgr::TYPE_XC_FREE_TRIANGLE, true);
 
-static	FAI_Sector FAI_SectorCache[6];
+  const CPointGPSArray &points = result.PointArray();
+  unsigned int iSize = points.size();
+  if (iSize != 5) {// Something went wrong here
+    return;
+  }
+
+  const CContestMgr::TriangleLeg *max_leg = CContestMgr::Instance().GetFAIAssistantMaxLeg();
+  const CContestMgr::TriangleLeg *leg0 = CContestMgr::Instance().GetFAIAssistantLeg(0);
+  const CContestMgr::TriangleLeg *leg1 = CContestMgr::Instance().GetFAIAssistantLeg(1);
+  const CContestMgr::TriangleLeg *leg2 = CContestMgr::Instance().GetFAIAssistantLeg(2);
+  const double distance = leg0->LegDist + leg1->LegDist + leg2->LegDist;
+
+  if (max_leg == nullptr || max_leg->LegDist < FAI_MIN_DISTANCE_THRESHOLD) {
+    return;
+  }
+
+  float fZoom = MapWindow::zoom.RealScale();
+  double fTic = 100;
+  if (fZoom > 50) fTic = 100;
+  else if (fZoom > 20) fTic = 50;
+  else if (fZoom > 10) fTic = 25; else fTic = 25;
+  if (DISTANCEMODIFY > 0.0)
+    fTic = fTic / DISTANCEMODIFY;
 
   const auto whitecolor = RGB_WHITE;
   const auto origcolor = Surface.SetTextColor(whitecolor);
   const auto oldpen = Surface.SelectObject(hpStartFinishThin);
   const auto oldbrush = Surface.SelectObject(LKBrush_Hollow);
 
-  const GeoToScreen<ScreenPoint> ToScreen(_Proj);
-/********************************************************************/
-  unsigned int ui;
-  double lat1 = 0;
-  double lon1 = 0;
-  double lat2 = 0;
-  double lon2 = 0;
-  BOOL bFAI = false;
-  double fDist, fAngle;
-  LockTaskData(); // protect from external task changes
-    bFAI =  CContestMgr::Instance().FAI();
-    CContestMgr::CResult result = CContestMgr::Instance().Result( CContestMgr::TYPE_FAI_TRIANGLE, true);
-    const CPointGPSArray &points = result.PointArray();
-    unsigned int iSize = points.size();
-    CContestMgr::TType sType = result.Type();
-
-    double lat_CP = CContestMgr::Instance().GetClosingPoint().Latitude();
-    double lon_CP = CContestMgr::Instance().GetClosingPoint().Longitude();
-    double fFAIDistance = result.Distance();
-  UnlockTaskData(); // protect from external task changes
-
-  typedef struct
-  {
-    int    LegIdx;
-    double LegDist;
-    double LegAngle;
-  } legtype;
-  legtype  Legs[10];
-
-
-  for(int i=0; i< 10;  i++)
-  {
-    Legs[i].LegIdx  =0;
-    Legs[i].LegDist =0.0;
-  }
-int numlegs=0;
-  if(((sType ==  CContestMgr::TYPE_FAI_TRIANGLE)
-	 || (sType ==  CContestMgr::TYPE_FAI_TRIANGLE4)
-#ifdef  FIVEPOINT_OPTIMIZER
-	 || (sType ==  CContestMgr::TYPE_FAI_TRIANGLE5)
-#endif
-	 ) && (iSize>2))
-  {
-    LKASSERT(iSize<100);
-    LockTaskData(); // protect from external task changes
-    for(ui=0; ui< iSize-2; ui++)
-    {
-      lat1 = points[ui].Latitude();
-      lon1 = points[ui].Longitude();
-      lat2 = points[ui+1].Latitude();
-      lon2 = points[ui+1].Longitude();
-      DistanceBearing(lat1, lon1, lat2, lon2, &fDist, &fAngle);
-      Legs[numlegs].LegIdx   = ui;
-      Legs[numlegs].LegDist  = fDist;
-
-      if(numlegs < 10)
-        numlegs ++;
-      LKASSERT (numlegs <10);
+  if (!CContestMgr::Instance().LooksLikeAFAITriangle()) {
+    // Does not look like a FAI attempt. Just draw both FAI sectors on longest leg.
+    FAI_SectorCache[0].CalcSectorCache(max_leg->Lat1, max_leg->Lon1, max_leg->Lat2, max_leg->Lon2, fTic, 0);
+    FAI_SectorCache[0].DrawFAISector(Surface, rc, _Proj, RGB_YELLOW);
+    FAI_SectorCache[1].CalcSectorCache(max_leg->Lat1, max_leg->Lon1, max_leg->Lat2, max_leg->Lon2, fTic, 1);
+    FAI_SectorCache[1].DrawFAISector(Surface, rc, _Proj, RGB_YELLOW);
+  } else {
+    if (leg0->LegDist > FAI_MIN_DISTANCE_THRESHOLD) {
+      // Draw the yellow sector on the best current direction.
+      FAI_SectorCache[2].CalcSectorCache(leg0->Lat1, leg0->Lon1, leg0->Lat2, leg0->Lon2, fTic, CContestMgr::Instance().isFAITriangleClockwise());
+      FAI_SectorCache[2].DrawFAISector(Surface, rc, _Proj, RGB_YELLOW);
     }
-
-    std::sort(std::begin(Legs), std::next(Legs, numlegs), [](const legtype& a, const legtype& b) {
-        return (a.LegDist > b.LegDist);
-    } );
-
-    float fZoom = MapWindow::zoom.RealScale() ;
-
-    double         fTic = 100;
-    if(fZoom > 50) fTic = 100; else
-    if(fZoom > 20) fTic = 50;  else
-    if(fZoom > 10) fTic = 25;  else fTic = 25;
-   /* if(fZoom > 3)  fTic = 10;  else fTic = 10;  // FAI grid below 10km need to much CPU power in moving map and PAN mode!!!
-    if(fZoom > 1)  fTic = 5;   else   // on slow devices like MIO
-    if(fZoom > 0.5)fTic = 2;   else   // the user should use Analysis page for this
-    if(fZoom > 0.2)fTic = 1;*/
-    if( DISTANCEMODIFY > 0.0)
-      fTic =  fTic/ DISTANCEMODIFY;
-
-    for(int i= 0 ; i < min(numlegs,2); i++)
-    {
-        #ifndef DITHER
-            LKColor rgbCol = RGB_BLUE;
-            switch(i)
-            {
-              case 0: rgbCol = RGB_YELLOW; break;
-              case 1: rgbCol = RGB_CYAN  ; break;
-              case 2: rgbCol = RGB_GREEN ; break;
-              default:
-              break;
-            }
-                #else
-            LKColor rgbCol = RGB_DARKBLUE;
-            switch(i)
-            {
-              case 0: rgbCol = RGB_LIGHTGREY; break;
-              case 1: rgbCol = RGB_GREY  ; break;
-              case 2: rgbCol = RGB_MIDDLEGREY ; break;
-              default:
-              break;
-            }
-#endif
-      lat1 = points[Legs[i].LegIdx].Latitude();
-      lon1 = points[Legs[i].LegIdx].Longitude();
-      lat2 = points[Legs[i].LegIdx+1].Latitude();
-      lon2 = points[Legs[i].LegIdx+1].Longitude();
-      DistanceBearing(lat1, lon1, lat2, lon2, &fDist, &fAngle);
-      if(fDist > FAI_MIN_DISTANCE_THRESHOLD)
-      {
-        FAI_SectorCache[2*i].CalcSectorCache( lat1,  lon1,  lat2,  lon2, fTic, 0);
-        FAI_SectorCache[2*i].DrawFAISector ( Surface, rc, _Proj, rgbCol );
-        FAI_SectorCache[2*i+1].CalcSectorCache( lat1,  lon1,  lat2,  lon2, fTic, 1);
-        FAI_SectorCache[2*i+1].DrawFAISector ( Surface, rc, _Proj,  rgbCol );
-      }
+    // Draw leg1 a bit before becoming a FAI one in the correct direction . We start drawing a bit before 28%
+    if (leg1->LegDist > distance * 0.25) {
+      FAI_SectorCache[3].CalcSectorCache(leg1->Lat1, leg1->Lon1, leg1->Lat2, leg1->Lon2, fTic, CContestMgr::Instance().isFAITriangleClockwise());
+      FAI_SectorCache[3].DrawFAISector(Surface, rc, _Proj, RGB_CYAN);
     }
-
-      UnlockTaskData();
-
-/*********************************************************/
-
-	  // TODO : check if visible for avoid to far draw outside screen.
-	  // for 1000m radius cylinder, it's better to build cylinder in screen coordinate
-	  // and draw this like polygon ; cf. Task sector drawing
-
-
-
-      if (ISPARAGLIDER && bFAI && (OvertargetMode !=  OVT_XC)) {    // No need to draw the circle if we are targetting it
-          LKPen hpSectorPen(PEN_SOLID, IBLSCALE(2), FAI_SECTOR_COLOR);
-          const auto hOldPen = Surface.SelectObject(hpSectorPen);
-          const RasterPoint Pt1 = _Proj.ToRasterPoint(lat_CP, lon_CP);
-
-          int iRadius = (int) ((fFAIDistance * 0.20) * zoom.ResScaleOverDistanceModify());
-          Surface.DrawCircle(Pt1.x, Pt1.y, iRadius, rc, false);                    /* 20% destination circle */
-
-          iRadius = (int) ((500) * zoom. ResScaleOverDistanceModify());             /* 1000m circle  */
-          Surface.DrawCircle(Pt1.x, Pt1.y, iRadius, rc, false);
-
-          Surface.SelectObject(hOldPen);
-
-      }
-
-/*********************************************************/
-
   }
 
-/********************************************************************/
-    // restore original color
-    Surface.SetTextColor(origcolor);
-    Surface.SelectObject(oldpen);
-    Surface.SelectObject(oldbrush);
+  Surface.SetTextColor(origcolor);
+  Surface.SelectObject(oldpen);
+  Surface.SelectObject(oldbrush);
 
 }
 

--- a/Common/Source/Draw/DrawFAIOpti.cpp
+++ b/Common/Source/Draw/DrawFAIOpti.cpp
@@ -912,7 +912,7 @@ void MapWindow::DrawFAIOptimizer(LKSurface &Surface, const RECT &rc, const Scree
   const auto oldpen = Surface.SelectObject(hpStartFinishThin);
   const auto oldbrush = Surface.SelectObject(LKBrush_Hollow);
 
-  if (!CContestMgr::Instance().LooksLikeAFAITriangle()) {
+  if (!CContestMgr::Instance().LooksLikeAFAITriangleAttempt()) {
     // Does not look like a FAI attempt. Just draw both FAI sectors on longest leg.
     FAI_SectorCache[0].CalcSectorCache(max_leg->Lat1, max_leg->Lon1, max_leg->Lat2, max_leg->Lon2, fTic, 0);
     FAI_SectorCache[0].DrawFAISector(Surface, rc, _Proj, RGB_YELLOW);

--- a/Common/Source/Draw/LKDrawInfoPage.cpp
+++ b/Common/Source/Draw/LKDrawInfoPage.cpp
@@ -209,7 +209,11 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			_stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, MsgToken(1860)); // HSI
 			break;
 		case IM_CONTEST:
-			_stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, MsgToken(957)); // Contest
+		    if ( AdditionalContestRule == 0)
+			  _stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, MsgToken(957)); // Contest
+			else
+			  _stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, CContestMgr::XCRuleToString(AdditionalContestRule)); // Contest
+
 			break;
 		case IM_TRF+IM_TOP:
 			_stprintf(Buffer,_T("%d.%d %s"), ModeIndex, IM_TRF+1, MsgToken(910)); // Target
@@ -358,7 +362,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_CLASSIC_DIST, true, BufferValue, BufferUnit, BufferTitle);
+		    if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_FF_DIST, true, BufferValue, BufferUnit, BufferTitle);
+		    else
+			  showunit=LKFormatValue(LK_OLC_CLASSIC_DIST, true, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_TRF+IM_TOP:
@@ -384,7 +391,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[9],&qcolumn[8], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_FAI_DIST, true, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_FT_DIST, true, BufferValue, BufferUnit, BufferTitle);
+            else
+			  showunit=LKFormatValue(LK_OLC_FAI_DIST, true, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[8],&qcolumn[8], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_AUX:
@@ -416,7 +426,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[12], &qcolumn[12], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_LEAGUE_DIST, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_FAI_DIST, true, BufferValue, BufferUnit, BufferTitle);
+            else
+			  showunit=LKFormatValue(LK_OLC_LEAGUE_DIST, false, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[12], &qcolumn[12], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_AUX:
@@ -449,7 +462,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 											&qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_3TPS_DIST, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_DIST, true, BufferValue, BufferUnit, BufferTitle);
+            else
+			  showunit=LKFormatValue(LK_OLC_3TPS_DIST, false, BufferValue, BufferUnit, BufferTitle);
 			_tcscpy(BufferUnit,_T(""));
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16],&qcolumn[16],
 											&qrow[3],&qrow[4],&qrow[2]);
@@ -486,7 +502,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_NEXT_ALTDIFF, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_CLASSIC_PREDICTED_DIST, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_FF_SCORE, true, BufferValue, BufferUnit, BufferTitle);
+            else
+			  showunit=LKFormatValue(LK_OLC_CLASSIC_PREDICTED_DIST, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_AUX:
 			index=GetInfoboxType(5);
@@ -514,7 +533,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[9], &qcolumn[8], &qrow[6],&qrow[7],&qrow[5]);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_FAI_PREDICTED_DIST, true , BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_FT_SCORE, true, BufferValue, BufferUnit, BufferTitle);
+            else
+			  showunit=LKFormatValue(LK_OLC_FAI_PREDICTED_DIST, true , BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[8], &qcolumn[8], &qrow[6],&qrow[7],&qrow[5]);
 			break;
 		case IM_AUX:
@@ -543,8 +565,12 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_LD_CRUISE, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			_tcscpy(BufferValue,_T(""));
-            _tcscpy(BufferTitle,_T(""));
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_FAI_SCORE, true, BufferValue, BufferUnit, BufferTitle);
+            else {
+              _tcscpy(BufferValue, _T(""));
+              _tcscpy(BufferTitle, _T(""));
+            }
 			break;
 		case IM_AUX:
 			index=GetInfoboxType(7);
@@ -570,7 +596,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_LD_INST, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_3TPS_PREDICTED_DIST, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_SCORE, true, BufferValue, BufferUnit, BufferTitle);
+            else
+			  showunit=LKFormatValue(LK_OLC_3TPS_PREDICTED_DIST, false, BufferValue, BufferUnit, BufferTitle);
 			_tcscpy(BufferUnit,_T(""));
 			break;
 		case IM_AUX:
@@ -601,8 +630,11 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_FIN_ALTDIFF, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			//showunit=LKFormatValue(LK_OLC_PLUS_SCORE, false, BufferValue, BufferUnit, BufferTitle);
-			showunit=LKFormatValue(LK_OLC_CLASSIC_SPEED, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ) {
+				showunit=LKFormatValue(LK_XC_MEAN_SPEED, false, BufferValue, BufferUnit, BufferTitle);
+			} else {
+				showunit = LKFormatValue(LK_OLC_CLASSIC_SPEED, false, BufferValue, BufferUnit, BufferTitle);
+			}
 			break;
 		case IM_AUX:
 			index=GetInfoboxType(9);
@@ -633,8 +665,11 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[8], &qcolumn[8],&qrow[9],&qrow[10],&qrow[8]);
 			break;
 		case IM_CONTEST:
-			//showunit=LKFormatValue(LK_OLC_PLUS_PREDICTED_SCORE, false, BufferValue, BufferUnit, BufferTitle);
-			showunit=LKFormatValue(LK_OLC_FAI_SPEED, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ){
+				_tcscpy(BufferValue, _T(""));
+				_tcscpy(BufferTitle, _T(""));
+			} else
+			  showunit=LKFormatValue(LK_OLC_FAI_SPEED, false, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[8], &qcolumn[8],&qrow[9],&qrow[10],&qrow[8]);
 			break;
 		case IM_AUX:
@@ -665,8 +700,11 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_TASK_DISTCOV, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			//showunit=LKFormatValue(LK_OLC_LEAGUE_SCORE, false, BufferValue, BufferUnit, BufferTitle);
-			showunit=LKFormatValue(LK_OLC_LEAGUE_SPEED, true, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ){
+              _tcscpy(BufferValue, _T(""));
+              _tcscpy(BufferTitle, _T(""));
+            } else
+              showunit=LKFormatValue(LK_OLC_LEAGUE_SPEED, true, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_AUX:
 			index=GetInfoboxType(11);
@@ -696,7 +734,11 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_FIN_GR, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_3TPS_SPEED, true, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ){
+              _tcscpy(BufferValue, _T(""));
+              _tcscpy(BufferTitle, _T(""));
+            } else
+              showunit=LKFormatValue(LK_OLC_3TPS_SPEED, true, BufferValue, BufferUnit, BufferTitle);
 			_tcscpy(BufferUnit,_T(""));
 			break;
 		case IM_AUX:
@@ -732,8 +774,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_CONTEST:
-			showunit=LKFormatValue(LK_OLC_PLUS_SCORE, false, BufferValue, BufferUnit, BufferTitle);
-			//showunit=LKFormatValue(LK_OLC_CLASSIC_SPEED, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ){
+              showunit=LKFormatValue(LK_XC_PREDICTED_DIST, true, BufferValue, BufferUnit, BufferTitle);
+			} else
+              showunit=LKFormatValue(LK_OLC_PLUS_SCORE, false, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_AUX:
@@ -767,8 +811,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[9], &qcolumn[9],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_CONTEST:
-			//showunit=LKFormatValue(LK_OLC_FAI_SPEED, false, BufferValue, BufferUnit, BufferTitle);
-			showunit=LKFormatValue(LK_OLC_PLUS_PREDICTED_SCORE, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ){
+              showunit=LKFormatValue(LK_XC_CLOSURE_PERC, true, BufferValue, BufferUnit, BufferTitle);
+			} else
+              showunit=LKFormatValue(LK_OLC_PLUS_PREDICTED_SCORE, false, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[8], &qcolumn[8],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_AUX:
@@ -802,8 +848,10 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[13], &qcolumn[13],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_CONTEST:
-			//showunit=LKFormatValue(LK_OLC_LEAGUE_SPEED, true, BufferValue, BufferUnit, BufferTitle);
-			showunit=LKFormatValue(LK_OLC_LEAGUE_SCORE, false, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule )
+              showunit=LKFormatValue(LK_XC_CLOSURE_DIST, true, BufferValue, BufferUnit, BufferTitle);
+            else
+              showunit=LKFormatValue(LK_OLC_LEAGUE_SCORE, false, BufferValue, BufferUnit, BufferTitle);
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[12], &qcolumn[12],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_AUX:
@@ -832,9 +880,13 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_MC, true, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-			_tcscpy(BufferValue,_T(""));
-            _tcscpy(BufferTitle,_T(""));
-			//showunit=LKFormatValue(LK_OLC_3TPS_SPEED, true, BufferValue, BufferUnit, BufferTitle);
+            if ( AdditionalContestRule ){
+              _tcscpy(BufferValue, _T(""));
+              _tcscpy(BufferTitle, _T(""));
+            } else {
+              _tcscpy(BufferValue, _T(""));
+              _tcscpy(BufferTitle, _T(""));
+            }
 			break;
 		case IM_AUX:
 			index=GetInfoboxType(16);

--- a/Common/Source/Draw/LKDrawInfoPage.cpp
+++ b/Common/Source/Draw/LKDrawInfoPage.cpp
@@ -209,11 +209,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			_stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, MsgToken(1860)); // HSI
 			break;
 		case IM_CONTEST:
-		    if ( AdditionalContestRule == 0)
-			  _stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, MsgToken(957)); // Contest
-			else
 			  _stprintf(Buffer,_T("%d.%d %s"), ModeIndex, curtype+1, CContestMgr::XCRuleToString(AdditionalContestRule)); // Contest
-
 			break;
 		case IM_TRF+IM_TOP:
 			_stprintf(Buffer,_T("%d.%d %s"), ModeIndex, IM_TRF+1, MsgToken(910)); // Target
@@ -362,7 +358,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-		    if ( AdditionalContestRule )
+		    if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_FF_DIST, true, BufferValue, BufferUnit, BufferTitle);
 		    else
 			  showunit=LKFormatValue(LK_OLC_CLASSIC_DIST, true, BufferValue, BufferUnit, BufferTitle);
@@ -391,7 +387,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[9],&qcolumn[8], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_FT_DIST, true, BufferValue, BufferUnit, BufferTitle);
             else
 			  showunit=LKFormatValue(LK_OLC_FAI_DIST, true, BufferValue, BufferUnit, BufferTitle);
@@ -426,7 +422,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[12], &qcolumn[12], &qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_FAI_DIST, true, BufferValue, BufferUnit, BufferTitle);
             else
 			  showunit=LKFormatValue(LK_OLC_LEAGUE_DIST, false, BufferValue, BufferUnit, BufferTitle);
@@ -462,7 +458,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 											&qrow[3],&qrow[4],&qrow[2]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_DIST, true, BufferValue, BufferUnit, BufferTitle);
             else
 			  showunit=LKFormatValue(LK_OLC_3TPS_DIST, false, BufferValue, BufferUnit, BufferTitle);
@@ -502,7 +498,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_NEXT_ALTDIFF, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_FF_SCORE, true, BufferValue, BufferUnit, BufferTitle);
             else
 			  showunit=LKFormatValue(LK_OLC_CLASSIC_PREDICTED_DIST, false, BufferValue, BufferUnit, BufferTitle);
@@ -533,7 +529,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[9], &qcolumn[8], &qrow[6],&qrow[7],&qrow[5]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_FT_SCORE, true, BufferValue, BufferUnit, BufferTitle);
             else
 			  showunit=LKFormatValue(LK_OLC_FAI_PREDICTED_DIST, true , BufferValue, BufferUnit, BufferTitle);
@@ -565,7 +561,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_LD_CRUISE, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_FAI_SCORE, true, BufferValue, BufferUnit, BufferTitle);
             else {
               _tcscpy(BufferValue, _T(""));
@@ -596,7 +592,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_LD_INST, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_SCORE, true, BufferValue, BufferUnit, BufferTitle);
             else
 			  showunit=LKFormatValue(LK_OLC_3TPS_PREDICTED_DIST, false, BufferValue, BufferUnit, BufferTitle);
@@ -630,7 +626,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_FIN_ALTDIFF, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ) {
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) ) {
 				showunit=LKFormatValue(LK_XC_MEAN_SPEED, false, BufferValue, BufferUnit, BufferTitle);
 			} else {
 				showunit = LKFormatValue(LK_OLC_CLASSIC_SPEED, false, BufferValue, BufferUnit, BufferTitle);
@@ -665,7 +661,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[8], &qcolumn[8],&qrow[9],&qrow[10],&qrow[8]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ){
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) ){
 				_tcscpy(BufferValue, _T(""));
 				_tcscpy(BufferTitle, _T(""));
 			} else
@@ -700,7 +696,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_TASK_DISTCOV, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ){
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) ){
               _tcscpy(BufferValue, _T(""));
               _tcscpy(BufferTitle, _T(""));
             } else
@@ -734,7 +730,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_FIN_GR, false, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ){
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) ){
               _tcscpy(BufferValue, _T(""));
               _tcscpy(BufferTitle, _T(""));
             } else
@@ -774,7 +770,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ){
+            if ( static_cast<int>(AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC)) ){
               showunit=LKFormatValue(LK_XC_PREDICTED_DIST, true, BufferValue, BufferUnit, BufferTitle);
 			} else
               showunit=LKFormatValue(LK_OLC_PLUS_SCORE, false, BufferValue, BufferUnit, BufferTitle);
@@ -811,7 +807,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[9], &qcolumn[9],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ){
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) ){
               showunit=LKFormatValue(LK_XC_CLOSURE_PERC, true, BufferValue, BufferUnit, BufferTitle);
 			} else
               showunit=LKFormatValue(LK_OLC_PLUS_PREDICTED_SCORE, false, BufferValue, BufferUnit, BufferTitle);
@@ -848,7 +844,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[13], &qcolumn[13],&qrow[12],&qrow[13],&qrow[11]);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule )
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) )
               showunit=LKFormatValue(LK_XC_CLOSURE_DIST, true, BufferValue, BufferUnit, BufferTitle);
             else
               showunit=LKFormatValue(LK_OLC_LEAGUE_SCORE, false, BufferValue, BufferUnit, BufferTitle);
@@ -880,7 +876,7 @@ void MapWindow::DrawInfoPage(LKSurface& Surface,  const RECT& rc, bool forceinit
 			showunit=LKFormatValue(LK_MC, true, BufferValue, BufferUnit, BufferTitle);
 			break;
 		case IM_CONTEST:
-            if ( AdditionalContestRule ){
+            if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::OLC) ){
               _tcscpy(BufferValue, _T(""));
               _tcscpy(BufferTitle, _T(""));
             } else {

--- a/Common/Source/Draw/LKDrawLook8000.cpp
+++ b/Common/Source/Draw/LKDrawLook8000.cpp
@@ -286,6 +286,9 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 case OVT_MATE:
                     LKFormatDist(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
+                case OVT_XC:
+                    LKFormatDist(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                break;
                 case OVT_FLARM:
                     LKFormatDist(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
                     break;
@@ -343,6 +346,9 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 case OVT_MATE:
                     LKFormatBrgDiff(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
+                case OVT_XC:
+                    LKFormatBrgDiff(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    break;
                 case OVT_FLARM:
                     LKFormatBrgDiff(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
                     break;
@@ -396,6 +402,9 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 case OVT_MATE:
                     LKFormatGR(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
+                case OVT_XC:
+                    LKFormatGR(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    break;
                 case OVT_FLARM:
                     LKFormatGR(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
                     break;
@@ -443,6 +452,9 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     break;
                 case OVT_MATE:
                     LKFormatAltDiff(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
+                    break;
+                case OVT_XC:
+                    LKFormatAltDiff(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
                     break;
                 case OVT_FLARM:
                     LKFormatAltDiff(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
@@ -567,6 +579,9 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 case OVT_MATE:
                     LKFormatAltDiff(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
+                case OVT_XC:
+                  LKFormatAltDiff(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                break;
                 case OVT_FLARM:
                     LKFormatAltDiff(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
                     break;

--- a/Common/Source/Draw/LKDrawLook8000.cpp
+++ b/Common/Source/Draw/LKDrawLook8000.cpp
@@ -287,7 +287,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     LKFormatDist(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
                 case OVT_XC:
-                    LKFormatDist(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    LKFormatDist(RESWP_FAIOPTIMIZED, false, BufferValue, BufferUnit);
                 break;
                 case OVT_FLARM:
                     LKFormatDist(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
@@ -347,7 +347,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     LKFormatBrgDiff(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
                 case OVT_XC:
-                    LKFormatBrgDiff(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    LKFormatBrgDiff(RESWP_FAIOPTIMIZED, false, BufferValue, BufferUnit);
                     break;
                 case OVT_FLARM:
                     LKFormatBrgDiff(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
@@ -403,7 +403,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     LKFormatGR(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
                 case OVT_XC:
-                    LKFormatGR(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    LKFormatGR(RESWP_FAIOPTIMIZED, false, BufferValue, BufferUnit);
                     break;
                 case OVT_FLARM:
                     LKFormatGR(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
@@ -454,7 +454,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     LKFormatAltDiff(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
                 case OVT_XC:
-                    LKFormatAltDiff(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    LKFormatAltDiff(RESWP_FAIOPTIMIZED, false, BufferValue, BufferUnit);
                     break;
                 case OVT_FLARM:
                     LKFormatAltDiff(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
@@ -580,8 +580,8 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     LKFormatAltDiff(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
                     break;
                 case OVT_XC:
-                  LKFormatAltDiff(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
-                break;
+                    LKFormatAltDiff(RESWP_FAIOPTIMIZED, false, BufferValue, BufferUnit);
+                    break;
                 case OVT_FLARM:
                     LKFormatAltDiff(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
                     break;

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -2255,7 +2255,7 @@ olc_score:
 		// B126
 		case LK_OLC_FAI_CLOSE_PERCENT:
 			bFAI = CContestMgr::Instance().FAI();
-			fDist =CContestMgr::Instance().Result(CContestMgr::TYPE_FAI_TRIANGLE, false).Distance();
+			fDist =CContestMgr::Instance().Result(CContestMgr::TYPE_OLC_FAI_PREDICTED, false).Distance();
 			fTogo =CContestMgr::Instance().GetClosingPointDist();
         		if((fDist >0) && (fTogo >0))
             		{
@@ -2649,11 +2649,11 @@ olc_score:
       case LK_XC_CLOSURE_PERC:
         _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
         _stprintf(BufferUnit, TEXT("%s"), TEXT("%"));
-        if (CContestMgr::Instance().GetXCTriangleClosurePercentuage() <= 0 ||
-            CContestMgr::Instance().GetXCTriangleClosurePercentuage() >= 100)
+        if (CContestMgr::Instance().GetXCTriangleClosurePercentage() <= 0 ||
+            CContestMgr::Instance().GetXCTriangleClosurePercentage() >= 100)
           _stprintf(BufferValue, _T(NULLMEDIUM));
         else {
-          const double dist = CContestMgr::Instance().GetXCTriangleClosurePercentuage()  ;
+          const double dist = CContestMgr::Instance().GetXCTriangleClosurePercentage()  ;
           _stprintf(BufferValue, TEXT("%5.1f"), dist);
           valid = true;
         }

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -2239,7 +2239,7 @@ olc_score:
 			} else {
 				_stprintf(BufferValue, TEXT(NULLLONG));
 			}
-			_stprintf(BufferUnit, TEXT("%s"),(Units::GetDistanceName()));
+			_stprintf(BufferUnit, TEXT("%s*"),(Units::GetDistanceName()));
 			if (lktitle)
 			{
 				if(bFAI)
@@ -2530,7 +2530,157 @@ olc_score:
       _tcscpy(BufferTitle, Data_Options[lkindex].Title );
       break;
 
-		// B141
+        //
+      case LK_XC_FF_DIST:
+        ivalue = CContestMgr::TYPE_XC_FREE_FLIGHT;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s"), (Units::GetDistanceName()));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"), DISTANCEMODIFY * OlcResults[ivalue].Distance());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_FF_SCORE:
+        ivalue = CContestMgr::TYPE_XC_FREE_FLIGHT;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("p"));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"),  OlcResults[ivalue].Score());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_FT_DIST:
+        ivalue = CContestMgr::TYPE_XC_FREE_TRIANGLE;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s"), (Units::GetDistanceName()));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"), DISTANCEMODIFY * OlcResults[ivalue].Distance());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_FT_SCORE:
+        ivalue = CContestMgr::TYPE_XC_FREE_TRIANGLE;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("p"));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%3.0f"),  OlcResults[ivalue].Score());
+          valid = true;
+        }
+        break;
+
+
+      case LK_XC_FAI_DIST:
+        ivalue = CContestMgr::TYPE_XC_FAI_TRIANGLE;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s"), (Units::GetDistanceName()));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"), DISTANCEMODIFY * OlcResults[ivalue].Distance());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_FAI_SCORE:
+        ivalue = CContestMgr::TYPE_XC_FAI_TRIANGLE;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("p"));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"),  OlcResults[ivalue].Score());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_DIST:
+        ivalue = CContestMgr::TYPE_XC;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s"), (Units::GetDistanceName()));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"), DISTANCEMODIFY * OlcResults[ivalue].Distance());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_SCORE:
+        ivalue = CContestMgr::TYPE_XC;
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("p"));
+        if (OlcResults[ivalue].Type() == CContestMgr::TYPE_INVALID)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"),  OlcResults[ivalue].Score());
+          valid = true;
+        }
+        break;
+
+      case LK_XC_CLOSURE_DIST:
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s"),Units::GetDistanceName());
+        if (CContestMgr::Instance().GetXCTriangleClosureDistance() == 0)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else if (OlcResults[ivalue].PredictedDistance() == 0 )  {
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        }
+        else {
+          const double dist =    DISTANCEMODIFY * CContestMgr::Instance().GetXCTriangleClosureDistance() ;
+          _stprintf(BufferValue, TEXT("%5.1f"), dist);
+          valid = true;
+        }
+        break;
+
+      case LK_XC_CLOSURE_PERC:
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s"), TEXT("%"));
+        if (CContestMgr::Instance().GetXCTriangleClosurePercentuage() <= 0 ||
+            CContestMgr::Instance().GetXCTriangleClosurePercentuage() >= 100)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          const double dist = CContestMgr::Instance().GetXCTriangleClosurePercentuage()  ;
+          _stprintf(BufferValue, TEXT("%5.1f"), dist);
+          valid = true;
+        }
+        break;
+
+
+      case LK_XC_PREDICTED_DIST:
+        _stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+        _stprintf(BufferUnit, TEXT("%s*"), (Units::GetDistanceName()));
+        if (CContestMgr::Instance().GetXCTriangleDistance() == 0)
+          _stprintf(BufferValue, _T(NULLMEDIUM));
+        else {
+          _stprintf(BufferValue, TEXT("%5.0f"), DISTANCEMODIFY * CContestMgr::Instance().GetXCTriangleDistance() );
+          valid = true;
+        }
+        break;
+
+		case LK_XC_MEAN_SPEED:
+			ivalue = CContestMgr::TYPE_XC_FREE_TRIANGLE;
+		_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title);
+		_stprintf(BufferUnit, TEXT("%s"), (Units::GetHorizontalSpeedName()));
+		if (CContestMgr::Instance().GetXCMeanSpeed() == 0)
+			_stprintf(BufferValue, _T(NULLMEDIUM));
+		else {
+			_stprintf(BufferValue, TEXT("%5.0f"), SPEEDMODIFY * CContestMgr::Instance().GetXCMeanSpeed() );
+			valid = true;
+		}
+		break;
+
+        // B141
 		case LK_WIND:
 			// LKTOKEN  _@M1185_ = "Wind"
 			_tcscpy(BufferTitle, MsgToken(1185));
@@ -2579,6 +2729,10 @@ olc_score:
 			break;
 
 		// B143  091222 using old ETE corrected now
+
+
+
+
 		case LK_LKFIN_ETE:
 lkfin_ete:
 			_stprintf(BufferValue,_T(NULLTIME)); // 091222

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -2453,6 +2453,9 @@ olc_score:
 				case OVT_MATE:
 					LKFormatGR(RESWP_TEAMMATE, true, BufferValue, BufferUnit);
 					break;
+                case OVT_XC:
+                    LKFormatGR(RESWP_FAIOPTIMIZED, true, BufferValue, BufferUnit);
+                    break;
 				case OVT_FLARM:
 					LKFormatGR(RESWP_FLARMTARGET, true, BufferValue, BufferUnit);
 					break;

--- a/Common/Source/Draw/RenderMapWindowBg.cpp
+++ b/Common/Source/Draw/RenderMapWindowBg.cpp
@@ -287,6 +287,9 @@ _skip_stuff:
         }
     }
 
+    if ( AdditionalContestRule && OvertargetMode ==  OVT_XC) {   // if we target the XC closing point we also draw the current best XC triangle if available
+        DrawXCBestTriangle(Surface, DrawRect, _Proj, Orig_Aircraft);
+    }
 
     // In QUICKDRAW do not paint other useless stuff
     if (QUICKDRAW) {

--- a/Common/Source/Draw/RenderMapWindowBg.cpp
+++ b/Common/Source/Draw/RenderMapWindowBg.cpp
@@ -287,8 +287,9 @@ _skip_stuff:
         }
     }
 
-    if ( AdditionalContestRule && OvertargetMode ==  OVT_XC) {   // if we target the XC closing point we also draw the current best XC triangle if available
-        DrawXCBestTriangle(Surface, DrawRect, _Proj, Orig_Aircraft);
+    if ( AdditionalContestRule!=static_cast<int>(CContestMgr::ContestRule::NONE) &&
+        ( OvertargetMode ==  OVT_XC || Flags_DrawXC ) ) {   // if we target the XC closing point we also draw the current best XC triangle if available
+      DrawXC(Surface, DrawRect, _Proj, Orig_Aircraft);
     }
 
     // In QUICKDRAW do not paint other useless stuff

--- a/Common/Source/ExpandMacros.cpp
+++ b/Common/Source/ExpandMacros.cpp
@@ -475,9 +475,9 @@ bool ExpandMacros(const TCHAR *In, TCHAR *OutBuffer, size_t Size){
             break;
 		case 41:
 			if (Flags_DrawXC )
-				_stprintf(OutBuffer,_T("%s"),MsgToken(2401));  //  "Draw\nXC"
+				_stprintf(OutBuffer,_T("%s"),MsgToken(2388));  //  "Draw\nXC"
 			else
-				_stprintf(OutBuffer,_T("%s"),MsgToken(2402));  //	"NoDraw\nXC"
+				_stprintf(OutBuffer,_T("%s"),MsgToken(2389));  //	"NoDraw\nXC"
 		break;
 
 

--- a/Common/Source/ExpandMacros.cpp
+++ b/Common/Source/ExpandMacros.cpp
@@ -65,7 +65,7 @@ bool ExpandMacros(const TCHAR *In, TCHAR *OutBuffer, size_t Size){
 	short i;
 	i= (*(a+4)-'0')*10;
 	i+= *(a+5)-'0';
-	LKASSERT(i>=0 && i<41);
+	LKASSERT(i>=0 && i<42);
 
 	switch(i) {
 		case 0:	// LOCKMODE
@@ -473,6 +473,14 @@ bool ExpandMacros(const TCHAR *In, TCHAR *OutBuffer, size_t Size){
                 _tcscpy(OutBuffer,_T(""));
             }
             break;
+		case 41:
+			if (Flags_DrawXC )
+				_stprintf(OutBuffer,_T("%s"),MsgToken(2401));  //  "Draw\nXC"
+			else
+				_stprintf(OutBuffer,_T("%s"),MsgToken(2402));  //	"NoDraw\nXC"
+		break;
+
+
 		default:
 			_stprintf(OutBuffer, _T("INVALID\n%d"),i);
 			break;

--- a/Common/Source/Globals.cpp
+++ b/Common/Source/Globals.cpp
@@ -665,6 +665,8 @@ void Globals_Init(void) {
 
   Flags_DrawTask=true;
   Flags_DrawFAI=false;
+  Flags_DrawXC = false;
+
   iFlarmDirection=0;
   AspPermanentChanged=0;
 

--- a/Common/Source/InputEvents.cpp
+++ b/Common/Source/InputEvents.cpp
@@ -2272,8 +2272,8 @@ void InputEvents::eventService(const TCHAR *misc) {
 	return;
   }
 
-  if (_tcscmp(misc, TEXT("OPTIMODE")) == 0) {
-	  CustomKeyHandler(ckOtimizerPointsToggle+1000); // passthrough mode
+  if (_tcscmp(misc, TEXT("DRAWXC")) == 0) {
+	  CustomKeyHandler(ckDrawXCToggle+1000); // passthrough mode
 	return;
   }
 

--- a/Common/Source/LKInterface/LKCustomKeyHandler.cpp
+++ b/Common/Source/LKInterface/LKCustomKeyHandler.cpp
@@ -386,42 +386,15 @@ passthrough:
         else
             LKSound(TEXT("LK_TONEDOWN.WAV"));
 		return true;
-	case ckOtimizerPointsToggle:
-		FAI_OptimizerMode++;
-#ifdef FIVEPOINT_OPTIMIZER
-		if(FAI_OptimizerMode > 5)
-#else
-		if(FAI_OptimizerMode > 4)
-#endif
-			FAI_OptimizerMode = 3;
-		TCHAR Optimizermsg[60];
-
-		switch(FAI_OptimizerMode)
-		{
-		  case 5:
-		   _stprintf(Optimizermsg,_T("%s: %s"),MsgToken(1296),MsgToken(1299)); // _@M1296_ "FAI Optimizer"  _@M1299_ "Mercedes star"
-		  break;
-		  case 4:
-		   _stprintf(Optimizermsg,_T("%s: %s"),MsgToken(1296),MsgToken(1298)); // _@M1296_ "FAI Optimizer"  "Start on leg"
-		  break;
-		  case 3:
-		  default:
-		   _stprintf(Optimizermsg,_T("%s: %s"),MsgToken(1296),MsgToken(1297)); // _@M1296_ "FAI Optimizer"  "Start on turnpoint"
-		   break;
-		}
-
-
-		 CContestMgr::Instance().RefreshFAIOptimizer();
-
-		DoStatusMessage(Optimizermsg,NULL,false);
-
-		if (EnableSoundModes) {
-			if (FAI_OptimizerMode == 5)
-				LKSound(TEXT("LK_TONEUP.WAV"));
-			else
-				LKSound(TEXT("LK_TONEDOWN.WAV"));
-		}
-		return true;
+    case ckDrawXCToggle:
+      Flags_DrawXC = !Flags_DrawXC;
+      if (EnableSoundModes) {
+        if (Flags_DrawXC == 0)
+          LKSound(TEXT("LK_TONEUP.WAV"));
+        else
+          LKSound(TEXT("LK_TONEDOWN.WAV"));
+      }
+      return true;
 	case ckResetView:
 		ModeType[LKMODE_MAP]    =       MP_MOVING;
 		ModeType[LKMODE_INFOMODE]=      IM_CRUISE;
@@ -558,7 +531,7 @@ CustomKeyLabel[57]=2246;	// Reset view
 CustomKeyLabel[58]=2038;	// Map Orientation
 CustomKeyLabel[59]=928;		// Restarting Comm Ports
 CustomKeyLabel[60]=2249;	// DspMode
-CustomKeyLabel[61]=2251;	// Optimizer Mode
+CustomKeyLabel[61]=2401;	// Toggle Draw XC
 CustomKeyLabel[62]=2337;	// Airspace lookup
 
 static_assert(62 < array_size(CustomKeyLabel), "invalid CustomKeyLabel array size");

--- a/Common/Source/LKInterface/LKCustomKeyHandler.cpp
+++ b/Common/Source/LKInterface/LKCustomKeyHandler.cpp
@@ -427,7 +427,7 @@ passthrough:
             case TARGETCIRCLE: _stprintf(MapOrientMsg,_T("%s"),MsgToken(682)) ; break;  // _@M682_ "Target circling"  _@M485_ "NorthUp above "
             case NORTHTRACK  : _stprintf(MapOrientMsg,_T("%s"),MsgToken(484)) ; break;  // _@M484_ "North/track"
             case NORTHSMART  : _stprintf(MapOrientMsg,_T("%s"),MsgToken(481)) ; break;  // _@M481_ "North Smart"
-            case TARGETUP    : _stprintf(MapOrientMsg,_T("%s"),MsgToken(2388)); break;  // _@M2388_"Target up"
+            case TARGETUP    : _stprintf(MapOrientMsg,_T("%s"),MsgToken(2349)); break;  // _@M2349_"Target up"
 
 	      }
 	      DoStatusMessage(MapOrientMsg,NULL,false);
@@ -531,7 +531,7 @@ CustomKeyLabel[57]=2246;	// Reset view
 CustomKeyLabel[58]=2038;	// Map Orientation
 CustomKeyLabel[59]=928;		// Restarting Comm Ports
 CustomKeyLabel[60]=2249;	// DspMode
-CustomKeyLabel[61]=2401;	// Toggle Draw XC
+CustomKeyLabel[61]=2388;	// Toggle Draw XC
 CustomKeyLabel[62]=2337;	// Airspace lookup
 
 static_assert(62 < array_size(CustomKeyLabel), "invalid CustomKeyLabel array size");

--- a/Common/Source/LKInterface/OverTargets.cpp
+++ b/Common/Source/LKInterface/OverTargets.cpp
@@ -73,11 +73,18 @@ int GetOvertargetIndex(void) {
 		return -1;
 		break;
 
+	case OVT_XC:
+		index=RESWP_FAIOPTIMIZED;
+	    if (ValidResWayPoint(index)) return index;
+	    return -1;
+	    break;
+
 	case OVT_FLARM:
 		index=RESWP_FLARMTARGET;
 		if (ValidResWayPoint(index)) return index;
 		return -1;
 		break;
+
 
 	// 4: home, 5: traffic, 6: mountain pass, last thermal, etc.
 	default:
@@ -136,6 +143,8 @@ TCHAR *GetOvertargetHeader(void) {
 	// LKTOKEN _@M1330_ "F>"
 	LK_tcsncpy(targetheader[OVT_FLARM], MsgToken(1330), OVERTARGETHEADER_MAX);
 
+	LK_tcsncpy(targetheader[OVT_XC], TEXT("X>"), OVERTARGETHEADER_MAX); // No need for translation here. X international code for Cross Country !
+
 	for (int i=0; i<OVT_MAXMODE+1; i++) targetheader[i][OVERTARGETHEADER_MAX]='\0';
 	DoInit[MDI_GETOVERTARGETHEADER]=false;
   }
@@ -174,6 +183,11 @@ _tryagain:
   // Skip Last Thermal if no thermal is detected ...
   if(OvertargetMode==OVT_THER && (!ValidResWayPoint(RESWP_LASTTHERMAL))) {
 	goto _tryagain;
+  }
+
+  	// Skip Cross Country triangle closing if no AdditionContetest active or not valid optimized point ...
+  if( OvertargetMode==OVT_XC && ( !AdditionalContestRule  || !ValidResWayPoint(RESWP_FAIOPTIMIZED))) {
+		goto _tryagain;
   }
 
   // Skip F rotation if no flarm or no valid flarm target

--- a/Common/Source/LKInterface/OverTargets.cpp
+++ b/Common/Source/LKInterface/OverTargets.cpp
@@ -185,8 +185,9 @@ _tryagain:
 	goto _tryagain;
   }
 
-  	// Skip Cross Country triangle closing if no AdditionContetest active or not valid optimized point ...
-  if( OvertargetMode==OVT_XC && ( !AdditionalContestRule  || !ValidResWayPoint(RESWP_FAIOPTIMIZED))) {
+  	// Skip Cross Country triangle closing if no Addition Contest active or not valid optimized point ...
+  if( OvertargetMode==OVT_XC &&
+      ( AdditionalContestRule==static_cast<int>(CContestMgr::ContestRule::NONE)  || !ValidResWayPoint(RESWP_FAIOPTIMIZED))) {
 		goto _tryagain;
   }
 

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -917,6 +917,9 @@ void LKParseProfileString(const char *sname, const char *svalue) {
     }
     return;
   }
+  PREAD(sname,svalue,szRegistryAdditionalContestRule,&AdditionalContestRule);
+  if (matchedstring) return;
+
 #ifdef _WGS84
   PREAD(sname,svalue,szRegistry_earth_model_wgs84,&earth_model_wgs84);
   if (matchedstring) return;

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -854,7 +854,7 @@ void LKParseProfileString(const char *sname, const char *svalue) {
   if (matchedstring) return;
   PREAD(sname,svalue,szRegistryBigFAIThreshold, &FAI28_45Threshold);
   if (matchedstring) return;
-  PREAD(sname,svalue,szRegistryFAIOptiMode    , &FAI_OptimizerMode);
+  PREAD(sname,svalue,szRegistryDrawXC    , &Flags_DrawXC);
   if (matchedstring) return;
 
   PREAD(sname,svalue,szRegistrySonarWarning,&SonarWarning_Config);

--- a/Common/Source/LKProfileResetDefault.cpp
+++ b/Common/Source/LKProfileResetDefault.cpp
@@ -343,7 +343,6 @@ void LKProfileResetDefault(void) {
   OverlayClock = 0;
   UseTwoLines = 1;
   SonarWarning_Config = 1; // sonar enabled by default on reset
-  FAI_OptimizerMode = 5;
   // default BB and IP is all ON
   ConfBB0 = 0; // TRM is off by default on v4
   ConfBB1 = 1;
@@ -453,6 +452,7 @@ void LKProfileResetDefault(void) {
 
   Flags_DrawTask=true;
   Flags_DrawFAI=false;
+  Flags_DrawXC=false;
   FAI28_45Threshold = FAI_BIG_THRESHOLD;
   BottomMode=BM_CRU;
   iFlarmDirection=0;
@@ -481,7 +481,7 @@ void LKProfileResetDefault(void) {
   Overlay_RightMid=1;
   Overlay_RightBottom=1;
 
-  AdditionalContestRule= 0;  // OFF by defauly
+  AdditionalContestRule= 2;  // OLC by defauly
 
 
 #ifdef _WGS84

--- a/Common/Source/LKProfileResetDefault.cpp
+++ b/Common/Source/LKProfileResetDefault.cpp
@@ -481,6 +481,8 @@ void LKProfileResetDefault(void) {
   Overlay_RightMid=1;
   Overlay_RightBottom=1;
 
+  AdditionalContestRule= 0;  // OFF by defauly
+
 
 #ifdef _WGS84
   earth_model_wgs84 = true;

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -428,6 +428,10 @@ void LKProfileSave(const TCHAR *szFile)
   rprintf(szRegistryOverlay_RightTop, Overlay_RightTop);
   rprintf(szRegistryOverlay_RightMid, Overlay_RightMid);
   rprintf(szRegistryOverlay_RightBottom, Overlay_RightBottom);
+
+  rprintf(szRegistryAdditionalContestRule, AdditionalContestRule);
+
+
 #ifdef _WGS84
   rprintf(szRegistry_earth_model_wgs84,earth_model_wgs84);
 #endif

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -412,7 +412,7 @@ void LKProfileSave(const TCHAR *szFile)
   rprintf(szRegistryGearMode      ,GearWarningMode);
   rprintf(szRegistryGearAltitude  ,GearWarningAltitude);
   rprintf(szRegistryBigFAIThreshold,FAI28_45Threshold);
-  rprintf(szRegistryFAIOptiMode   ,FAI_OptimizerMode);
+  rprintf(szRegistryDrawXC   ,Flags_DrawXC);
 
   if (SaveRuntime) rprintf(szRegistryBottomMode    ,BottomMode);
   rprintf(szRegistrySonarWarning    ,SonarWarning_Config);

--- a/android-studio/.idea/kotlinc.xml
+++ b/android-studio/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Kotlin2JsCompilerArguments">
-    <option name="sourceMapEmbedSources" />
-  </component>
-</project>

--- a/android-studio/.idea/kotlinc.xml
+++ b/android-studio/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JsCompilerArguments">
+    <option name="sourceMapEmbedSources" />
+  </component>
+</project>


### PR DESCRIPTION
Replace PR for #1243 

    1) Support for PG/HG most popular cross country online contests along with the Online Contest (OLC) which continues to be the default one. Implemented Contests rules:

    OFF
    Only FAI assistant
    OLC (Default)
    XContest 2018
    XContest 2019
    French CDF ligue
    Leonardo XC
    UK National League

    2) New FAI Assistant .

Preliminary documentation here : https://docs.google.com/document/d/1raS-fDz7-MBsYUUXJxd95G2PVBbaDt189hlwzFjD-S4/edit?usp=sharing