### PR TITLE
Add device connection type NMEA Replay (device emulation)

### DIFF
--- a/Common/Data/Dialogs/dlgConfigDevice_L.xml
+++ b/Common/Data/Dialogs/dlgConfigDevice_L.xml
@@ -11,7 +11,7 @@
     <WndButton Name="cmdF" Caption="F" X="251" Y="-999" Width="50" Height="40" Font="2" Tag="2" OnClickNotify="OnF" />
 
     <WndButton Name="cmdTerminal" Caption="_@M1871_" X="3" Y="138" Width="70" Height="28" Font="2" Tag="3" OnClickNotify="OnTerminalClicked" />
-    <WndButton Name="cmdBth" Caption="Bluetooth" X="3" Y="166" Width="70" Height="28" Font="2" Tag="2" OnClickNotify="OnBthDevice"/>
+    <WndButton Name="cmdBth" Caption="Bluetooth" X="3" Y="166" Width="70" Height="28" Font="2" Tag="2" OnClickNotify="OnBthDevice"/>    
     <WndButton Name="cmdClose" Caption="_@M186_" X="3" Y="194" Width="70" Height="28" Font="2" Tag="3" />
 
     <WndFrame Name="frmCommName" Caption="_@M232_" X="0" Y="40" Width="-1" Height="98" Font="2">
@@ -20,22 +20,24 @@
       <WndProperty Name="prpComDevice1" Caption="_@M450_" X="60" Y="1" Width="-1" Height="22" CaptionWidth="70" Font="2" Help="_@H153_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1" OnDataAccess="OnDeviceAData" />
       </WndProperty>
-      <WndProperty Name="prpComPort1" Caption="_@M530_" X="60" Y="-1" Width="155" Height="22" CaptionWidth="70" Font="2" Help="_@H154_">
+      <WndProperty Name="prpComPort1" Caption="_@M530_" X="60" Y="-1" Width="195" Height="22" CaptionWidth="70" Font="2" Help="_@H154_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1" OnDataAccess="OnComPort1Data"/>
       </WndProperty>
-      <WndProperty Name="prpExtSound1" Caption="_@M2250_" X="215" Y="-999" Width="-1" Height="22" CaptionWidth="70" Font="2" Help="_@H240_">
+        
+      <WndProperty Name="prpExtSound1" Caption="_@M2250_" X="235" Y="-999" Width="-1" Height="22" CaptionWidth="70" Font="2" Help="_@H240_">
         <DataField Name="" DataType="boolean"/>
       </WndProperty>
-      <WndProperty Name="prpComSpeed1" Caption="_@M135_" X="60" Y="-1" Width="155" Height="22" CaptionWidth="70" Font="2" Help="_@H155_">
+      <WndButton Name="cmdReplay" Caption="_@M285_" X="130" Y="45" Width="105" Height="22" Font="2" Tag="3" OnClickNotify="OnConfigDevReplayClicked" />  
+      <WndProperty Name="prpComSpeed1" Caption="_@M135_" X="60" Y="45" Width="155" Height="22" CaptionWidth="70" Font="2" Help="_@H155_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1" />
       </WndProperty>
       <WndProperty Name="prpComBit1" Caption=" " X="215" Y="-999" Width="-1" Height="22" CaptionWidth="1" Font="2" Help="_@H156_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1" />
       </WndProperty>
-      <WndProperty Name="prpComIpAddr1" Caption="IP" X="60" Y="-999" Width="220" Height="22" CaptionWidth="70" Font="2" Keyboard="1">
+      <WndProperty Name="prpComIpAddr1" Caption="IP" X="60" Y="-999" Width="240" Height="22" CaptionWidth="70" Font="2" Keyboard="1">
         <DataField Name="" DataType="string" DisplayFormat="%s" EditFormat="%s"/>
       </WndProperty>
-      <WndProperty Name="prpComIpPort1" Caption="Port" X="230" Y="-999" Width="-1" Height="22" CaptionWidth="30" Font="2" Keyboard="1">
+      <WndProperty Name="prpComIpPort1" Caption="Port" X="250" Y="-999" Width="-1" Height="22" CaptionWidth="30" Font="2" Keyboard="1">
         <DataField Name="" DataType="integer" DisplayFormat="%d" EditFormat="%d" Min="1" Max="65635" Step="1"/>
       </WndProperty>
       <WndProperty Name="prpStatus" Caption="_@M660_" X="60" Y="70" Width="-1" Height="22" CaptionWidth="70" Font="2" ReadOnly="1" Keyboard="0">

