### PR TITLE
Fix airspace map draw (critical)

### DIFF
--- a/Common/Source/Draw/DrawAirSpacesBorders.cpp
+++ b/Common/Source/Draw/DrawAirSpacesBorders.cpp
@@ -22,8 +22,8 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
        * draw underlying aispaces first (reverse order) with bigger pen
        * *********************************************************************/
       for (CAirspaceList::const_reverse_iterator it=airspaces_to_draw.rbegin(); it != airspaces_to_draw.rend(); ++it) {
-        if((*it)->Top()->Altitude> 0)
-        {
+        if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) 
+        {  // don't draw on map if upper limit is on sea level or below
           if ((*it)->DrawStyle()) {
 
             if ( asp_selected_flash && (*it)->Selected() ) {
@@ -45,14 +45,17 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
        ***********************************************************************/
 
       for (CAirspaceList::const_iterator it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
-        if ((*it)->DrawStyle() && ((*it)->Top()->Altitude> 0)) {
-          if ( asp_selected_flash && (*it)->Selected() ) {
-            Surface.SelectObject(LK_BLACK_PEN);
-          } else {
-            Surface.SelectObject(hAirspacePens[(*it)->Type()]);
+        if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) 
+        {  // don't draw on map if upper limit is on sea level or below
+          if ((*it)->DrawStyle() ) {
+            if ( asp_selected_flash && (*it)->Selected() ) {
+              Surface.SelectObject(LK_BLACK_PEN);
+            } else {
+              Surface.SelectObject(hAirspacePens[(*it)->Type()]);
+            }
+            if((*it)->DrawStyle() != adsDisabled)
+              (*it)->Draw(Surface, false);
           }
-          if((*it)->DrawStyle() != adsDisabled)
-            (*it)->Draw(Surface, false);
         }
       }//for
 

--- a/Common/Source/Draw/MapWindowA.cpp
+++ b/Common/Source/Draw/MapWindowA.cpp
@@ -214,8 +214,8 @@ void MapWindow::DrawTptAirSpace(LKSurface& Surface, const RECT& rc) {
     for (auto it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
 
         if (((*it)->DrawStyle() == adsHidden) ||
-             ((*it)->Top()->Altitude <= 0)){
-          continue;
+          ((  (*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))){
+          continue;  // don't draw on map if hidden or upper limit is on sea level or below
         }
 
         const int airspace_type = (*it)->Type();


### PR DESCRIPTION
hide airspace if upper limit is really referenced to MSL
not only Altitude <=0, Altitude can also be <=0 if referenced to AGL or FL