### PR TITLE
Airspace ACK improvements

### DIFF
--- a/Common/Header/LKAirspace.h
+++ b/Common/Header/LKAirspace.h
@@ -130,6 +130,8 @@ public:
   // Warning system
   // Set ack validity timeout according to config prameter
   void SetAckTimeout();
+  // check if airspace was already acknolaged
+  bool Acknowledged(void);
   // get nearest distance info to this airspace, returns true if distances calculated by warning system
   bool GetDistanceInfo(bool &inside, int &hDistance, int &Bearing, int &vDistance) const;
   // get warning point coordinates, returns true if airspace has valid distances calculated

--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -624,6 +624,12 @@ void CAirspaceBase::SetAckTimeout() {
     _warnacktimeout = _now + AcknowledgementTime;
 }
 
+bool  CAirspaceBase::Acknowledged(void) {
+	if (_warningacklevel >  awNone)
+		return true;
+	else
+		return false;
+}
 // Gets calculated distances, returns true if distances valid
 
 bool CAirspaceBase::GetDistanceInfo(bool &inside, int &hDistance, int &Bearing, int &vDistance) const {
@@ -951,7 +957,7 @@ void CAirspace::CalculateScreenPosition(const rectObj &screenbounds_latlon, cons
         // airspace is visible only if clipped polygon have more than 2 point.
         if (_screenpoints_clipped.size() > 2)  {
 
-            if ((!(iAirspaceBrush[_type] == NUMAIRSPACEBRUSHES - 1)) && ((_warninglevel == awNone) || (_warninglevel > _warningacklevel))) {
+            if ( (((!(iAirspaceBrush[_type] == NUMAIRSPACEBRUSHES - 1)) && (_warninglevel == awNone) && (_warningacklevel ==  awNone))|| (_warninglevel > _warningacklevel)/*(_warningacklevel == awNone)*/)) {
                 _drawstyle = adsFilled;
             } else {
                 _drawstyle = adsOutline;

--- a/Common/Source/Dialogs/dlgAirspaceDetails.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceDetails.cpp
@@ -77,6 +77,7 @@ static void OnAcknowledgeClicked(WndButton* pWnd){
     ScopeLock guard(CAirspaceManager::Instance().MutexRef());
     CAirspace* airspace = CAirspaceManager::Instance().GetAirspacesForDetails();
     if(airspace) {
+      CAirspaceManager::Instance().AirspaceSetAckLevel(*airspace, awNone);
       if (airspace_copy.Enabled()) {
         CAirspaceManager::Instance().AirspaceDisable(*airspace);
       } else {

--- a/Common/Source/Dialogs/dlgLKAirspaceWarning.cpp
+++ b/Common/Source/Dialogs/dlgLKAirspaceWarning.cpp
@@ -388,11 +388,14 @@ short ShowAirspaceWarningsToUser()
 
     case aweLeavingNonFly:
       // LKTOKEN _@M1241_ "Leaving"
+			 if(!airspace_copy.Acknowledged() )  // don't warn on leaving acknolaged airspaces
+			 {
 	  if( _tcsnicmp(  airspace_copy.Name(),   airspace_copy.TypeName() ,_tcslen(airspace_copy.TypeName())) == 0)
 		_stprintf(msgbuf,TEXT("%s %s"),MsgToken(1241),airspace_copy.Name());
 	  else
 		_stprintf(msgbuf,TEXT("%s %s %s"),MsgToken(1241),airspace_copy.TypeName(),airspace_copy.Name());
       DoStatusMessage(msgbuf);
+			 }
       break;
 
   }

--- a/Common/Source/Draw/Multimaps/RenderAirspaceTerrain.cpp
+++ b/Common/Source/Draw/Multimaps/RenderAirspaceTerrain.cpp
@@ -143,7 +143,7 @@ void RenderAirspaceTerrain(LKSurface& Surface, double PosLat, double PosLon, dou
         double fFrameColFact;
         int Framewidth = FRAMEWIDTH;
         if (Sideview_pHandeled[iSizeIdx].bEnabled) {
-            if (MapWindow::GetAirSpaceFillType() == MapWindow::asp_fill_border_only)
+            if ((MapWindow::GetAirSpaceFillType() == MapWindow::asp_fill_border_only) || (Sideview_pHandeled[iSizeIdx].psAS->DrawStyle()== adsOutline))
             {
 		  Surface.SelectObject(LKBrush_Hollow);
 		  Framewidth *=3;


### PR DESCRIPTION
-reset acknowledge state if airspace was dis-/enabled
-don't display "LEAVE" message on acknowledged airspaces
-draw acknowledged airspaces as outline incl. group ack and sideview.
reported here:
https://www.postfrontal.com/forum/topic.asp?TOPIC_ID=9047