### PR TITLE
Task statistic

### DIFF
--- a/Common/Data/Language/ENG_MSG.TXT
+++ b/Common/Data/Language/ENG_MSG.TXT
@@ -2383,3 +2383,5 @@ _@M2424_ "Max Autozoom level"
 
 _@M2425_ "Draw FAI Assistant"
 _@M2426_ "Draw XC Triangle"
+_@M2427_ "Task Elapsed Time" 
+_@M2428_ "TskTime"

--- a/Common/Header/Calculations.h
+++ b/Common/Header/Calculations.h
@@ -91,6 +91,7 @@ typedef struct _DERIVED_INFO
   double TaskDistanceCovered;
   double TaskTimeToGo;
   double TaskStartTime;
+  double TaskElapsedTime;
   double TaskSpeed;
   double TaskSpeedInstantaneous;
   double TaskAltitudeRequired;

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -734,7 +734,7 @@
 #define LK_XC_CLOSURE_PERC       146     // Additional Contest combined closure %
 #define LK_XC_PREDICTED_DIST     147     // Additional Contest combined closure distance
 #define LK_XC_MEAN_SPEED     148     // Additional Contest mean speed
-
+#define LK_TIMETASK          149     // elapsed time since task start
 
 // The following values are not available for custom configuration
 

--- a/Common/Header/Sizes.h
+++ b/Common/Header/Sizes.h
@@ -17,7 +17,7 @@
 #endif // _MSC_VER > 1000
 
 // Number of InfoBoxes
-#define NUMDATAOPTIONS_MAX                      149
+#define NUMDATAOPTIONS_MAX                      150
 
 
 #define DISTANCE_ROUNDING 20.0

