### PR TITLE
There is no "NOTAM" airspace in openAIP

### DIFF
--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -2189,9 +2189,6 @@ bool CAirspaceManager::FillAirspacesFromOpenAIP(const TCHAR* szFile) {
               if (_tcsicmp(dataStr,_T("GLIDING"))==0) Type=GLIDERSECT;
             }
             break;
-        case 'N':
-          /*  if (_tcsicmp(dataStr,_T("NOTAM"))==0) */ Type=CLASSNOTAM; // Prohibited area
-            break;
         //case 'O':
             //if (_tcsicmp(dataStr,_T("OTH"))==0) continue; //TODO: OTH missing in LK8000
             //break;

--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -2182,12 +2182,7 @@ bool CAirspaceManager::FillAirspacesFromOpenAIP(const TCHAR* szFile) {
             break;
         case 'G':
             if(len==1) Type=CLASSG; // G class airspace
-            else
-            {
-              if (_tcsicmp(dataStr,_T("GP"))==0)      Type=NOGLIDER;
-              if (_tcsicmp(dataStr,_T("GSEC"))==0)    Type=GLIDERSECT;
-              if (_tcsicmp(dataStr,_T("GLIDING"))==0) Type=GLIDERSECT;
-            }
+            else if (_tcsicmp(dataStr,_T("GLIDING"))==0) Type=GLIDERSECT;
             break;
         //case 'O':
             //if (_tcsicmp(dataStr,_T("OTH"))==0) continue; //TODO: OTH missing in LK8000
@@ -2210,7 +2205,7 @@ bool CAirspaceManager::FillAirspacesFromOpenAIP(const TCHAR* szFile) {
             break;
         case 'U':
             if (_tcsicmp(dataStr,_T("UIR"))==0)
-            Type = OTHER;; //TODO: UIR missing in LK8000
+            Type = OTHER; //TODO: UIR missing in LK8000
             break;
         default:
             break;


### PR DESCRIPTION
As far as I know there is no "Notam" airspace category in _openAIP_. (There is in _OpenAir_: `AC NOTAM`).
For reference here the _openAIP_ format specifications: [Airspace.pdf](https://github.com/LK8000/LK8000/files/4182998/Airspace.pdf)
