### PR TITLE
restore previous task if select dialog canceled

### DIFF
--- a/Common/Source/Dialogs/dlgTaskOverview.cpp
+++ b/Common/Source/Dialogs/dlgTaskOverview.cpp
@@ -393,6 +393,7 @@ static void OnCloseClicked(WndButton* pWnd) {
   if(pWnd) {
     WndForm * pForm = pWnd->GetParentWndForm();
     if(pForm) {
+      SaveDefaultTask(); // save  changed task
       pForm->SetModalResult(mrOK);
     }
   }
@@ -538,23 +539,18 @@ static void OnLoadClicked(WndButton* pWnd){ // 091216
   dfe = (DataFieldFileReader*) wp->GetDataField();
 
   int file_index = dfe->GetAsInteger();
+   LPCTSTR szFileName = dfe->GetPathFile();
+   LPCTSTR wextension = _tcsrchr(szFileName, _T('.'));
+    
   if (file_index>0) {
-	if (ValidTaskPoint(ActiveTaskPoint) && ValidTaskPoint(1)) {
+	if (ValidTaskPoint(ActiveTaskPoint) && ValidTaskPoint(1) &&   (_tcsicmp(wextension,_T(LKS_WP_CUP))!=0)) {
 		_stprintf(file_name, TEXT("%s '%s' ?"), MsgToken(891), dfe->GetAsString()); // Clear old task and load
 		if(MessageBoxX(file_name, _T(" "), mbYesNo) == IdNo) {
 			return;
 		}
 	}
-  } else {
-	// LKTOKEN  _@M467_ = "No Task to load"
-	MessageBoxX(MsgToken(467),_T(" "), mbOk);
-	return;
-  }
 
-  if (file_index>0) {
 
-      LPCTSTR szFileName = dfe->GetPathFile();
-      LPCTSTR wextension = _tcsrchr(szFileName, _T('.'));
       if(wextension) {
 
           TCHAR szFilePath[MAX_PATH];
@@ -578,7 +574,12 @@ static void OnLoadClicked(WndButton* pWnd){ // 091216
           UpdateFilePointer();
           UpdateCaption();
       }
-  }
+  } else {
+  	// LKTOKEN  _@M467_ = "No Task to load"
+  	MessageBoxX(MsgToken(467),_T(" "), mbOk);
+  	return;
+    }
+
 }
 
 

--- a/Common/Source/SaveLoadTask/LoadCupTask.cpp
+++ b/Common/Source/SaveLoadTask/LoadCupTask.cpp
@@ -19,6 +19,7 @@
 #include "Dialogs.h"
 #include "dlgTools.h"
 #include "resource.h"
+#include "InputEvents.h"
 
 int dlgTaskSelectListShowModal(void) ;
 
@@ -620,7 +621,7 @@ TCHAR szString[READLINE_LENGTH + 1];
 
   iNO_Tasks=0;
 
-
+  SaveDefaultTask(); // save current task for restore if no task load
   while(LoadCupTaskSingle(szFileName,szString, iNO_Tasks)&&( iNO_Tasks < MAX_TASKS ))
   {
     LockTaskData();
@@ -665,12 +666,22 @@ TCHAR szString[READLINE_LENGTH + 1];
     iNO_Tasks++;
   }
   TaskIndex =0;
-
+  InputEvents::eventTaskLoad(_T(LKF_DEFAULTASK)); //  restore old task
   dlgTaskSelectListShowModal();
   if((TaskIndex >= 0) && (TaskIndex < MAX_TASKS))
-    LoadCupTaskSingle(szFileName,szString, TaskIndex);
+  {     TCHAR file_name[180];
+        TCHAR *pWClast = NULL;
+        TCHAR * pToken = strsep_r(szTaskStrings[TaskIndex], TEXT(","), &pWClast) ;  // extract taskname
+        if((pToken) && (_tcslen (pToken)>1))
+	  _sntprintf(file_name,180, TEXT("%s %s ?"), MsgToken(891), pToken ); // Clear old task and load taskname
+        else
+          _sntprintf(file_name,180, TEXT("%s %s ?"), MsgToken(891), MsgToken(907)); // Clear old task and load task
+	if(MessageBoxX(file_name, _T(" "), mbYesNo) == IdYes) {
+	  LoadCupTaskSingle(szFileName,szString, TaskIndex); // load new task
+	}
+  }
 
-  LoadCupTaskSingle(szFileName,szString, TaskIndex);
+
 
   for (int i =0 ; i< MAX_TASKS;i++)    // free dynamic memory
     if(szTaskStrings[i] != NULL)


### PR DESCRIPTION
when CUP file, ask for "overwrite task" after task selection dialog
Save Task directly when TaskOverview Dialog is closed, to ensure new default task even after abnormal termination
to fix this:
https://github.com/LK8000/LK8000/issues/1358