--- a/Common/Source/Calc/ResetFlightStats.cpp
+++ b/Common/Source/Calc/ResetFlightStats.cpp
@@ -93,6 +93,7 @@ void ResetFlightStats(NMEA_INFO *Basic, DERIVED_INFO *Calculated) {
     Calculated->ValidFinish = false;
     Calculated->ValidStart = false;
     Calculated->TaskStartTime = 0;
+    Calculated->TaskElapsedTime =0;
     Calculated->TaskStartSpeed = 0;
     Calculated->TaskStartAltitude = 0;
     Calculated->LegStartTime = 0;

--- a/Common/Source/Calc/Task/TaskSpeed.cpp
+++ b/Common/Source/Calc/Task/TaskSpeed.cpp
@@ -143,12 +143,10 @@ void TaskSpeed(NMEA_INFO *Basic, DERIVED_INFO *Calculated, const double this_mac
       dFinal = 0;
     }
 
-    double dc = max(0.0, dr-dFinal); 
-    // amount of extra distance to travel in cruise/climb before final glide
 
     // actual task speed achieved so far
     v1 = d1/t1;
-    
+#define OLDTASKSPEED
 #ifdef OLDTASKSPEED  
     // time at end of final glide
     // equivalent time elapsed after final glide
@@ -171,6 +169,8 @@ void TaskSpeed(NMEA_INFO *Basic, DERIVED_INFO *Calculated, const double this_mac
     // been earned.
 
     // this will be bogus at fast starts though...
+    double dc = max(0.0, dr-dFinal);
+    // amount of extra distance to travel in cruise/climb before final glide
 
     LKASSERT((t1+dc/v1+dFinal/Vfinal)!=0);
     LKASSERT((t1+dFinal/Vfinal)!=0);

--- a/Common/Source/Calc/Task/TaskStatistic.cpp
+++ b/Common/Source/Calc/Task/TaskStatistic.cpp
@@ -20,7 +20,8 @@ extern AATDistance aatdistance;
 void TaskStatistics(NMEA_INFO *Basic, DERIVED_INFO *Calculated, 
                     const double this_maccready)
 {
-
+if( Calculated->ValidFinish)  // don't update statistics after task finished
+  return;
   if (!ValidTaskPoint(ActiveTaskPoint) || 
       ((ActiveTaskPoint>0) && !ValidTaskPoint(ActiveTaskPoint-1))) {
 

--- a/Common/Source/Calc/Task/TaskStatistic.cpp
+++ b/Common/Source/Calc/Task/TaskStatistic.cpp
@@ -425,7 +425,10 @@ if( Calculated->ValidFinish)  // don't update statistics after task finished
   Calculated->TaskAltitudeDifference = total_energy_height - Calculated->TaskAltitudeRequired; 
   Calculated->TaskAltitudeDifference0 = total_energy_height - TaskAltitudeRequired0;
   Calculated->NextAltitudeDifference0 = total_energy_height - Calculated->NextAltitudeRequired0;
-
+  if( Calculated->TaskStartTime > 0)
+    Calculated->TaskElapsedTime =  Basic->Time-  Calculated->TaskStartTime;
+  else
+    Calculated->TaskElapsedTime =0;
   Calculated->TaskAltitudeArrival += Calculated->TaskAltitudeDifference;
 
   Calculated->GRFinish= CalculateGlideRatio(Calculated->TaskDistanceToGo, Calculated->NavAltitude - final_height);

--- a/Common/Source/DataOptions.cpp
+++ b/Common/Source/DataOptions.cpp
@@ -321,7 +321,9 @@ void FillDataOptions()
     SetDataOption(LK_XC_CLOSURE_PERC, ugDistance, TEXT("_@M2264_"), TEXT("_@M2275_"));		// AdditionalContest combined closure %
     SetDataOption(LK_XC_PREDICTED_DIST, ugDistance, TEXT("_@M2265_"), TEXT("_@M2276_"));		   // Additional Contest combined distance
 	SetDataOption(LK_XC_MEAN_SPEED, ugDistance, TEXT("_@M2277_"), TEXT("_@M2278_"));		   // Additional Contest combined distance
+	SetDataOption(LK_TIMETASK, ugDistance, TEXT("_@M2427_"), TEXT("_@M2488_"));		   // Elapsed task time (time since start
   
+
 	//Before adding new items, consider changing NUMDATAOPTIONS_MAX
   static_assert(LK_XC_MEAN_SPEED < NUMDATAOPTIONS_MAX, "NUMDATAOPTIONS_MAX are too small");
 

--- a/Common/Source/Draw/LKProcess.cpp
+++ b/Common/Source/Draw/LKProcess.cpp
@@ -786,6 +786,26 @@ goto_bearing:
 			break;
 
 
+		case LK_TIMETASK:
+			_stprintf(BufferValue,_T(NULLTIME));
+			if (lktitle)
+				//  _@M2427_  "Task elapsed time" LKTOKEN _@M2428_ "TskTime"
+				_tcscpy(BufferTitle, MsgToken(2428));
+			else
+				_stprintf(BufferTitle, TEXT("%s"), Data_Options[lkindex].Title );
+
+			if (DerivedDrawInfo.TaskElapsedTime > 0) {
+				valid=true;
+				if (Units::TimeToTextDown(BufferValue, DerivedDrawInfo.TaskElapsedTime)) // 091112
+					_stprintf(BufferUnit, TEXT("h"));
+				else
+					_stprintf(BufferUnit, TEXT("m"));
+			} else {
+				_stprintf(BufferValue, TEXT(NULLTIME));
+			}
+
+			break;
+
 		// B37
 		case LK_GLOAD:
 			if ( DrawInfo.AccelerationAvailable) { 


### PR DESCRIPTION
improved Task statistics

-Task, new value elapsed Task time
-Task, stop calculation update after valid finish
-Task, use old average task speed calculation


returned to the average old Task speed calculation!

The old one (just one of the three) is simply calculated as Task distance covered, divided by elapsed task time. Also known as “averaged task speed” (up to current time and position)

Maybe not a sophisticated but easy to understand definition.

The others are predictions assuming different pre-conditions of MC height and direct final glide, but nobody can explain how it works exactly and how it must be interpreted

I replayed a lot of IGC files but the predicted speeds never made any sense to me and were far away from the real task speed after finishing the task.

Also users complained about it:
https://www.postfrontal.com/forum/topic.asp?TOPIC_ID=7836&SearchTerms=Task+Speed
https://www.postfrontal.com/forum/topic.asp?TOPIC_ID=8214&SearchTerms=Task+Speed




