### PR TITLE
Some fixes

### DIFF
--- a/Common/Source/Draw/LKDrawInfoPage.cpp
+++ b/Common/Source/Draw/LKDrawInfoPage.cpp
@@ -983,114 +983,116 @@ label_HSI:
 	VDrawLine(Surface,rc, qcolumn[0],qrow[2],qcolumn[16],qrow[2],RGB_DARKGREEN);
         #endif
 	static bool showQFU=false, showVFRlanding=false;
-	static bool usingQFU, approach, landing;
-	DrawHSI(Surface,rc,usingQFU,approach,landing);
-	if(landing) {
-		showVFRlanding=!showVFRlanding; //make it blinking
-		if(usingQFU) showQFU=!showVFRlanding;
-		else showQFU=false;
-	} else {
-		showVFRlanding=false;
-		if(usingQFU) showQFU=!showQFU; //make it blinking
-		else showQFU=false;
-	}
-	if(showVFRlanding || showQFU) { //show QFU or "VFR landing"
-		if(showVFRlanding) {
-			_stprintf(Buffer,TEXT("VFR %s"),MsgToken(931)); //TODO: toupper()
-			#ifndef DITHER
-			icolor=INVERTCOLORS?RGB_YELLOW:RGB_DARKYELLOW;
-			#else
-			icolor=RGB_WHITE;
-			#endif
+	{
+		bool usingQFU=false, approach=false, landing=false;
+		DrawHSI(Surface,rc,usingQFU,approach,landing);
+		if(landing) {
+			showVFRlanding=!showVFRlanding; //make it blinking
+			if(usingQFU) showQFU=!showVFRlanding;
+			else showQFU=false;
+		} else {
+			showVFRlanding=false;
+			if(usingQFU) showQFU=!showQFU; //make it blinking
+			else showQFU=false;
 		}
-		if(showQFU) {
-			_stprintf(Buffer, TEXT("QFU: %d%s"),WayPointList[Task[ActiveTaskPoint].Index].RunwayDir,MsgToken(2179));
-			#ifndef DITHER
-			icolor=RGB_GREEN;
-			#else
+		if(showVFRlanding || showQFU) { //show QFU or "VFR landing"
+			if(showVFRlanding) {
+				_stprintf(Buffer,TEXT("VFR %s"),MsgToken(931)); //TODO: toupper()
+				#ifndef DITHER
+				icolor=INVERTCOLORS?RGB_YELLOW:RGB_DARKYELLOW;
+				#else
+				icolor=RGB_WHITE;
+				#endif
+			}
+			if(showQFU) {
+				_stprintf(Buffer, TEXT("QFU: %d%s"),WayPointList[Task[ActiveTaskPoint].Index].RunwayDir,MsgToken(2179));
+				#ifndef DITHER
+				icolor=RGB_GREEN;
+				#else
+				icolor=RGB_WHITE;
+				#endif
+			}
+		} else { //show next waypoint name
 			icolor=RGB_WHITE;
-			#endif
-		}
-	} else { //show next waypoint name
-		icolor=RGB_WHITE;
-		if(ValidTaskPoint(ActiveTaskPoint)) {
-			if(Task[ActiveTaskPoint].Index >=0) _tcscpy(Buffer, WayPointList[Task[ActiveTaskPoint].Index].Name);
-			else {
+			if(ValidTaskPoint(ActiveTaskPoint)) {
+				if(Task[ActiveTaskPoint].Index >=0) _tcscpy(Buffer, WayPointList[Task[ActiveTaskPoint].Index].Name);
+				else {
+					_tcscpy(Buffer,MsgToken(912)); // [no dest]
+					icolor=AMBERCOLOR;
+				}
+			} else {
 				_tcscpy(Buffer,MsgToken(912)); // [no dest]
 				icolor=AMBERCOLOR;
 			}
-		} else {
-			_tcscpy(Buffer,MsgToken(912)); // [no dest]
-			icolor=AMBERCOLOR;
 		}
-	}
-	Surface.SelectObject(LK8PanelMediumFont);
-	LKWriteText(Surface,  Buffer, qcolumn[8],qrow[1], WTMODE_NORMAL, WTALIGN_CENTER, icolor, false);
-	showunit=true;
-	if (ScreenLandscape) {
-		LKFormatValue(LK_NEXT_ETE, true, BufferValue, BufferUnit, BufferTitle);
-		_tcscpy(BufferUnit,_T(""));
-		WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[3],&qrow[4],&qrow[2]);
-		LKFormatValue(LK_NEXT_DIST, true, BufferValue, BufferUnit, BufferTitle);
-		WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[3], &qcolumn[3],&qrow[7],&qrow[8],&qrow[6]);
-		LKFormatValue(LK_NEXT_ETA, true, BufferValue, BufferUnit, BufferTitle);
-		_tcscpy(BufferUnit,_T(""));
-		WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
-		if(!approach) { //if not landing print also dist, ETE and ETA respect task end
-			LKFormatValue(LK_FIN_ETE, true, BufferValue, BufferUnit, BufferTitle);
+		Surface.SelectObject(LK8PanelMediumFont);
+		LKWriteText(Surface,  Buffer, qcolumn[8],qrow[1], WTMODE_NORMAL, WTALIGN_CENTER, icolor, false);
+		showunit=true;
+		if (ScreenLandscape) {
+			LKFormatValue(LK_NEXT_ETE, true, BufferValue, BufferUnit, BufferTitle);
 			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
-			LKFormatValue(LK_FIN_DIST, true, BufferValue, BufferUnit, BufferTitle);
-			if(ScreenSize==ss800x480 || ScreenSize==ss480x272)
-				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[15], &qcolumn[15],&qrow[7],&qrow[8],&qrow[6]);
-			else {
+			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[3],&qrow[4],&qrow[2]);
+			LKFormatValue(LK_NEXT_DIST, true, BufferValue, BufferUnit, BufferTitle);
+			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[3], &qcolumn[3],&qrow[7],&qrow[8],&qrow[6]);
+			LKFormatValue(LK_NEXT_ETA, true, BufferValue, BufferUnit, BufferTitle);
+			_tcscpy(BufferUnit,_T(""));
+			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
+			if(!approach) { //if not landing print also dist, ETE and ETA respect task end
+				LKFormatValue(LK_FIN_ETE, true, BufferValue, BufferUnit, BufferTitle);
 				_tcscpy(BufferUnit,_T(""));
-				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[7],&qrow[8],&qrow[6]);
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
+				LKFormatValue(LK_FIN_DIST, true, BufferValue, BufferUnit, BufferTitle);
+				if(ScreenSize==ss800x480 || ScreenSize==ss480x272)
+					WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[15], &qcolumn[15],&qrow[7],&qrow[8],&qrow[6]);
+				else {
+					_tcscpy(BufferUnit,_T(""));
+					WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[7],&qrow[8],&qrow[6]);
+				}
+				LKFormatValue(LK_FIN_ETA, true, BufferValue, BufferUnit, BufferTitle);
+				_tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);
+			} else { //show other interesting things for landing
+				int col=16;
+				bool unitInvisible=true;
+				if(ScreenSize==ss800x480 || ScreenSize==ss480x272) {
+					col=15;
+					unitInvisible=false;
+				}
+				LKFormatValue(LK_IAS, true, BufferValue, BufferUnit, BufferTitle);
+				if(unitInvisible) _tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[col], &qcolumn[col],&qrow[3],&qrow[4],&qrow[2]);
+				LKFormatValue(LK_HAGL, true, BufferValue, BufferUnit, BufferTitle);
+				if(unitInvisible) _tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[col], &qcolumn[col],&qrow[12],&qrow[13],&qrow[11]);
 			}