--- a/Common/Data/Dialogs/dlgConfigDevice_P.xml
+++ b/Common/Data/Dialogs/dlgConfigDevice_P.xml
@@ -21,12 +21,11 @@
 
       <WndProperty Name="prpExtSound1" Caption="_@M2250_" X="60" Y="-1" Width="179" Height="18" CaptionWidth="80" Font="2" Help="_@H240_">
         <DataField Name="" DataType="boolean"/>
-      </WndProperty>
-
-      <WndProperty Name="prpComSpeed1" Caption="_@M135_" X="60" Y="-1" Width="140" Height="22" CaptionWidth="80" Font="2" Help="_@H155_">
+      </WndProperty> 
+      <WndButton Name="cmdReplay" Caption="_@M285_" X="140" Y="65" Width="98" Height="22" Font="2" Tag="3" OnClickNotify="OnConfigDevReplayClicked" />
+      <WndProperty Name="prpComSpeed1" Caption="_@M135_" X="60" Y="65" Width="140" Height="22" CaptionWidth="80" Font="2" Help="_@H155_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
-
       <WndProperty Name="prpComBit1" Caption=" " X="200" Y="-999" Width="33" Height="22" CaptionWidth="1" Font="2" Help="_@H156_">
         <DataField Name="" DataType="enum" Min="0" Max="50" Step="1"/>
       </WndProperty>
@@ -53,7 +52,7 @@
     </WndProperty>
 
     <WndButton Name="cmdClose" Caption="_@M186_" X="2" Y="258" Width="58" Height="45" Font="2" Tag="2" />
-    <WndButton Name="cmdBth" Caption="Bluetooth" X="60" Y="-999" Width="58" Height="45" Font="2" Tag="2" OnClickNotify="OnBthDevice" />
+    <WndButton Name="cmdBth" Caption="Bluetooth" X="60" Y="-999" Width="58" Height="45" Font="2" Tag="2" OnClickNotify="OnBthDevice" />    
     <WndButton Name="cmdConfigDev" Caption="_@M2414_" X="120" Y="-999" Width="58" Height="45" Font="2" Tag="2" OnClickNotify="OnConfigDevClicked" />
     <WndButton Name="cmdTerminal" Caption="_@M1871_" X="180" Y="-999" Width="58" Height="45" Font="2" Tag="2" OnClickNotify="OnTerminalClicked" />
 

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -18,6 +18,7 @@
 /*
  * General defines for LK8000
  */
+#define NMEA_REPLAY _T("NMEAReplay")
 
 #define INVALID_GR	999
 // max allowed for both signed and unsigned shorts

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -852,6 +852,8 @@ GEXTERN unsigned dwBitIndex[NUMDEV];
 GEXTERN TCHAR szIpAddress[NUMDEV][MAX_URL_LEN];
 GEXTERN unsigned dwIpPort[NUMDEV];
 GEXTERN TCHAR dwDeviceName[NUMDEV][DEVNAMESIZE+1];
+GEXTERN TCHAR Replay_FileName[NUMDEV][LKSIZEBUFFERPATH+1];
+GEXTERN int ReplaySpeed[NUMDEV];
 GEXTERN bool UseExtSound[NUMDEV];
 GEXTERN double LastFlarmCommandTime;
 GEXTERN bool  DevIsCondor;

--- a/Common/Header/LKProfiles.h
+++ b/Common/Header/LKProfiles.h
@@ -127,6 +127,20 @@ extern const char szRegistryDeviceC[];
 extern const char szRegistryDeviceD[];
 extern const char szRegistryDeviceE[];
 extern const char szRegistryDeviceF[];
+extern const char szRegistryReplayFileA[];
+extern const char szRegistryReplayFileB[];
+extern const char szRegistryReplayFileC[];
+extern const char szRegistryReplayFileD[];
+extern const char szRegistryReplayFileE[];
+extern const char szRegistryReplayFileF[];
+
+extern const char szRegistryReplaySpeedA[];
+extern const char szRegistryReplaySpeedB[];
+extern const char szRegistryReplaySpeedC[];
+extern const char szRegistryReplaySpeedD[];
+extern const char szRegistryReplaySpeedE[];
+extern const char szRegistryReplaySpeedF[];
+
 extern const char szRegistryDisableAutoLogger[];
 extern const char szRegistryLiveTrackerInterval[];
 extern const char szRegistryLiveTrackerRadar_config[];

