### PR TITLE
Color e-ink support

### DIFF
--- a/Common/Header/Asset.hpp
+++ b/Common/Header/Asset.hpp
@@ -23,10 +23,19 @@ static inline
 bool IsDithered() {
 #ifdef DITHER
     return true;
-#elif defined(ANDROID) && defined(__arm__)
+#elif defined(ANDROID) && (defined(__arm__) || defined(__aarch64__))
     return is_dithered;
 #else
     return false;
+#endif
+}
+
+static inline
+bool IsEinkColored() {
+#if defined(ANDROID) && (defined(__arm__)||defined(__aarch64__))
+        return is_eink_colored;
+#else
+        return false;
 #endif
 }
 

--- a/Common/Header/Defines.h
+++ b/Common/Header/Defines.h
@@ -273,7 +273,7 @@
 #define LKMAXBACKGROUNDS        10
 
 // Number of color ramp available for draw terrain
-#define NUMRAMPS        16
+#define NUMRAMPS        18
 
 // Task format version
 #define LKTASKVERSION	'3'

--- a/Common/Source/Android/Main.cpp
+++ b/Common/Source/Android/Main.cpp
@@ -107,11 +107,13 @@ Java_org_LK8000_NativeView_initializeNative(JNIEnv *env, jobject obj,
   event_queue = new EventQueue();
 
 
-#ifdef __arm__
+#if defined __arm__ || defined __aarch64__
   // Android eInk devices support
   is_dithered = is_dithered || StringIsEqual(native_view->GetProduct(), "Poke_Pro");
   is_dithered = is_dithered || StringIsEqual(native_view->GetProduct(), "C68");
   is_dithered = is_dithered || StringIsEqual(native_view->GetProduct(), "yotaphone2");
+  is_dithered = is_dithered || StringIsEqual(native_view->GetProduct(), "HLTE203T");
+  is_eink_colored = is_eink_colored || StringIsEqual(native_view->GetProduct(), "HLTE203T");
 #endif
 
 

--- a/Common/Source/Dialogs/dlgConfiguration.cpp
+++ b/Common/Source/Dialogs/dlgConfiguration.cpp
@@ -3148,6 +3148,8 @@ DataField* dfe = wp->GetDataField();
     dfe->addEnumText(TEXT("GA Relative"));
     dfe->addEnumText(TEXT("LiteAlps"));
     dfe->addEnumText(TEXT("Low Hills"));
+    dfe->addEnumText(TEXT("Low Alps color e-ink"));
+    dfe->addEnumText(TEXT("Low Alps gray e-ink"));
     dfe->Set(TerrainRamp_Config);
     wp->RefreshDisplay();
   }