-			LKFormatValue(LK_FIN_ETA, true, BufferValue, BufferUnit, BufferTitle);
-			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);
-		} else { //show other interesting things for landing
-			int col=16;
-			bool unitInvisible=true;
-			if(ScreenSize==ss800x480 || ScreenSize==ss480x272) {
-				col=15;
-				unitInvisible=false;
-			}
-			LKFormatValue(LK_IAS, true, BufferValue, BufferUnit, BufferTitle);
-			if(unitInvisible) _tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[col], &qcolumn[col],&qrow[3],&qrow[4],&qrow[2]);
-			LKFormatValue(LK_HAGL, true, BufferValue, BufferUnit, BufferTitle);
-			if(unitInvisible) _tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[col], &qcolumn[col],&qrow[12],&qrow[13],&qrow[11]);
-		}
-	} else {
-		LKFormatValue(LK_NEXT_ETE, true, BufferValue, BufferUnit, BufferTitle);
-		_tcscpy(BufferUnit,_T(""));
-		WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[3],&qrow[4],&qrow[2]);
-		LKFormatValue(LK_NEXT_DIST, true, BufferValue, BufferUnit, BufferTitle);
-		_tcscpy(BufferUnit,_T(""));
-		WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[3], &qcolumn[3],&qrow[6],&qrow[7],&qrow[5]);
-		LKFormatValue(LK_NEXT_ETA, true, BufferValue, BufferUnit, BufferTitle);
-		_tcscpy(BufferUnit,_T(""));
-		WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
-		if(!approach) { //if not landing print also dist, ETE and ETA respect task end
-			LKFormatValue(LK_FIN_ETE, true, BufferValue, BufferUnit, BufferTitle);
-			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
-			LKFormatValue(LK_FIN_DIST, true, BufferValue, BufferUnit, BufferTitle);
-			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[6],&qrow[7],&qrow[5]);
-			LKFormatValue(LK_FIN_ETA, true, BufferValue, BufferUnit, BufferTitle);
-			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);
 		} else {
-			LKFormatValue(LK_IAS, true, BufferValue, BufferUnit, BufferTitle);
+			LKFormatValue(LK_NEXT_ETE, true, BufferValue, BufferUnit, BufferTitle);
 			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
-			LKFormatValue(LK_HAGL, true, BufferValue, BufferUnit, BufferTitle);
+			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[3],&qrow[4],&qrow[2]);
+			LKFormatValue(LK_NEXT_DIST, true, BufferValue, BufferUnit, BufferTitle);
 			_tcscpy(BufferUnit,_T(""));
