### PR TITLE
remove compiler warning (PC compiler only)

### DIFF
--- a/Common/Source/Calc/Task/TaskStatistic.cpp
+++ b/Common/Source/Calc/Task/TaskStatistic.cpp
@@ -20,8 +20,9 @@ extern AATDistance aatdistance;
 void TaskStatistics(NMEA_INFO *Basic, DERIVED_INFO *Calculated, 
                     const double this_maccready)
 {
-if( Calculated->ValidFinish)  // don't update statistics after task finished
-  return;
+  if( Calculated->ValidFinish) { // don't update statistics after task finished
+    return;
+  }
   if (!ValidTaskPoint(ActiveTaskPoint) || 
       ((ActiveTaskPoint>0) && !ValidTaskPoint(ActiveTaskPoint-1))) {
 


### PR DESCRIPTION
prevent warning
TaskStatistic.cpp:23:1: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
by using extra brackets.