### PR TITLE
Fix "NorthUP Above" interference with "Orientation" setting

### DIFF
--- a/Common/Header/MapWindow.h
+++ b/Common/Header/MapWindow.h
@@ -359,9 +359,13 @@ class MapWindow {
     unsigned _mode;                    /**< @brief Current Map Display Mode */
     unsigned _lastMode;                /**< @brief Previous Map Display Mode */
     TModeFly _userForcedFlyMode;       /**< @brief Fly Mode forced by a user */
+    bool _autoNorthUP =false;
 
-  public:
+
+   public:
     Mode();
+    bool autoNorthUP(){return _autoNorthUP;};
+    void setAutoNorthUP(bool t_AutoNorthUP) {_autoNorthUP = t_AutoNorthUP;};
 
     TModeFly UserForcedMode() const    { return _userForcedFlyMode; }
     void UserForcedMode(TModeFly umode) { _userForcedFlyMode = umode; }
@@ -704,7 +708,7 @@ private:
   static double GetInvDrawScale() { return zoom.InvDrawScale(); }
   static double GetDrawScale() { return zoom.DrawScale(); }
   static double GetDisplayAngle() { return DisplayAngle; }
-  static void SetAutoOrientation(bool doreset);
+  static void SetAutoOrientation();
 
   static BrushReference hInvBackgroundBrush[LKMAXBACKGROUNDS]; // fixed number of backgrounds in MapWindow
 

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -3858,7 +3858,7 @@ int ival;
     if (DisplayOrientation_Config != wp->GetDataField()->GetAsInteger()) {
       DisplayOrientation_Config = wp->GetDataField()->GetAsInteger();
       DisplayOrientation=DisplayOrientation_Config;
-      MapWindow::SetAutoOrientation(true); // reset
+      MapWindow::SetAutoOrientation(); // reset
     }
   }
 

