### PR TITLE
Enable external sound also on Android devices

### DIFF
--- a/Common/Header/options.h
+++ b/Common/Header/options.h
@@ -28,7 +28,7 @@
 #endif
 
 // Disable externally generated sounds
-#if !defined(KOBO)
+#if !defined(KOBO) && !defined(ANDROID)
     // audio can be also implemented for external device
     #define DISABLEEXTAUDIO
 #endif

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -1295,8 +1295,6 @@ void UpdateComPortSetting(WndForm* pOwner,  size_t idx, const TCHAR* szPortName)
     }
     else
     {
-    bManageExtAudio &= IsSoundInit();
-
     bool bBt = ((_tcslen(szPortName) > 3) && ((_tcsncmp(szPortName, _T("BT:"), 3) == 0) || (_tcsncmp(szPortName, _T("Bluetooth Server"), 3) == 0)));
     bool bTCPClient = (_tcscmp(szPortName, _T("TCPClient")) == 0);
     bool bTCPServer = (_tcscmp(szPortName, _T("TCPServer")) == 0);


### PR DESCRIPTION
Some Android devices (especially e-ink) does not have sound.
This enable external sound on all Android and so user has a choose to use it.