--- a/Common/Source/Comm/FilePort.cpp
+++ b/Common/Source/Comm/FilePort.cpp
@@ -1,0 +1,110 @@
+/*
+ * LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+ * Released under GNU/GPL License v.2
+ * See CREDITS.TXT file for authors and copyrights
+ * 
+ * File:   FilePort.cpp
+ * Author: Bruno de Lacheisserie
+ * 
+ * Created on February 22, 2016, 8:29 PM
+ */
+#include "externs.h"
+#include "FilePort.h"
+#include <functional>
+using namespace std::placeholders;
+
+
+FilePort::FilePort (int idx, const tstring& sName) : ComPort(idx, sName)
+{
+// not yet needed
+}
+
+FilePort::~FilePort() {
+	// not yet needed
+}
+
+bool FilePort::Initialize() {
+TCHAR szReplayFileName [MAX_PATH];
+
+  LocalPath(szReplayFileName,TEXT(LKD_LOGS),Replay_FileName[GetPortIndex()]);
+	FileStream = _tfopen(szReplayFileName, TEXT("rt"));
+
+	if((!FileStream) || (!ComPort::Initialize()))
+	{
+		 StartupStore(_T(". FilePort  %u failed to open file %s Port <%s> %s"), (unsigned)GetPortIndex() + 1, Replay_FileName[GetPortIndex()], GetPortName(), NEWLINE);
+		 StatusMessage(mbOk, NULL, TEXT("%s %s"), MsgToken(762), GetPortName());
+		 return false;
+	}
+
+	StartupStore(_T(". FilePort  %u open file %s Port <%s> OK%s"), (unsigned)GetPortIndex() + 1, Replay_FileName[GetPortIndex()], GetPortName(), NEWLINE);
+	return true;
+}
+
+
+int FilePort::SetRxTimeout(int TimeOut) {
+// not yet needed
+return 0;
+}
+
+size_t FilePort::Read(void *pString, size_t size) {
+char* szString = (char*)pString;
+
+	if(!FileStream) {
+			return false;
+	}
+
+	if (fgets((char*) szString, size, FileStream)==NULL) {
+		szString[0] = '\0';
+		return false;
+	}
+	return strlen(szString);;
+}
+
+
+bool FilePort::Close() {
+	ComPort::Close();
+	fclose(FileStream);
+	FileStream = NULL;
+	StartupStore(_T(". FilePort %u %s closed Ok.%s"), (unsigned)GetPortIndex(),GetPortName(), NEWLINE);
+	return true;
+}
+
+bool FilePort::Write(const void *data, size_t length) {
+  return true;
+}
+
+
+
+unsigned FilePort::RxThread()
+{
+unsigned long	dwWaitTime = 5;
+unsigned LineCnt =0;
+char szString[MAX_NMEA_LEN];
+size_t nRecv;
+
+
+	while (!StopEvt.tryWait(dwWaitTime) && FileStream )
+	{
+		nRecv =  Read(szString, MAX_NMEA_LEN-1);
+		UpdateStatus();
+
+		if((strncmp (szString,"$GPRMC", 6) ==0) || (LineCnt++ >= 25)) // wait until next GPS fix or at least every 25 sentences
+		{
+			LineCnt =0;
+			if(ReplaySpeed[GetPortIndex()] >0)
+				dwWaitTime = 1000/ReplaySpeed[GetPortIndex()]; // x1 = 1Hz
+			else
+				dwWaitTime = 10000;  //  ( 0 = 0.1Hz GPS  )
+		}	else {
+			dwWaitTime = 20;
+		}
+
+		if(dwWaitTime < 20)
+			dwWaitTime = 20; // avoid cpu overhead;
+
+		if (nRecv > 0) {
+				std::for_each(std::begin(szString), std::begin(szString) + nRecv, std::bind(&FilePort::ProcessChar, this, _1));
+		}
+	}
+	return 0UL;
+}

