### PR TITLE
store/load SoundMode fix

### DIFF
--- a/Common/Header/LKProfiles.h
+++ b/Common/Header/LKProfiles.h
@@ -450,6 +450,7 @@ char szRegistryAdditionalContestRule[]       = "Additional_Contest_Rule";
 #ifdef _WGS84
 char szRegistry_earth_model_wgs84[] = "earth_model_wgs84";
 #endif
+char szRegistrySoundSwitch[] = "SoundSwitch";
 //
 //
 //
@@ -811,7 +812,7 @@ extern const char szRegistryAdditionalContestRule[];
 #ifdef _WGS84
 extern const char szRegistry_earth_model_wgs84[];
 #endif
-
+extern const char szRegistrySoundSwitch[];
 //
 //
 #endif

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -994,6 +994,17 @@ void LKParseProfileString(const char *sname, const char *svalue) {
     }
   }
 
+  if(!SaveRuntime) {
+    EnableSoundModes =true;
+  }
+  else
+  {
+    PREAD(sname,svalue,szRegistrySoundSwitch,&EnableSoundModes);
+    if (matchedstring) {
+     return;
+    }
+  }
+
   #if TESTBENCH
   if (!strcmp(sname,"LKVERSION") && !strcmp(sname,"PROFILEVERSION")) {
       StartupStore(_T("... UNMANAGED PARAMETER inside profile: <%s>=<%s>\n"),sname,svalue);

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -449,6 +449,8 @@ void LKProfileSave(const TCHAR *szFile)
     rprintf(szRegistryScreenSizeX  ,ScreenSizeX);
     rprintf(szRegistryScreenSizeY  ,ScreenSizeY);
   }
+  if (SaveRuntime)
+    rprintf(szRegistrySoundSwitch,EnableSoundModes);
 
   fprintf(pfp,PNEWLINE); // end of file
   fflush(pfp);

--- a/Common/Source/lk8000.cpp
+++ b/Common/Source/lk8000.cpp
@@ -111,6 +111,7 @@ BOOL	InitInstance    ();
 
 extern void CreateCalculationThread();
 extern void PreloadInitialisation(bool ask);
+extern bool LKProfileLoad(const TCHAR *szFile);
 #ifdef PNA
 extern bool LoadModelFromProfile(void);
 #endif
@@ -235,16 +236,17 @@ bool Startup(const TCHAR* szCmdLine) {
   #if USELKASSERT
   StartupStore(TEXT(". USELKASSERT option enabled%s"),NEWLINE);
   #endif
-  
-  // This is needed otherwise LKSound will be silent until we init Globals.
-  EnableSoundModes=true;
 
-
-  LKSound(_T("LK_CONNECT.WAV"));
 
   Globals_Init();
 
   StartupLogFreeRamAndStorage();
+
+#ifdef PRELOAD_SOUND_SWITCH
+  LocalPath(defaultProfileFile, _T(LKD_CONF), _T(LKPROFILE));
+  LKProfileLoad(defaultProfileFile);
+#endif  
+  LKSound(_T("LK_CONNECT.WAV"));
 
   lscpu_init();
   if (HaveSystemInfo) {


### PR DESCRIPTION
if Save Runtime is enabled
SaveRuntime check on storing (not loading) parameters.
correct handling on missing parameter using "matchedstring"
replaced atoi by strsol for unicode
Store Sound ON/OFF
