### PR TITLE
Modified minimum reasonable AutoZoom limit for PG mode

### DIFF
--- a/Common/Source/Draw/MapScale.cpp
+++ b/Common/Source/Draw/MapScale.cpp
@@ -17,16 +17,15 @@ double MapWindow::LimitMapScale(double value) {
   if (mode.Is(Mode::MODE_CIRCLING)) {
       // during circling
       minreasonable = 50.0;
-      if ( ISPARAGLIDER ) minreasonable = 10.0;
   } else {
       // if not circling
       minreasonable = 100.0;
-      if ( ISPARAGLIDER || ISCAR ) minreasonable = 10.0;
+      if ( ISCAR ) minreasonable = 10.0;
       if (zoom.AutoZoom()) {
 	if (AATEnabled && (ActiveTaskPoint>0)) {
-	  if ( ISPARAGLIDER ) minreasonable = 10.0; else minreasonable = 1200.0;
+	  if ( ISPARAGLIDER ) minreasonable = 500; else minreasonable = 1200.0;
 	} else {
-	  if ( ISPARAGLIDER ) minreasonable = 10.0; else minreasonable = 600.0;
+	  if ( ISPARAGLIDER ) minreasonable = 500; else minreasonable = 600.0;
 	}
       }
   }


### PR DESCRIPTION
In PG mode the minimum reasonable AutoZoom limit was only 10. This can lead to a very
confusing situation for the pilot that never have a clear filling on where the cylinder
is as the zoom continues to increase. This new hard coded value should me more reliable
but in the future a rework, eliminating also ISPARAGLIDER, will be necessary.