--- a/Common/Source/Draw/DrawFuturePos.cpp
+++ b/Common/Source/Draw/DrawFuturePos.cpp
@@ -27,7 +27,7 @@ void MapWindow::DrawFuturePos(LKSurface& Surface, const POINT& Orig, const RECT&
 
         POINT p1,p2;
 
-        if(!headUpLine && (DisplayOrientation==TRACKUP || DisplayOrientation==NORTHCIRCLE || DisplayOrientation==TARGETCIRCLE || DisplayOrientation==TARGETUP)) { //Track up map view
+        if( !MapWindow::mode.autoNorthUP() && !headUpLine && (DisplayOrientation==TRACKUP || DisplayOrientation==NORTHCIRCLE || DisplayOrientation==TARGETCIRCLE || DisplayOrientation==TARGETUP)) { //Track up map view
             p1.x=Orig.x-NIBLSCALE(4);
             p2.x=Orig.x+NIBLSCALE(4);
             p1.y=p2.y=Orig.y-(int)round(dist2min);

--- a/Common/Source/Draw/DrawHeading.cpp
+++ b/Common/Source/Draw/DrawHeading.cpp
@@ -22,10 +22,10 @@ void MapWindow::DrawHeading(LKSurface& Surface, const POINT& Orig, const RECT& r
 
     int tmp = isqrt4((ClipRect.GetSize().cx*ClipRect.GetSize().cx) + (ClipRect.GetSize().cy*ClipRect.GetSize().cy));
     POINT p2;
-    if (!(DisplayOrientation == TRACKUP || DisplayOrientation == NORTHCIRCLE || DisplayOrientation == TARGETCIRCLE || DisplayOrientation == TARGETUP)) {
+    if (  MapWindow::mode.autoNorthUP() ||   !( DisplayOrientation == TRACKUP || DisplayOrientation == NORTHCIRCLE || DisplayOrientation == TARGETCIRCLE || DisplayOrientation == TARGETUP)) {   // NorthUP
         p2.y= Orig.y - (int)(tmp*fastcosine(DrawInfo.TrackBearing));
         p2.x= Orig.x + (int)(tmp*fastsine(DrawInfo.TrackBearing));
-    } else {
+    } else {  // TrackUP
         p2.x=Orig.x;
         p2.y=Orig.y - (int)tmp;
     }

--- a/Common/Source/Draw/LKGeneralAviation.cpp
+++ b/Common/Source/Draw/LKGeneralAviation.cpp
@@ -154,6 +154,7 @@ void MapWindow::DrawHSIarc(LKSurface& Surface, const POINT& Orig, const RECT& rc
 	if ( DisplayOrientation == NORTHSMART ||
 		DisplayOrientation == NORTHTRACK ||
 		DisplayOrientation == NORTHUP ||
+		MapWindow::mode.autoNorthUP() ||
 		MapWindow::mode.Is(MapWindow::Mode::MODE_CIRCLING)
 		)
 	{

--- a/Common/Source/Draw/MapWindowZoom.cpp
+++ b/Common/Source/Draw/MapWindowZoom.cpp
@@ -51,10 +51,11 @@ void MapWindow::Zoom::CalculateAutoZoom()
   if (wait_for_new_wpt_distance>0) wait_for_new_wpt_distance--;		//This counter is needed to get new valid waypoint distance after wp changes
   if ( (wpd > 0) && (wait_for_new_wpt_distance==0) ) {
     double AutoZoomFactor;
-    if( (DisplayOrientation == NORTHTRACK && !mode.Is(Mode::MODE_CIRCLING)) ||
+    if ((DisplayOrientation == NORTHTRACK && !mode.Is(Mode::MODE_CIRCLING)) ||
         DisplayOrientation == NORTHUP ||
         DisplayOrientation == NORTHSMART ||
-        ((DisplayOrientation == NORTHCIRCLE || DisplayOrientation == TARGETCIRCLE || DisplayOrientation == TARGETUP) && mode.Is(Mode::MODE_CIRCLING)) )
+        ((MapWindow::mode.autoNorthUP() || DisplayOrientation == NORTHCIRCLE || DisplayOrientation == TARGETCIRCLE || DisplayOrientation == TARGETUP)
+            && mode.Is(Mode::MODE_CIRCLING)))
       AutoZoomFactor = 2.5;
     else
       AutoZoomFactor = 4;

--- a/Common/Source/Draw/OrigAndOrient.cpp
+++ b/Common/Source/Draw/OrigAndOrient.cpp
@@ -15,7 +15,7 @@ bool MapWindow::GliderCenter=false;
 void MapWindow::CalculateOrientationNormal(void) {
   double trackbearing = DrawInfo.TrackBearing;
 
-  if( (DisplayOrientation == NORTHUP) ||
+  if( ( MapWindow::mode.autoNorthUP() ||  DisplayOrientation == NORTHUP) ||
       ((DisplayOrientation == NORTHTRACK) &&(!mode.Is(Mode::MODE_CIRCLING)))
 	|| (DisplayOrientation == NORTHSMART) ||
 	( ((DisplayOrientation == NORTHCIRCLE) ||(DisplayOrientation==TARGETCIRCLE)) && (mode.Is(Mode::MODE_CIRCLING)) ) )
@@ -41,7 +41,7 @@ void MapWindow::CalculateOrientationNormal(void) {
 	DisplayAircraftAngle = 0.0;
   }
 
-	if (DisplayOrientation == TARGETUP) {
+	if ( ! MapWindow::mode.autoNorthUP() && DisplayOrientation == TARGETUP) {
 		DisplayAngle = DerivedDrawInfo.WaypointBearing;
 		DisplayAircraftAngle = trackbearing-DisplayAngle;
 	}
@@ -59,7 +59,8 @@ void MapWindow::CalculateOrientationTargetPan(void) {
   if ((ActiveTaskPoint==TargetPanIndex)
       &&(DisplayOrientation != NORTHUP)
       &&(DisplayOrientation != NORTHSMART) // 100419
-      &&(DisplayOrientation != NORTHTRACK)) {
+      &&(DisplayOrientation != NORTHTRACK)
+      &&(!MapWindow::mode.autoNorthUP())) {
     // target-up
     DisplayAngle = DerivedDrawInfo.WaypointBearing;
     DisplayAircraftAngle = DrawInfo.TrackBearing-DisplayAngle;
@@ -138,21 +139,12 @@ void MapWindow::CalculateOrigin(const RECT& rc, POINT *Orig) {
 
 // change dynamically the map orientation mode
 // set true flag for resetting DisplayOrientation mode and return
-void MapWindow::SetAutoOrientation(bool doreset) {
-
-  static bool doinit=true;
-  static int oldDisplayOrientation=0;
-
-  if (doinit||doreset) {
-	oldDisplayOrientation=DisplayOrientation;
-	doinit=false;
-  }
+void MapWindow::SetAutoOrientation() {
 
   // 1.4 because of correction if mapscale reported on screen in MapWindow2
   if (MapWindow::zoom.Scale() * 1.4 >= AutoOrientScale) {
-	// DisplayOrientation=NORTHSMART; // better to keep the glider centered on low zoom levels
-	DisplayOrientation=NORTHUP;
+    MapWindow::mode.setAutoNorthUP(true);
   } else {
-	DisplayOrientation=oldDisplayOrientation;
+	  MapWindow::mode.setAutoNorthUP(false);
   }
 }

--- a/Common/Source/Draw/RenderMapWindow.cpp
+++ b/Common/Source/Draw/RenderMapWindow.cpp
@@ -87,7 +87,7 @@ void MapWindow::RenderMapWindow(LKSurface& Surface, const RECT& rc)
 
   MapWindow::UpdateTimeStats(true);
 
-  SetAutoOrientation(false); // false for no reset Old values
+  SetAutoOrientation(); // false for no reset Old values
 
   //
   // When BigZoom trigger, we shall not calculate waypoints and olc.

--- a/Common/Source/InputEvents.cpp
+++ b/Common/Source/InputEvents.cpp
@@ -3139,7 +3139,7 @@ int iOrientation = DisplayOrientation ;
     if  (MapSpaceMode==MSM_MAP)
     {
 	  DisplayOrientation = iOrientation;
-      MapWindow::SetAutoOrientation(true); // 101008 reset it
+      MapWindow::SetAutoOrientation(); // 101008 reset it
     }
     else
 	  SetMMNorthUp(GetSideviewPage(),iOrientation);

--- a/Common/Source/LKInterface/LKCustomKeyHandler.cpp
+++ b/Common/Source/LKInterface/LKCustomKeyHandler.cpp
@@ -418,7 +418,7 @@ passthrough:
 	      DisplayOrientation++;
 	      if(DisplayOrientation > TARGETUP)
 		DisplayOrientation = 0;
-	      MapWindow::SetAutoOrientation(true); // 101008 reset it
+	      MapWindow::SetAutoOrientation(); // 101008 reset it
 	      switch(DisplayOrientation)
 	      {
             case TRACKUP     : _stprintf(MapOrientMsg,_T("%s"),MsgToken(737)) ; break;  // _@M737_ "Track up"

--- a/Common/Source/LKProfileInitRuntime.cpp
+++ b/Common/Source/LKProfileInitRuntime.cpp
@@ -65,7 +65,7 @@ void LKProfileInitRuntime(void) {
 
   CALCULATED_INFO.AutoMacCready = AutoMacCready_Config==true?1:0;
   DisplayOrientation = DisplayOrientation_Config;
-  MapWindow::SetAutoOrientation(true); // reset old autoorientation
+  MapWindow::SetAutoOrientation(); // reset old autoorientation
 
   MapWindow::GliderScreenPositionY = MapWindow::GliderScreenPosition;
 


### PR DESCRIPTION
In current version if user exit app with a zoom level above "NorthUP Above" setting he will end up with a modified "Orientation" settings. This decouple the two settings.