--- a/Common/Source/LKSnailTrail.cpp
+++ b/Common/Source/LKSnailTrail.cpp
@@ -93,7 +93,7 @@ void SnailTrail_Create(void) {
   iSnailSizes[15]= tmpsize;
 
 
-  if (!IsDithered()) {
+  if (!IsDithered()||IsEinkColored()) {
 
     // COLORED SNAIL TRAIL
     //

--- a/Common/Source/MapDraw/ColorRamps.h
+++ b/Common/Source/MapDraw/ColorRamps.h
@@ -43,7 +43,9 @@ const COLORRAMP terrain_shadow[] = {
     {63, {60, 60, 60}},
     {63, {60, 60, 60}},
     {63, {60, 10, 10}}, // LiteAlps
-    {63, {60, 10, 10}}  // Low Hills
+    {63, {60, 10, 10}}, // Low Hills
+    {63, {16, 32, 32}}, // Low Alps color e-ink
+    {63, {16, 32, 32}}  // Low Alps gray e-ink
 };
 
 static_assert(array_size(terrain_shadow) == NUMRAMPS, "invalid terrain_shadow");
@@ -64,7 +66,10 @@ const COLORRAMP terrain_highlight[] = {
     {63, {250, 250, 250}},
     {255, {0, 0, 0}},
     {255, {0, 0, 0}},
-    {255, {0, 0, 0}}};
+    {255, {0, 0, 0}},
+    {255, {0, 0, 0}}, // Low Alps color e-ink
+    {255, {0, 0, 0}}  // Low Alps gray e-ink
+    };
 
 static_assert(array_size(terrain_highlight) == NUMRAMPS, "invalid terrain_highlight");
 
@@ -85,7 +90,9 @@ const bool terrain_doshading[] = {
     1, // YouSee HiContrast
     0, // Obstacles
     1, // LiteAlps
-    1  // Low Hills
+    1,  // Low Hills
+    1, // Low Alps color e-ink
+    1  // Low Alps gray e-ink
 };
 
 static_assert(array_size(terrain_doshading) == NUMRAMPS, "invalid terrain_doshading");
@@ -107,7 +114,9 @@ const bool terrain_minalt[NUMRAMPS] = {
     1, // YouSee HiContrast
     1, // Obstacles
     1, // Lite Alps
-    1  // Low Hills
+    1, // Low Hills
+    1, // Low Alps color e-ink
+    1  // Low Alps gray e-ink
 };
 
 static_assert(array_size(terrain_minalt) == NUMRAMPS, "invalid terrain_minalt");
@@ -437,6 +446,38 @@ const COLORRAMP terrain_colors[][NUM_COLOR_RAMP_LEVELS] = {
         {750, {0xde, 0xc8, 0xbd}},  // very light brown
         {1000, {0xe3, 0xe4, 0xe9}}, // light ice
         {1000, {0xe3, 0xe4, 0xe9}}, // light ice
+    },
+    {
+// Low Alps color e-ink
+        {0, {0xff, 0xff, 0xff}},
+        {250, {0xff, 0xff, 0xff}},
+        {500, {0x70, 0xc0, 0xa7}},
+        {750, {0xca, 0xe7, 0xb9}},
+        {1000, {0xf4, 0xea, 0xaf}},
+        {1250, {0xdc, 0xb2, 0x82}},
+        {1500, {0xca, 0x8e, 0x72}},
+        {1750, {180, 180, 180}},
+        {2000, {140, 140, 140}},
+        {2250, {130, 130, 130}},
+        {2500, {200, 200, 200}},
+        {3000, {220, 220, 220}},
+        {4000, {240, 240, 240}},
+    },
+    {
+// Low Alps gray e-ink
+        {0, {0xff, 0xff, 0xff}},
+        {250, {0xff, 0xff, 0xff}},
+        {500, {0xf4, 0xea, 0xaf}},
+        {750, {0xdc, 0xb2, 0x82}},
+        {1000, {0xca, 0x8e, 0x72}},
+        {1250, {180, 180, 180}},
+        {1500, {160, 160, 160}},
+        {1750, {150, 150, 150}},
+        {2000, {140, 140, 140}},
+        {2250, {130, 130, 130}},
+        {2500, {200, 200, 200}},
+        {3000, {220, 220, 220}},
+        {4000, {240, 240, 240}},
     },
 };
 

--- a/Common/Source/xcs/Android/Product.cpp
+++ b/Common/Source/xcs/Android/Product.cpp
@@ -30,10 +30,11 @@ Copyright_License {
 
 bool has_cursor_keys;
 
-#ifdef __arm__
+#if defined __arm__ || defined __aarch64__
 
 bool is_nook = false; 
 bool is_dithered = false;
+bool is_eink_colored = false;
 
 bool
 IsGalaxyTab22()

--- a/Common/Source/xcs/Android/Product.hpp
+++ b/Common/Source/xcs/Android/Product.hpp
@@ -28,14 +28,14 @@ Copyright_License {
 
 extern bool has_cursor_keys;
 
-#ifdef __arm__
-extern bool is_nook, is_dithered;
+#if defined __arm__ || defined __aarch64__
+extern bool is_nook, is_dithered, is_eink_colored;
 #endif
 
 /**
  * Returns whether the application is running on Galaxy Tab with Android 2.2
  */
-#ifdef __arm__
+#if defined __arm__ || defined __aarch64__
 gcc_const
 bool
 IsGalaxyTab22();

--- a/Common/Source/xcs/Product.hpp
+++ b/Common/Source/xcs/Product.hpp
@@ -28,8 +28,8 @@ Copyright_License {
 
 extern bool has_cursor_keys;
 
-#ifdef __arm__
-extern bool is_nook, is_dithered;
+#if defined __arm__ || defined __aarch64__
+extern bool is_nook, is_dithered, is_eink_colored;
 #endif
 
 /**


### PR DESCRIPTION
Color e-ink support.
It recognizes the HiSense A5 Pro CC as "dithered" screen, to use the higher contrast menu and bottom bar, but it keeps the snail trail colored.
Two new terrain colors dedicated to e-ink screens are defined: "Low Alps color e-ink" (optimized using an HiSense A5 Pro CC) and "Low Alps gray e-ink"  (checked with a Yotaphone 2). The latter is the same as "Low Alps" for targets where DITHER is defined, but made available to Android devices.