### PR TITLE
Parse numbers as radiof requency with decimal only.

### DIFF
--- a/Common/Source/Dialogs/dlgAirspaceDetails.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceDetails.cpp
@@ -141,9 +141,9 @@ double  ExtractFrequency(TCHAR *text)
 			       if((text[i+6] >= '0') && (text[i+6] <= '9'))
 			    	   kHz += (text[i+6]-'0');
 
+            fFreq = (double) Mhz+ (double)kHz/1000.0f;
+            return fFreq;
 		       }
-		       fFreq = (double) Mhz+ (double)kHz/1000.0f;
-		       return fFreq;
 	         }
 	   }
    }


### PR DESCRIPTION
This prevents airspaces numbers identified as frequency (such as french notam airspace numbering)