### PR TITLE
Prevent drawing airspace on map

### DIFF
--- a/Common/Source/Draw/DrawAirSpacesBorders.cpp
+++ b/Common/Source/Draw/DrawAirSpacesBorders.cpp
@@ -22,18 +22,21 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
        * draw underlying aispaces first (reverse order) with bigger pen
        * *********************************************************************/
       for (CAirspaceList::const_reverse_iterator it=airspaces_to_draw.rbegin(); it != airspaces_to_draw.rend(); ++it) {
-        if ((*it)->DrawStyle()) {
+        if((*it)->Top()->Altitude> 0)
+        {
+          if ((*it)->DrawStyle()) {
 
-          if ( asp_selected_flash && (*it)->Selected() ) {
-            Surface.SelectObject(LK_BLACK_PEN);
-          } else {
-            Surface.SelectObject(hBigAirspacePens[(*it)->Type()]);
-          }
-          if((*it)->DrawStyle()==adsDisabled) {
-            Surface.SelectObject(LKPen_Grey_N2 );
-          }
+            if ( asp_selected_flash && (*it)->Selected() ) {
+              Surface.SelectObject(LK_BLACK_PEN);
+            } else {
+              Surface.SelectObject(hBigAirspacePens[(*it)->Type()]);
+            }
+            if((*it)->DrawStyle()==adsDisabled) {
+              Surface.SelectObject(LKPen_Grey_N2 );
+            }
 
-          (*it)->Draw(Surface, false);
+            (*it)->Draw(Surface, false);
+          }
         }
       } // for
 
@@ -42,7 +45,7 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
        ***********************************************************************/
 
       for (CAirspaceList::const_iterator it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
-        if ((*it)->DrawStyle()) {
+        if ((*it)->DrawStyle() && ((*it)->Top()->Altitude> 0)) {
           if ( asp_selected_flash && (*it)->Selected() ) {
             Surface.SelectObject(LK_BLACK_PEN);
           } else {

--- a/Common/Source/Draw/MapWindowA.cpp
+++ b/Common/Source/Draw/MapWindowA.cpp
@@ -213,7 +213,8 @@ void MapWindow::DrawTptAirSpace(LKSurface& Surface, const RECT& rc) {
 
     for (auto it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
 
-        if ((*it)->DrawStyle() == adsHidden) {
+        if (((*it)->DrawStyle() == adsHidden) ||
+             ((*it)->Top()->Altitude <= 0)){
           continue;
         }
 


### PR DESCRIPTION
in case it is defined on MSL (=on/under ground) without any vertical expansion.
For example (in open air format):
AH 0

This can be useful to have regional radio frequencies present.

https://www.postfrontal.com/forum/topic.asp?whichpage=1&TOPIC_ID=9124&#72205