--- a/Common/Source/Comm/FilePort.h
+++ b/Common/Source/Comm/FilePort.h
@@ -47,16 +47,18 @@ public:
     unsigned long SetBaudrate(unsigned long) override { return 0U; }
     unsigned long GetBaudrate() const override {  return 0U; }
 
-    void UpdateStatus() override {};
+    void UpdateStatus() override {return;};
 
     bool Write(const void *data, size_t length) override;
-    size_t Read(void *szString, size_t size) override;
+    size_t Read(void *szString, size_t size) override {  return 0; };
+    int ReadLine(void *pString, size_t size);
 
+    Poco::Event FileStopEvt;
 protected:
 
     unsigned RxThread() override;
 
-
+    unsigned long m_dwWaitTime;
     FILE *FileStream;
 
 private:

--- a/Common/Source/Comm/FilePort.h
+++ b/Common/Source/Comm/FilePort.h
@@ -1,0 +1,67 @@
+/*
+ * LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+ * Released under GNU/GPL License v.2
+ * See CREDITS.TXT file for authors and copyrights
+ * 
+ * File:   FilePort.h
+ * Author: Bruno de Lacheisserie
+ *
+ * Created on February 22, 2016, 8:29 PM
+ */
+
+#ifndef FilePort_H
+#define FilePort_H
+
+#include "ComPort.h"
+
+
+#ifdef WIN32
+#ifdef PPC2002
+
+#endif
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+
+#endif
+
+
+
+class FilePort :  public ComPort {
+public:
+
+    FilePort(int idx, const tstring& sName);
+
+    ~FilePort();
+    
+    bool Initialize() override;
+    bool Close() override;
+
+    void Flush() override {};
+    void Purge() override {};
+    void CancelWaitEvent() override {};
+
+    int SetRxTimeout(int TimeOut) override;
+    unsigned long SetBaudrate(unsigned long) override { return 0U; }
+    unsigned long GetBaudrate() const override {  return 0U; }
+
+    void UpdateStatus() override {};
+
+    bool Write(const void *data, size_t length) override;
+    size_t Read(void *szString, size_t size) override;
+
+protected:
+
+    unsigned RxThread() override;
+
+
+    FILE *FileStream;
+
+private:
+
+};
+
+#endif /* FilePort_H */
+

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -12,6 +12,7 @@
 #include "Util/TruncateString.hpp"
 #include "BtHandler.h"
 #include "SerialPort.h"
+#include "FilePort.h"
 #include "Bluetooth/BthPort.h"
 #include "GpsIdPort.h"
 #include "TCPPort.h"
