### PR TITLE
Replaced "#ifdef KOBO" by "IsDithered()" in drawing function

### DIFF
--- a/Common/Source/Dialogs/dlgMultiSelectList.cpp
+++ b/Common/Source/Dialogs/dlgMultiSelectList.cpp
@@ -485,11 +485,12 @@ if(fFact > 1.0 ) fFact = 1.0; else
 LKColor BaseColor = RGB_GREEN ;
 extern  LKColor MixColors(const LKColor& Color2, double fFact1) ;
 
-#ifdef KOBO
-BaseColor = RGB_BLACK;
-#else
-BaseColor =  BaseColor.MixColors( RGB_BLUE, fFact);
-#endif
+if (IsDithered()) {
+  BaseColor = RGB_BLACK;
+} else {
+  BaseColor = BaseColor.MixColors(RGB_BLUE, fFact);
+}
+
 if(pTraf->Status == LKT_GHOST)  UTF8Pictorial( Surface,  rc, MsgToken(2382) ,BaseColor); else     // _@M2382_ "■"
   if(pTraf->Status == LKT_ZOMBIE) UTF8Pictorial( Surface,  rc,  MsgToken(2383) ,BaseColor);else      // _@M2383_ "●"
     UTF8Pictorial( Surface,  rc, MsgToken(2384)  ,BaseColor);    // _@M2384_ "●"

--- a/Common/Source/Draw/DrawFAIOpti.cpp
+++ b/Common/Source/Draw/DrawFAIOpti.cpp
@@ -137,10 +137,9 @@ void FAI_Sector::AnalysisDrawFAISector (LKSurface& Surface, const RECT& rc, cons
 void FAI_Sector::DrawFAISector (LKSurface& Surface, const RECT& rc, const ScreenProjection& _Proj ,const LKColor& InFfillcolor) {
 
 LKColor fillcolor = InFfillcolor;
-#ifdef KOBO
+if (IsDithered()) {
   fillcolor = RGB_SBLACK;
-#endif
-
+}
 const PixelRect ScreenRect(rc);
 const GeoToScreen<ScreenPoint> ToScreen(_Proj);
 

--- a/Common/Source/Draw/DrawTRI.cpp
+++ b/Common/Source/Draw/DrawTRI.cpp
@@ -483,11 +483,12 @@ void MapWindow::DrawAHRS(LKSurface& Surface, const RECT& rc)
 
   /*********************************************************************************************/
     LKPen   hpHorizonGround(PEN_SOLID, IBLSCALE(1),RGB_BLACK);
-#ifdef KOBO
-  LKBrush hbHorizonGround(LKColor(125,20,0));
-#else
-  LKBrush hbHorizonGround(LKColor(255,140,0));
-#endif
+  LKBrush hbHorizonGround;
+  if (IsDithered()) {
+     hbHorizonGround = LKBrush(LKColor(125, 20, 0));
+  } else {
+     hbHorizonGround = LKBrush(LKColor(255, 140, 0));
+  }
 
     const auto oldpen = Surface.SelectObject(hpHorizonGround);
     const auto oldbrush = Surface.SelectObject(hbHorizonGround);

--- a/Common/Source/Draw/LKDrawWaypoints.cpp
+++ b/Common/Source/Draw/LKDrawWaypoints.cpp
@@ -836,9 +836,9 @@ LKColor GetUTF8WaypointSymbol(TCHAR* pPict, const int Style)
       Col = LKColor(199,21,133);
     break;
   } // switch estyle
-#ifdef KOBO
-  Col = LKColor(30,30,30);
-#endif
+	if (IsDithered()) {
+		Col = LKColor(30, 30, 30);
+	}
 return Col;
 }
 


### PR DESCRIPTION
"#ifdef KOBO" should be used only in hardware specific function.
For drawing function, when a BW device is targeted,  IsDithered() should be used.
Todo : replace all "#ifdef DITHER" by IsDithered() so we can manage also Android e-Ink devices