-			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);
+			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[3], &qcolumn[3],&qrow[6],&qrow[7],&qrow[5]);
+			LKFormatValue(LK_NEXT_ETA, true, BufferValue, BufferUnit, BufferTitle);
+			_tcscpy(BufferUnit,_T(""));
+			WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[4], &qcolumn[4],&qrow[12],&qrow[13],&qrow[11]);
+			if(!approach) { //if not landing print also dist, ETE and ETA respect task end
+				LKFormatValue(LK_FIN_ETE, true, BufferValue, BufferUnit, BufferTitle);
+				_tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
+				LKFormatValue(LK_FIN_DIST, true, BufferValue, BufferUnit, BufferTitle);
+				_tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[6],&qrow[7],&qrow[5]);
+				LKFormatValue(LK_FIN_ETA, true, BufferValue, BufferUnit, BufferTitle);
+				_tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);
+			} else {
+				LKFormatValue(LK_IAS, true, BufferValue, BufferUnit, BufferTitle);
+				_tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[3],&qrow[4],&qrow[2]);
+				LKFormatValue(LK_HAGL, true, BufferValue, BufferUnit, BufferTitle);
+				_tcscpy(BufferUnit,_T(""));
+				WriteInfo(Surface, &showunit, BufferValue, BufferUnit, BufferTitle, &qcolumn[16], &qcolumn[16],&qrow[12],&qrow[13],&qrow[11]);
+			}
 		}
 	}
 	goto label_End; // End of HSI

--- a/Common/Source/Waypoints/ParseOpenAIP.cpp
+++ b/Common/Source/Waypoints/ParseOpenAIP.cpp
@@ -404,7 +404,7 @@ bool ParseNavAids(XMLNode &navAidsNode)
         XMLNode node=NavAidNode.getChildNode(TEXT("RADIO"));
         if(node.isEmpty()) continue;
         if(!GetContent(node, TEXT("FREQUENCY"), dataStr)) continue;
-        comments<<"Frequency: "<<dataStr<<" MHz";
+        comments << "Frequency: " << dataStr << (new_waypoint.Style != STYLE_NDB ? " MHz" : " kHz");
         LK_tcsncpy(new_waypoint.Freq, dataStr, CUPSIZE_FREQ);
         if (_tcslen(dataStr)>CUPSIZE_FREQ) new_waypoint.Freq[CUPSIZE_FREQ]= _T('\0');
         if(GetContent(node, TEXT("CHANNEL"), dataStr)) comments<<" Channel: "<<dataStr;
@@ -418,7 +418,7 @@ bool ParseNavAids(XMLNode &navAidsNode)
         if(GetValue(node,TEXT("DECLINATION"),value)) comments<<"Declination: "<<value<<MsgToken(2179);
         if(GetContent(node,TEXT("ALIGNEDTOTRUENORTH"),dataStr)) {
             if(_tcsicmp(dataStr,_T("TRUE"))==0) comments<<" True north";
-            else if(_tcsicmp(dataStr,_T("TRUE"))==0) comments<<" Magnetic north";
+            else if(_tcsicmp(dataStr,_T("FALSE"))==0) comments<<" Magnetic north";
         }
 
         // Add the comments


### PR DESCRIPTION
For DrawHSI: just surrounded the scope of output parameter with parenthesis...
In this way they don't have to be static...

For parsing openAIP nav aids: the NDB frequencies are in kHz not in MHz:
https://en.wikipedia.org/wiki/Non-directional_beacon