@@ -372,7 +373,7 @@ void RefreshComPortList() {
     COMMPort.push_back(_T("TCPClient"));
     COMMPort.push_back(_T("TCPServer"));
     COMMPort.push_back(_T("UDPServer"));
-
+    COMMPort.push_back(NMEA_REPLAY);
 #ifdef ANDROID
 
   JNIEnv *env = Java::GetEnv();
@@ -626,7 +627,8 @@ BOOL devInit() {
 
         DeviceList[i].iSharedPort =-1;
         for(uint j = 0; j < i ; j++) {
-            if((!DeviceList[j].Disabled) && (IsIdenticalPort(i,j)) &&  DeviceList[j].iSharedPort <0) {
+            if( (_tcsncmp(Port,NMEA_REPLAY, _tcslen(NMEA_REPLAY)) != 0)
+            		&& (!DeviceList[j].Disabled) && (IsIdenticalPort(i,j)) &&  DeviceList[j].iSharedPort <0) {
                 devInit(&DeviceList[i]);
                 DeviceList[i].iSharedPort =j;
                 StartupStore(_T(". Port <%s> Already used, Device %c shares it with %c ! %s"), Port, (_T('A') + i),(_T('A') + j), NEWLINE);
@@ -705,6 +707,8 @@ BOOL devInit() {
 #ifdef ANDROID
             Com = new UsbSerialPort(i, &Port[4], dwSpeed[SpeedIndex], BitIndex);
 #endif
+        } else  if (_tcsncmp(Port,NMEA_REPLAY, _tcslen(NMEA_REPLAY)) == 0) {
+        	Com = new FilePort(i, NMEA_REPLAY);
         } else {
             Com = new SerialPort(i, Port, dwSpeed[SpeedIndex], BitIndex, PollingMode);
         }

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -1301,8 +1301,9 @@ void UpdateComPortSetting(WndForm* pOwner,  size_t idx, const TCHAR* szPortName)
     bool bBt = ((_tcslen(szPortName) > 3) && ((_tcsncmp(szPortName, _T("BT:"), 3) == 0) || (_tcsncmp(szPortName, _T("Bluetooth Server"), 3) == 0)));
     bool bTCPClient = (_tcscmp(szPortName, _T("TCPClient")) == 0);
     bool bTCPServer = (_tcscmp(szPortName, _T("TCPServer")) == 0);
+    bool bFileReplay = (_tcscmp(szPortName, NMEA_REPLAY)    == 0);
     bool bUDPServer = (_tcscmp(szPortName, _T("UDPServer")) == 0);
-    bool bCOM = !(bBt || bTCPClient || bTCPServer || bUDPServer || ( DeviceList[SelectedDevice].iSharedPort>=0 ));
+    bool bCOM = !(bBt || bTCPClient || bTCPServer || bUDPServer || bFileReplay || ( DeviceList[SelectedDevice].iSharedPort>=0 ));
     if(bCOM)
     {
       ShowWindowControl(wf, TEXT("prpComPort1"), true);
@@ -1321,10 +1322,14 @@ void UpdateComPortSetting(WndForm* pOwner,  size_t idx, const TCHAR* szPortName)
       ShowWindowControl(wf, TEXT("prpComIpPort1"),  bTCPClient || bTCPServer || bUDPServer);
     }
 
+    ShowWindowControl(wf, TEXT("cmdReplay"), bFileReplay);
+
     // Manage external sounds only if necessary
     if (bManageExtAudio) {
         ShowWindowControl(wf,  TEXT("prpExtSound1"), !bHide);
     }
+
+
     }
     TCHAR StateText[255];
     _tcscpy(StateText,_T(""));
@@ -1351,10 +1356,16 @@ void UpdateComPortSetting(WndForm* pOwner,  size_t idx, const TCHAR* szPortName)
 
 
   static void OnConfigDevClicked(WndButton* pWnd){
-//   if(DeviceList[SelectedDevice])
      if(DeviceList[SelectedDevice].Config)
        DeviceList[SelectedDevice].Config(&DeviceList[SelectedDevice]);
 }
+
+
+extern void dlgNMEAReplayShowModal(void);
+static void OnConfigDevReplayClicked(WndButton* pWnd){
+	dlgNMEAReplayShowModal();
+}
+
 
 
 
@@ -1423,6 +1434,7 @@ static CallBackTableEntry_t CallBackTable[]={
   ClickNotifyCallbackEntry(OnE),
   ClickNotifyCallbackEntry(OnF),
   ClickNotifyCallbackEntry(OnConfigDevClicked),
+  ClickNotifyCallbackEntry(OnConfigDevReplayClicked),
   ClickNotifyCallbackEntry(OnNextDevice),
   ClickNotifyCallbackEntry(OnTerminalClicked),
   EndCallBackEntry()

--- a/Common/Source/Dialogs/dlgNMEAReplay.cpp
+++ b/Common/Source/Dialogs/dlgNMEAReplay.cpp
@@ -1,0 +1,111 @@
+/*
+   LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+   Released under GNU/GPL License v.2
+   See CREDITS.TXT file for authors and copyrights
+
+   $Id: dlgLoggerReplay.cpp,v 1.1 2011/12/21 10:29:29 root Exp root $
+*/
+
+#include "externs.h"
+#include "Dialogs.h"
+#include "WindowControls.h"
+#include "dlgTools.h"
+#include "resource.h"
+
+static WndForm *wf=NULL;
+
+static void OnStopClicked(WndButton* pWnd) {
+  RestartCommPorts();
+}
+
+static void OnStartClicked(WndButton* pWnd) {
+  WndProperty* wp;
+  wp = (WndProperty*)wf->FindByName(TEXT("prpIGCFile"));
+  if (wp) {
+    DataFieldFileReader* dfe;
+    dfe = (DataFieldFileReader*)wp->GetDataField();
+
+    _tcscpy(Replay_FileName[SelectedDevice],dfe->GetPathFile());
+
+  }
+  RestartCommPorts();
+}
+
+static void OnCloseClicked(WndButton* pWnd) {
+
+  if(pWnd) {
+    WndProperty* wp;
+    wp = (WndProperty*)wf->FindByName(TEXT("prpIGCFile"));
+    if (wp) {
+      DataFieldFileReader* dfe;
+      dfe = (DataFieldFileReader*)wp->GetDataField();
+
+      _tcscpy(Replay_FileName[SelectedDevice],dfe->GetPathFile());
+
+    }
+    WndForm * pForm = pWnd->GetParentWndForm();
+    if(pForm) {
+      pForm->SetModalResult(mrOK);
+    }
+  }
+}
+
+
+static void OnRateData(DataField *Sender, DataField::DataAccessKind_t Mode){
+
+  switch(Mode){
+    case DataField::daGet:
+      Sender->Set(ReplaySpeed[SelectedDevice]);
+    break;
+    case DataField::daPut:
+    case DataField::daChange:
+    	ReplaySpeed[SelectedDevice] = (int) Sender->GetAsFloat();
+    break;
+  case DataField::daInc:
+  case DataField::daDec:
+  case DataField::daSpecial:
+    break;
+  }
+
+}
+
+
+static CallBackTableEntry_t CallBackTable[]={
+  ClickNotifyCallbackEntry(OnStopClicked),
+  ClickNotifyCallbackEntry(OnStartClicked),
+  DataAccessCallbackEntry(OnRateData),
+  ClickNotifyCallbackEntry(OnCloseClicked),
+  EndCallBackEntry()
+};
+
+
+void dlgNMEAReplayShowModal(){
+
+  wf = dlgLoadFromXML(CallBackTable, IDR_XML_LOGGERREPLAY);
+
+  WndProperty* wp;
+
+  if (wf) {
+
+    wp = (WndProperty*)wf->FindByName(TEXT("prpRate"));
+    if (wp) {
+      wp->GetDataField()->SetAsFloat(ReplaySpeed[SelectedDevice]);
+      wp->RefreshDisplay();
+    }
+
+    wp = (WndProperty*)wf->FindByName(TEXT("prpIGCFile"));
+    if (wp) {
+      DataFieldFileReader* dfe = static_cast<DataFieldFileReader*>(wp->GetDataField());
+      if(dfe) {
+        dfe->ScanDirectoryTop(_T(LKD_LOGS), _T("*" LKS_TXT));
+        dfe->Lookup(Replay_FileName[SelectedDevice]);
+      }
+      wp->RefreshDisplay();
+    }
+
+    wf->ShowModal();
+
+    delete wf;
+  }
+  wf = NULL;
+}

--- a/Common/Source/Dialogs/dlgNMEAReplay.cpp
+++ b/Common/Source/Dialogs/dlgNMEAReplay.cpp
@@ -15,7 +15,17 @@
 static WndForm *wf=NULL;
 
 static void OnStopClicked(WndButton* pWnd) {
-  RestartCommPorts();
+    ReplaySpeed[SelectedDevice] = 0;
+	if(wf)
+	{
+		WndProperty* wp = (WndProperty*)wf->FindByName(TEXT("prpRate"));
+		if(wp)
+		{
+	    wp->GetDataField()->Set(ReplaySpeed[SelectedDevice]);
+	    wp->RefreshDisplay();
+		}
+	}
+
 }
 
 static void OnStartClicked(WndButton* pWnd) {
@@ -24,9 +34,21 @@ static void OnStartClicked(WndButton* pWnd) {
   if (wp) {
     DataFieldFileReader* dfe;
     dfe = (DataFieldFileReader*)wp->GetDataField();
-
     _tcscpy(Replay_FileName[SelectedDevice],dfe->GetPathFile());
 
+  }
+  if( ReplaySpeed[SelectedDevice] ==0)
+  {
+    ReplaySpeed[SelectedDevice] = 1;
+    if(wf)
+    {
+      WndProperty* wp = (WndProperty*)wf->FindByName(TEXT("prpRate"));
+      if(wp)
+      {
+        wp->GetDataField()->Set(ReplaySpeed[SelectedDevice]);
+        wp->RefreshDisplay();
+      }
+    }
   }
   RestartCommPorts();
 }
@@ -41,6 +63,14 @@ static void OnCloseClicked(WndButton* pWnd) {
       dfe = (DataFieldFileReader*)wp->GetDataField();
 
       _tcscpy(Replay_FileName[SelectedDevice],dfe->GetPathFile());
+
+    }
+    wp = (WndProperty*)wf->FindByName(TEXT("prpRate"));
+    if (wp) {
+      DataFieldFileReader* dfe;
+      dfe = (DataFieldFileReader*)wp->GetDataField();
+
+      ReplaySpeed[SelectedDevice] = dfe->GetAsFloat();
 
     }
     WndForm * pForm = pWnd->GetParentWndForm();

--- a/Common/Source/Globals.cpp
+++ b/Common/Source/Globals.cpp
@@ -603,6 +603,8 @@ void Globals_Init(void) {
     dwDeviceName[i][0]=_T('\0');
     szPort      [i][0]=_T('\0');
     szIpAddress [i][0]=_T('\0');
+    Replay_FileName [i][0]=_T('\0');
+    ReplaySpeed[i]   = 1;
     dwSpeedIndex[i]   = 2;
     dwBitIndex  [i]   = (BitIndex_t)bit8N1;
     dwIpPort    [i]   = 23;

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -389,6 +389,21 @@ void LKParseProfileString(const char *sname, const char *svalue) {
   PREAD(sname,svalue,szRegistryDeviceD,&dwDeviceName[3][0], array_size(dwDeviceName[3]));
   PREAD(sname,svalue,szRegistryDeviceE,&dwDeviceName[4][0], array_size(dwDeviceName[4]));
   PREAD(sname,svalue,szRegistryDeviceF,&dwDeviceName[5][0], array_size(dwDeviceName[5]));
+
+  PREAD(sname,svalue,szRegistryReplayFileA, &Replay_FileName[0][0], array_size(Replay_FileName[0]));
+  PREAD(sname,svalue,szRegistryReplayFileB, &Replay_FileName[1][0], array_size(Replay_FileName[1]));
+  PREAD(sname,svalue,szRegistryReplayFileC, &Replay_FileName[2][0], array_size(Replay_FileName[2]));
+  PREAD(sname,svalue,szRegistryReplayFileD, &Replay_FileName[3][0], array_size(Replay_FileName[3]));
+  PREAD(sname,svalue,szRegistryReplayFileE, &Replay_FileName[4][0], array_size(Replay_FileName[4]));
+  PREAD(sname,svalue,szRegistryReplayFileF, &Replay_FileName[5][0], array_size(Replay_FileName[5]));
+
+  PREAD(sname,svalue,szRegistryReplaySpeedA, &ReplaySpeed[0]);
+  PREAD(sname,svalue,szRegistryReplaySpeedB, &ReplaySpeed[1]);
+  PREAD(sname,svalue,szRegistryReplaySpeedC, &ReplaySpeed[2]);
+  PREAD(sname,svalue,szRegistryReplaySpeedD, &ReplaySpeed[3]);
+  PREAD(sname,svalue,szRegistryReplaySpeedE, &ReplaySpeed[4]);
+  PREAD(sname,svalue,szRegistryReplaySpeedF, &ReplaySpeed[5]);
+
   PREAD(sname,svalue,szRegistryDisableAutoLogger,&DisableAutoLogger);
   PREAD(sname,svalue,szRegistryLiveTrackerInterval,&LiveTrackerInterval);
   PREAD(sname,svalue,szRegistryLiveTrackerRadar_config,&LiveTrackerRadar_config);

--- a/Common/Source/LKProfileResetDefault.cpp
+++ b/Common/Source/LKProfileResetDefault.cpp
@@ -413,6 +413,8 @@ void LKProfileResetDefault() {
     dwDeviceName[i][0]=_T('\0');
     szPort      [i][0]=_T('\0');
     szIpAddress [i][0]=_T('\0');
+    Replay_FileName[i][0]=_T('\0');
+    ReplaySpeed [i]   = 1;
     dwSpeedIndex[i]   = 2;
     dwBitIndex  [i]   = (BitIndex_t)bit8N1;
     dwIpPort    [i]   = 23;

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -617,6 +617,7 @@ void LKDeviceSave(const TCHAR *szFile)
   rprintf(szRegistryIpPort5,dwIpPort[4]);
   rprintf(szRegistryIpPort6,dwIpPort[5]);
 
+
 #define IO_PARAM_SIZE 160
 
   for(int n = 0; n < NUMDEV; n++)
@@ -643,6 +644,22 @@ void LKDeviceSave(const TCHAR *szFile)
   rprintf(szRegistryUseExtSound4,UseExtSound[3]);
   rprintf(szRegistryUseExtSound5,UseExtSound[4]);
   rprintf(szRegistryUseExtSound6,UseExtSound[5]);
+
+	rprintf(szRegistryReplayFileA ,Replay_FileName[0]);
+	rprintf(szRegistryReplayFileB ,Replay_FileName[1]);
+	rprintf(szRegistryReplayFileC ,Replay_FileName[2]);
+	rprintf(szRegistryReplayFileD ,Replay_FileName[3]);
+	rprintf(szRegistryReplayFileE ,Replay_FileName[4]);
+	rprintf(szRegistryReplayFileF ,Replay_FileName[5]);
+
+  rprintf(szRegistryReplaySpeedA,ReplaySpeed[0]);
+  rprintf(szRegistryReplaySpeedB,ReplaySpeed[1]);
+  rprintf(szRegistryReplaySpeedC,ReplaySpeed[2]);
+  rprintf(szRegistryReplaySpeedD,ReplaySpeed[3]);
+  rprintf(szRegistryReplaySpeedE,ReplaySpeed[4]);
+  rprintf(szRegistryReplaySpeedF,ReplaySpeed[5]);
+
+
 
   rprintf(szRegistryUseGeoidSeparation,UseGeoidSeparation);
   rprintf(szRegistryPollingMode,PollingMode);

--- a/Common/Source/LKProfiles.cpp
+++ b/Common/Source/LKProfiles.cpp
@@ -219,6 +219,20 @@ const char szRegistryDeviceC[] = "DeviceC";
 const char szRegistryDeviceD[] = "DeviceD";
 const char szRegistryDeviceE[] = "DeviceE";
 const char szRegistryDeviceF[] = "DeviceF";
+const char szRegistryReplayFileA[] = "ReplayFileA";
+const char szRegistryReplayFileB[] = "ReplayFileB";
+const char szRegistryReplayFileC[] = "ReplayFileC";
+const char szRegistryReplayFileD[] = "ReplayFileD";
+const char szRegistryReplayFileE[] = "ReplayFileE";
+const char szRegistryReplayFileF[] = "ReplayFileF";
+
+extern const char szRegistryReplaySpeedA[]= "ReplaSpeedA";
+extern const char szRegistryReplaySpeedB[]= "ReplaSpeedB";
+extern const char szRegistryReplaySpeedC[]= "ReplaSpeedC";
+extern const char szRegistryReplaySpeedD[]= "ReplaSpeedD";
+extern const char szRegistryReplaySpeedE[]= "ReplaSpeedE";
+extern const char szRegistryReplaySpeedF[]= "ReplaSpeedF";
+
 const char szRegistryDisableAutoLogger[] = "DisableAutoLogger";
 const char szRegistryLiveTrackerInterval[] = "LiveTrackerInterval";
 const char szRegistryLiveTrackerRadar_config[] = "LiveTrackerRadar_config";

--- a/Makefile
+++ b/Makefile
@@ -1160,6 +1160,7 @@ COMMS	:=\
 	$(CMM)/Bluetooth/BtHandlerWince.cpp \
 	$(CMM)/Bluetooth/BthPort.cpp \
 	$(CMM)/Obex/CObexPush.cpp \
+	$(CMM)/FilePort.cpp\
 
 
 DEVS	:=\
@@ -1297,6 +1298,7 @@ DLGS	:=\
 	$(DLG)/dlgIGCProgress.cpp \
 	$(DLG)/dlgFlarmIGCDownload.cpp \
 	$(DLG)/dlgLXIGCDownload.cpp \
+	$(DLG)/dlgNMEAReplay.cpp \
 	
 	
 SRC_FILES :=\


### PR DESCRIPTION
NMEA replay setup in device dialog
exclude NMEA replay from shared ports.
Activate Start/Stop Buttons in File dlg (= COM Port restart)
add new Port type FilePort for NMEA File input for each device seperatly
Allow parallel NMEA reaply