### PR TITLE
EOS/ERA/10k fixes & IGC File download

### DIFF
--- a/Common/Data/Dialogs/dlgDevLXNav_L.xml
+++ b/Common/Data/Dialogs/dlgDevLXNav_L.xml
@@ -2,9 +2,12 @@
 <PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
   <WndForm Type="Dialog" X="0" Y="0" Width="320" Height="240" Caption="LXNav Config" Popup="1" Font="2" >   
     <WndButton Name="cmdClose"       Caption="_@M186_"     X="2" Y="1"  Width="110"  Height="28" Font="2" Tag="3" />
-    <WndButton Name="cmdIGCDownload" Caption="_@M2398_"    X="120" Y="1" Width="110"  Height="28" Font="2" Tag="3" />                          
-    <WndButton Name="cmdValues" Caption="_@M2467_"    X="120" Y="-1" Width="110"  Height="28" Font="2" Tag="3"  />
-  
+    <WndButton Name="cmdIGCDownload" Caption="_@M2398_"    X="130" Y="1" Width="110"  Height="28" Font="2" Tag="3" />                          
+    <WndButton Name="cmdValues" Caption="_@M2467_"    X="130" Y="-1" Width="110"  Height="28" Font="2" Tag="3"  />
+    
+      <WndProperty Name="prpQNHDir" Caption="QNH" X="2" Y="35" Width="120" Height="21" CaptionWidth="50" Font="2" Help="_@H1345_">
+        <DataField Name="" DataType="enum"  Min="0" Max="3" Step="1"/>
+      </WndProperty>  
      <WndProperty Name="prpMCDir" Caption="_@M2447_" X="2" Y="-1" Width="120" Height="21" CaptionWidth="50" Font="2" Help="_@H1345_">
         <DataField Name="" DataType="enum"  Min="0" Max="3" Step="1"/>
       </WndProperty> 

--- a/Common/Data/Dialogs/dlgDevLXNav_P.xml
+++ b/Common/Data/Dialogs/dlgDevLXNav_P.xml
@@ -2,9 +2,12 @@
 <PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
   <WndForm Type="Dialog" X="0" Y="0" Width="240" Height="320" Caption="LXNav Config" Popup="1" Font="2" >   
     <WndButton Name="cmdClose"       Caption="_@M186_"     X="2" Y="1"  Width="110"  Height="28" Font="2" Tag="3" /> 
-    <WndButton Name="cmdIGCDownload" Caption="_@M2398_"    X="120" Y="1" Width="110"  Height="28" Font="2" Tag="3" />           
-    <WndButton Name="cmdValues"      Caption="_@M2467_"    X="120" Y="-1" Width="110"  Height="28" Font="2" Tag="3" />
-   
+    <WndButton Name="cmdIGCDownload" Caption="_@M2398_"    X="130" Y="1" Width="110"  Height="28" Font="2" Tag="3" />           
+    <WndButton Name="cmdValues"      Caption="_@M2467_"    X="130" Y="-1" Width="110"  Height="28" Font="2" Tag="3" />
+  
+      <WndProperty Name="prpQNHDir" Caption="QNH" X="2" Y="35" Width="120" Height="21" CaptionWidth="50" Font="2" Help="_@H1345_">
+        <DataField Name="" DataType="enum"  Min="0" Max="3" Step="1"/>
+      </WndProperty>        
      <WndProperty Name="prpMCDir" Caption="_@M2447_" X="2" Y="-1" Width="120" Height="21" CaptionWidth="50" Font="2" Help="_@H1345_">
         <DataField Name="" DataType="enum"  Min="0" Max="3" Step="1"/>
       </WndProperty>  

--- a/Common/Data/Language/Translations/en.json
+++ b/Common/Data/Language/Translations/en.json
@@ -2560,5 +2560,7 @@
     "_@H001357_": "SPEED  \nEn-/Disable Speed (IAS) value reception from external LX device",
     "_@H001358_": "DIRECT \nEn-/Disable the direct Link to pass logger task declarations to the Logger\nOFF: If a logger is included in the LX device (e.g. LX S100) \nON: for external logger connected to the LX devce (e.g. LX V7 ",
     "_@H001359_": "VARIO  \nEn-/Disable variometer value reception from external LX device",
-    "_@H001360_": "T-TRGT (Transmit Target)\nsend Navigation TARGET waypoint information to LX compatible devices. The navigation target can be send by $PLXVTARG or $GPRMB sentences of the protocol.\nOFF: no target data transmission \n$PLXVTARG: send to device using $PLXVTARG protocol sentences\n$GPRMB: send to device using $GPRMB protocol sentences. If possible at the remote device we recomend to use $PLXVTARG because it includes the target elevation."
+    "_@H001360_": "T-TRGT (Transmit Target)\nsend Navigation TARGET waypoint information to LX compatible devices. The navigation target can be send by $PLXVTARG or $GPRMB sentences of the protocol.\nOFF: no target data transmission \n$PLXVTARG: send to device using $PLXVTARG protocol sentences\n$GPRMB: send to device using $GPRMB protocol sentences. If possible at the remote device we recomend to use $PLXVTARG because it includes the target elevation.",
+    "_@M002574_": "No Device found",
+    "_@M002575_": "Wrong Block answer"
 }

--- a/Common/Header/devLX.h
+++ b/Common/Header/devLX.h
@@ -34,7 +34,7 @@ typedef enum {
   _POLAR  ,
   _DIRECT ,
   _T_TRGT ,
-
+  _QNH    ,
   _LAST
 } ValueStringIndex;
 

--- a/Common/Header/devLX_EOS_ERA.h
+++ b/Common/Header/devLX_EOS_ERA.h
@@ -46,6 +46,32 @@
 #define I_S_VOL  5
 #define I_SIGNAL 6
 
+
+
+#define REC_NO_ERROR      0
+#define REC_TIMEOUT_ERROR 1
+#define REC_CRC_ERROR     2
+#define REC_ABORTED       3
+#define FILENAME_ERROR    4
+#define FILE_OPEN_ERROR   5
+#define IGC_RECEIVE_ERROR 6
+#define REC_NO_DEVICE     7
+#define REC_NOMSG         8
+#define REC_INVALID_SIZE  9
+#define REC_WRONG_BLOCK  10
+#define REC_ZERO_BLOCK   11
+
+
+
+
+
+void StartEOS_IGCReadThread(void) ;
+void StopEOS_IGCReadThread(void) ;
+bool SetEOSBinaryModeFlag(bool ) ;
+
+uint8_t EOSRecChar( DeviceDescriptor_t *d, uint8_t *inchar, uint16_t Timeout) ;
+uint8_t EOSRecChar16(DeviceDescriptor_t *d, uint16_t *inchar, uint16_t Timeout) ;
+bool EOSBlockReceived(void);
 class DevLX_EOS_ERA : public DevLX
 {
   //----------------------------------------------------------------------------
@@ -59,7 +85,7 @@ class DevLX_EOS_ERA : public DevLX
     /// Send string as NMEA sentence with prefix '$', suffix '*', and CRC
     static bool SendNmea(PDeviceDescriptor_t, const TCHAR buf[], unsigned errBufSize, TCHAR errBuf[]);
     static bool SendNmea(PDeviceDescriptor_t, const TCHAR buf[]);
-    static bool OnStartIGC_FileRead(TCHAR Filename[]) ;
+    static bool OnStartIGC_FileRead(TCHAR Filename[], uint16_t) ;
     static BOOL AbortLX_IGC_FileRead(void);
 
   //----------------------------------------------------------------------------
@@ -92,7 +118,8 @@ class DevLX_EOS_ERA : public DevLX
     static bool SendDecl(PDeviceDescriptor_t d, unsigned row, unsigned n_rows, TCHAR content[], unsigned errBufSize, TCHAR errBuf[]);
 
    static BOOL ParseNMEA(PDeviceDescriptor_t d, TCHAR* sentence, NMEA_INFO* info);
-
+   static BOOL EOSParseStream(DeviceDescriptor_t *d, char *String, int len, NMEA_INFO *GPS_INFO);
+   
    static BOOL Config(PDeviceDescriptor_t d);
    static void OnCloseClicked(WndButton* pWnd);
    static void OnCancelClicked(WndButton* pWnd);

--- a/Common/Header/device.h
+++ b/Common/Header/device.h
@@ -116,6 +116,7 @@ typedef struct{
   DataBiIoDir POLARDir ; // Polar 2 voltage
   DataBiIoDir DirLink  ; // Direct Link
   DataTP_Type T_TRGTDir; // Send Navigation Target information protocol sentence
+  DataBiIoDir QNHDir   ; // QNH data exchange
 } DeviceIO;
 
 struct DeviceDescriptor_t {

--- a/Common/Header/dlgEOSIGCDownload.h
+++ b/Common/Header/dlgEOSIGCDownload.h
@@ -1,0 +1,43 @@
+/*
+   LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+   Released under GNU/GPL License v.2
+   See CREDITS.TXT file for authors and copyrights
+
+   $Id$
+*/
+
+#ifndef _DLGEOSIGCDOWNLOAD_H_
+#define _DLGEOSIGCDOWNLOAD_H_
+
+
+#define PRPGRESS_DLG 1
+  ListElement* dlgEOSIGCSelectListShowModal(  void) ;
+  void AddEOSElement(TCHAR Line1[], TCHAR Line2[] , uint32_t size);
+  void EOSListFilled(BOOL filled) ;
+
+
+
+
+             
+typedef union{
+  uint16_t val;
+  uint8_t byte[2];
+} ConvUnion;               
+  
+#define REC_TIMEOUT 1000 // receive timeout in ms               
+  
+#define STX             0x02
+#define ACK             0x06
+#define SYNC            0x16 // Syncronization byte (deprecated) 1 B
+#define GET_LOGGER_INFO 0xC4 // Get logger info 3 B
+#define SET_TASK        0xCA // Set task 352 B
+#define GET_TASK        0xCB // Get task 3 B
+#define SET_CLASS       0xD0 // Set Class 12 B
+#define GET_FLIGHT_INFO 0xF0 // Get flight info 4 B
+#define GET_FLIGTH_BLK  0xF1 // Get flight block 7 B
+#define GET_NO_FLIGHTS  0xF2 // Get number of flights 3 B
+#define SEND_RADIO_CMD  0xF3 // Send CMD to Radio Variable
+#define SET_OBS_ZONE    0xF4 // Set Obs Zone 31 B
+#define GET_OBS_ZONE    0xF5 // Get Obs Zone 4 B
+
+#endif

--- a/Common/Source/Devices/devLXNano3.cpp
+++ b/Common/Source/Devices/devLXNano3.cpp
@@ -509,8 +509,19 @@ BOOL DevLXNanoIII::ShowData(WndForm* wf ,PDeviceDescriptor_t d)
 {
 WndProperty *wp;
 if(!wf) return false;
-wp = (WndProperty*)wf->FindByName(TEXT("prpMCDir"));
+
 int PortNum = d->PortNumber;
+   wp = (WndProperty*)wf->FindByName(TEXT("prpQNHDir"));
+  if (wp) {
+    DataField* dfe = wp->GetDataField(); dfe->Clear();
+    dfe->addEnumText(MsgToken(491));  // LKTOKEN  _@M491_ "OFF"
+  //  dfe->addEnumText(MsgToken(2452)); // LKTOKEN  _@M2452_ "IN"
+    dfe->addEnumText(MsgToken(2453)); // LKTOKEN  _@M2453_ "OUT"
+ //   dfe->addEnumText(MsgToken(2454)); // LKTOKEN  _@M2454_ "IN & OUT"
+    dfe->Set((uint) PortIO[PortNum].QNHDir);
+    wp->RefreshDisplay();
+  }
+  wp = (WndProperty*)wf->FindByName(TEXT("prpMCDir"));
   if (wp) {
     DataField* dfe = wp->GetDataField(); dfe->Clear();
     dfe->addEnumText(MsgToken(491));  // LKTOKEN  _@M491_ "OFF"
@@ -703,6 +714,7 @@ static bool OnTimer(WndForm* pWnd)
 
   if(wf)
   {
+    wp = (WndProperty*)wf->FindByName(TEXT("prpQNHDir")    ); UpdateValueTxt( wp,  _QNH   );    
     wp = (WndProperty*)wf->FindByName(TEXT("prpMCDir")     ); UpdateValueTxt( wp,  _MC    );
     wp = (WndProperty*)wf->FindByName(TEXT("prpBUGDir")    ); UpdateValueTxt( wp,  _BUGS  );
     wp = (WndProperty*)wf->FindByName(TEXT("prpBALDir")    ); UpdateValueTxt( wp,  _BAL   );
@@ -1233,7 +1245,9 @@ void DevLXNanoIII::OnValuesClicked(WndButton* pWnd) {
         if (wf) ShowData(wf, Device());
       }
     }
+    
     StartupStore(_T(" Nano3 CLEAR VALUES %s"), NEWLINE);
+    SetDataText( _QNH,   _T(""));    
     SetDataText( _MC,    _T(""));
     SetDataText( _BUGS,  _T(""));
     SetDataText( _BAL,   _T(""));
@@ -1970,9 +1984,15 @@ BOOL DevLXNanoIII::PLXV0(PDeviceDescriptor_t d, const TCHAR* sentence, NMEA_INFO
   NMEAParser::ExtractParameter(sentence,szTmp1,0);
   if  (_tcscmp(szTmp1,_T("QNH"))==0)
   {
+    
     NMEAParser::ExtractParameter(sentence,szTmp2,2);
-    UpdateQNH((StrToDouble(szTmp2,NULL))/100.0);
-    StartupStore(_T("Nano3 QNH: %s"),szTmp2);
+    double newQNH = StrToDouble(szTmp2,NULL)/100.0;
+    SetDataText( _QNH,   szTmp2);
+    if(IsDirInput(PortIO[d->PortNumber].QNHDir))
+    {
+      UpdateQNH(newQNH);
+      StartupStore(_T("Nano3 QNH: %s"),szTmp2);
+    }
     return true;
   }
 

--- a/Common/Source/Devices/devLX_EOS_ERA.cpp
+++ b/Common/Source/Devices/devLX_EOS_ERA.cpp
@@ -1535,12 +1535,15 @@ bool ret = false;
   if(Values(d))
   {
     TCHAR szTmp[MAX_NMEA_LEN];
-    _sntprintf(szTmp,MAX_NMEA_LEN,  _T("%3.0f L = %3.0f%% %s"),fTmp,(fTmp/WEIGHTS[2]*100.0), info);
-    SetDataText(_BAL,  szTmp);
+    if(WEIGHTS[2] > 0)
+    {
+      _sntprintf(szTmp,MAX_NMEA_LEN,  _T("%3.0f L = %3.0f%% %s"),fTmp,(fTmp/WEIGHTS[2]*100.0), info);
+      SetDataText(_BAL,  szTmp);
+    }
   }
   if(IsDirInput(PortIO[d->PortNumber].BALDir  ))
   {
-    if(fabs(fTmp- GlidePolar::BallastLitres) > 1 )
+    if((fabs(fTmp- GlidePolar::BallastLitres) > 1 )  &&   (WEIGHTS[2] > 0))
     {
       GlidePolar::BallastLitres = fTmp;
       BALLAST =  GlidePolar::BallastLitres / WEIGHTS[2];
@@ -1832,8 +1835,9 @@ static int iNoFlights=0;
     NMEAParser::ExtractParameter(sentence, Surname  ,8);
     NMEAParser::ExtractParameter(sentence, Type     ,9);
     NMEAParser::ExtractParameter(sentence, Reg      ,10);
-    ParToDouble(sentence, 15, &fTmp);
-    uint32_t filesize = (uint32_t)fTmp;
+     uint32_t filesize  = 0;
+    if (ParToDouble(sentence, 15, &fTmp))
+       filesize = (uint32_t)fTmp;
     
     TCHAR Line[2][MAX_NMEA_LEN];
     _sntprintf( Line[0],MAX_NMEA_LEN, _T("%s %s %s  %s %s"),FileName, Pilot,Surname, Reg, Type);

--- a/Common/Source/Devices/devLX_EOS_ERA.cpp
+++ b/Common/Source/Devices/devLX_EOS_ERA.cpp
@@ -25,7 +25,8 @@
 #include "dlgIGCProgress.h"
 #include "Util/Clamp.hpp"
 #include "OS/Sleep.h"
-#include "dlgLXIGCDownload.h"
+#include "devLX_EOS_ERA.h"
+#include "dlgEOSIGCDownload.h"
 #include "externs.h"
 #include "Baro.h"
 #include "Utils.h"
@@ -34,15 +35,16 @@
 #include "McReady.h"
 #include "Time/PeriodClock.hpp"
 #include "Calc/Vario.h"
-
-static FILE *f= NULL;
+#include <queue>
+#include "Thread/Mutex.hpp"
+#include "Thread/Cond.hpp"
 
 unsigned int uiEOSDebugLevel = 1;
 extern bool UpdateQNH(const double newqnh);
 
 #define NANO_PROGRESS_DLG
 #define BLOCK_SIZE 32
-
+#define _deb (0)
 
 PDeviceDescriptor_t DevLX_EOS_ERA::m_pDevice=NULL;
 BOOL DevLX_EOS_ERA::m_bShowValues = false;
@@ -159,6 +161,8 @@ BOOL  DevLX_EOS_ERA::Values( PDeviceDescriptor_t d)
 
 }
 
+
+
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// Installs device specific handlers.
 ///
@@ -190,6 +194,7 @@ BOOL DevLX_EOS_ERA::Install(PDeviceDescriptor_t d) {
   d->PutFreqStandby = EOSPutFreqStandby;
   d->StationSwap    = EOSStationSwap;
   d->PutRadioMode   = EOSRadioMode;
+  d->ParseStream    = EOSParseStream;
 
   StartupStore(_T(". %s installed (platform=%s test=%u)%s"),
     GetName(),
@@ -199,38 +204,85 @@ BOOL DevLX_EOS_ERA::Install(PDeviceDescriptor_t d) {
 } // Install()
 
 
+namespace {
+  std::queue<uint8_t> EOSbuffered_data;
+  Mutex EOSmutex;
+  Cond EOScond;
+  bool bEOSBinMode= false;
+}
 
-extern long  StrTol(const  TCHAR *buff) ;
+bool EOSBlockReceived() {
+  ScopeLock lock(EOSmutex);
+  return (!EOSbuffered_data.empty());
+}
+  
+bool IsEOSInBinaryMode() {
+  ScopeLock lock(EOSmutex);
+  return bEOSBinMode;
+}
 
-
-long LX_EOS_ERABaudrate(int iIdx)
-{
-//  indexes are following:
-//  enum { br4800=0, br9600, br19200, br38400, br57600,
-//  br115200,br230400,br256000,br460800, br500k, br1M};
-long lBaudrate = -1;
-  switch (iIdx)
-  {
-    case 0:  lBaudrate = 4800   ; break;
-    case 1:  lBaudrate = 9600   ; break;
-    case 2:  lBaudrate = 19200  ; break;
-    case 3:  lBaudrate = 38400  ; break;
-    case 4:  lBaudrate = 56800  ; break;
-    case 5:  lBaudrate = 115200 ; break;
-    case 6:  lBaudrate = 230400 ; break;
-    case 7:  lBaudrate = 256000 ; break;
-    case 8:  lBaudrate = 460800 ; break;
-    case 9:  lBaudrate = 500000 ; break;
-    case 10: lBaudrate = 1000000; break;
-    default: lBaudrate = -1     ; break;
+bool SetEOSBinaryModeFlag(bool bBinMode) {
+  ScopeLock lock(EOSmutex);
+  bool OldVal = bEOSBinMode;
+  bEOSBinMode = bBinMode;
+  if(!bEOSBinMode) {
+    // same as clear() but free allocated memory.
+    EOSbuffered_data = std::queue<uint8_t>();
   }
-return lBaudrate;
+  return OldVal;
+}
+
+
+
+BOOL DevLX_EOS_ERA::EOSParseStream(DeviceDescriptor_t *d, char *String, int len, NMEA_INFO *GPS_INFO) {
+  if ((!d) || (!String) || (!len)) {
+    return FALSE;
+  }
+  
+    if (!IsEOSInBinaryMode()) {
+    return FALSE;
+  }
+
+  ScopeLock lock(EOSmutex);
+
+  for (int i = 0; i < len; i++) {
+    EOSbuffered_data.push((uint8_t)String[i]);
+  }
+  EOScond.Broadcast();
+
+  return  true;
 }
 
 
 
 
+uint8_t EOSRecChar( DeviceDescriptor_t *d, uint8_t *inchar, uint16_t Timeout) {
+  ScopeLock lock(EOSmutex);
 
+  while(EOSbuffered_data.empty()) {
+    if(!EOScond.Wait(EOSmutex, Timeout)) 
+    {
+      return REC_TIMEOUT_ERROR;
+    }
+  }
+  if(inchar) {
+    *inchar = EOSbuffered_data.front();
+   
+  }
+  EOSbuffered_data.pop();
+
+  return REC_NO_ERROR;
+}
+
+uint8_t EOSRecChar16(DeviceDescriptor_t *d, uint16_t *inchar, uint16_t Timeout) {
+  ConvUnion tmp;
+  int error = EOSRecChar(d, &(tmp.byte[0]), Timeout);
+  if (error == REC_NO_ERROR) {
+    error = EOSRecChar(d, &(tmp.byte[1]), Timeout);
+  }
+  *inchar = tmp.val;
+  return error;
+}
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// Parses LXWPn sentences.
 ///
@@ -246,6 +298,9 @@ return lBaudrate;
 BOOL DevLX_EOS_ERA::ParseNMEA(PDeviceDescriptor_t d, TCHAR* sentence, NMEA_INFO* info)
 {
  if (Declare()) return false ;  // do not configure during declaration
+ 
+ 
+ if( IsEOSInBinaryMode()) return false;
 static char lastSec =0;
   if( /*!Declare() &&*/ (info->Second != lastSec))  // execute every second only if no task is declaring
   {
@@ -267,13 +322,14 @@ static char lastSec =0;
       SendNmea(d, TEXT("LXDT,GET,SENS"));
     if( ((info->Second+4) %4) ==0) 
       SendNmea(d, TEXT("LXDT,GET,NAVIGATE,0"));
-    
+
     static double oldQNH= -1.0;
+
     if(IsDirOutput(PortIO[d->PortNumber].QNHDir))
     {      
-      if(fabs( oldQNH - QNH) > 0.1)   
+      if(fabs( oldQNH - QNH) > 0.9)   
       { TCHAR szTmp[MAX_NMEA_LEN];
-        _stprintf(szTmp,  TEXT("LXDT,SET,MC_BAL,,,,,,,%4u"),(int) (QNH+0.5) );
+        _stprintf(szTmp,  TEXT("LXDT,SET,MC_BAL,,,,,,,%4u"),(int) (QNH) );
         SendNmea(d, szTmp);
         oldQNH = QNH;
       }
@@ -349,7 +405,9 @@ BOOL DevLX_EOS_ERA::SetupLX_Sentence(PDeviceDescriptor_t d)
  if (Declare()) return false ;  // do not configure during declaration
   if((i++%2)==0)
   {
-    SendNmea(d, TEXT("PFLX0,LXWP0,1,LXWP1,5,LXWP2,1,LXWP3,1,LXDT,1,LXBC,1,GPRMB,5"));
+    SendNmea(d, TEXT("PFLX0,LXWP0,1,LXWP1,5,LXWP2,1,LXWP3,1,GPRMB,5"));
+
+    SendNmea( d, _T("LXDT,SET,BC_INT,AHRS,0.5,SENS,2.0"));      
   }
   else
     if(!LX_EOS_ERA_bValid)
@@ -385,7 +443,7 @@ int PortNum = d->PortNumber;
     dfe->addEnumText(MsgToken(2452)); // LKTOKEN  _@M2452_ "IN"
     dfe->addEnumText(MsgToken(2453)); // LKTOKEN  _@M2453_ "OUT"
     dfe->addEnumText(MsgToken(2454)); // LKTOKEN  _@M2454_ "IN & OUT"
-    dfe->Set((uint) PortIO[PortNum].MCDir);
+    dfe->Set((uint) PortIO[PortNum].QNHDir);
     wp->RefreshDisplay();
   }
   
@@ -1189,23 +1247,20 @@ UnlockFlightData();
     MessageBoxX(MsgToken(2418), MsgToken(2397), mbOk);
     return;
   }
-
+    SendNmea(Device(), _T("LXDT,SET,BC_INT,AHRS,0.0,SENS,0.0"));    
+      Poco::Thread::sleep(50);
     SendNmea(Device(), _T("LXDT,GET,FLIGHTS_NO"));
-
-    dlgLX_IGCSelectListShowModal();
+      Poco::Thread::sleep(50);
+    dlgEOSIGCSelectListShowModal();
 }
 
 
 
 
- bool  DevLX_EOS_ERA::OnStartIGC_FileRead(TCHAR Filename[]) {
+ bool  DevLX_EOS_ERA::OnStartIGC_FileRead(TCHAR Filename[], uint16_t uiNo) {
 
-TCHAR IGCFilename[MAX_PATH];
-LocalPath(IGCFilename, _T(LKD_LOGS), Filename);
 
-  f = _tfopen( IGCFilename, TEXT("w"));
-  if(f == NULL)   return false;
-  fclose(f);
+  
   // SendNmea(Device(), _T("PLXVC,KEEP_ALIVE,W"), errBufSize, errBuf);
   StartupStore(_T(" ******* LX_EOS_ERA  IGC Download START ***** %s") , NEWLINE);
   /*
@@ -1215,9 +1270,11 @@ LocalPath(IGCFilename, _T(LKD_LOGS), Filename);
   SendNmea(Device(), szTmp);
   StartupStore(_T("> %s %s") ,szTmp, NEWLINE);
   IGCDownload(true);
-#ifdef  NANO_PROGRESS_DLG
-  CreateIGCProgressDialog();
-#endif*/
+   */
+#define  EOS_PROGRESS_DLG
+#ifdef  EOS_PROGRESS_DLG
+ // CreateIGCProgressDialog();
+#endif
 return true;
 
 }
@@ -1227,14 +1284,10 @@ return true;
 BOOL DevLX_EOS_ERA::AbortLX_IGC_FileRead(void)
 {
 
-  if(f != NULL)
-  {
-    fclose(f); f= NULL;
-  }
   bool bWasInProgress = IGCDownload() ;
   IGCDownload ( false );
 
-#ifdef  NANO_PROGRESS_DLG
+#ifdef  EOS_PROGRESS_DLG
   CloseIGCProgressDialog();
 #endif
   return bWasInProgress;
@@ -1268,8 +1321,8 @@ BOOL DevLX_EOS_ERA::LXWP0(PDeviceDescriptor_t d, const TCHAR* sentence, NMEA_INF
   //   v1[0],v1[1],v1[2],v1[3],v1[4],v1[5], hdg, windspeed*CS<CR><LF>
   //
   // 0 loger_stored : [Y|N] (not used in LX1600)
-  // 1 IAS [km/h] ----> Condor uses TAS!
-  // 2 baroaltitude [m]
+  // 1 TAS [km/h]  TAS!
+  // 2 true Altitude [m] (already QNH corrected!!!)
   // 3-8 vario values [m/s] (last 6 measurements in last second)
   // 9 heading of plane (not used in LX1600)
   // 10 windcourse [deg] (not used in LX1600)
@@ -1293,7 +1346,7 @@ double fDir,fTmp,airspeed=0;
       if(IsDirInput(PortIO[d->PortNumber].SPEEDDir  ))
       {
         airspeed = fTmp/TOKPH;
-        info->IndicatedAirspeed = airspeed;
+        info->TrueAirspeed = airspeed;
         info->AirspeedAvailable = TRUE;
       }
     }
@@ -1731,7 +1784,7 @@ static int iNoFlights=0;
   else
   if(_tcsncmp(szTmp, _T("MC_BAL"), 6) == 0)
   {
-    StartupStore(TEXT("MC_BAL %s"), sentence);
+    if(_deb)  StartupStore(TEXT("MC_BAL %s"), sentence);
     if(ParToDouble(sentence, 2, &fTmp)) {EOSSetMC(d, fTmp,_T("($LXDT)") );}
     if(ParToDouble(sentence, 3, &fTmp)) {EOSSetBAL(d, fTmp,_T("($LXDT)") );}
     if(ParToDouble(sentence, 4, &fTmp)) {EOSSetBUGS(d, fTmp,_T("($LXDT)") );}
@@ -1760,6 +1813,7 @@ static int iNoFlights=0;
     if(ParToDouble(sentence, 2, &fTmp)) iNoFlights =(int) (fTmp+0.05);
     if(iNoFlights > 0)
     {
+      EOSListFilled(false);
       _sntprintf(szTmp, MAX_NMEA_LEN, _T("LXDT,GET,FLIGHT_INFO,%i"),1);
       SendNmea(d,szTmp);
     }
@@ -1778,15 +1832,20 @@ static int iNoFlights=0;
     NMEAParser::ExtractParameter(sentence, Surname  ,8);
     NMEAParser::ExtractParameter(sentence, Type     ,9);
     NMEAParser::ExtractParameter(sentence, Reg      ,10);
+    ParToDouble(sentence, 15, &fTmp);
+    uint32_t filesize = (uint32_t)fTmp;
+    
     TCHAR Line[2][MAX_NMEA_LEN];
     _sntprintf( Line[0],MAX_NMEA_LEN, _T("%s %s %s  %s %s"),FileName, Pilot,Surname, Reg, Type);
-    _sntprintf( Line[1],MAX_NMEA_LEN, _T("%s (%s-%s) "), Date ,Takeoff ,Landing);
-    AddElement(Line[0], Line[1]);
+    _sntprintf( Line[1],MAX_NMEA_LEN, _T("%s (%s-%s) %ukB"), Date ,Takeoff ,Landing,filesize/1024);
+    AddEOSElement(Line[0], Line[1], filesize );
     if(iNo < iNoFlights)
     {
       _sntprintf(szTmp, MAX_NMEA_LEN, _T("LXDT,GET,FLIGHT_INFO,%i"),iNo+1);
       SendNmea(d,szTmp);
     }
+    else
+      EOSListFilled(true);
   }
   else
   if(_tcsncmp(szTmp, _T("SENS"), 4) == 0)  // Sensor Data?
@@ -1923,8 +1982,7 @@ TCHAR  szTmp[MAX_NMEA_LEN];
   _sntprintf(szTmp,MAX_NMEA_LEN, TEXT("LXDT,SET,MC_BAL,%.1f,,,,,"), MacCready);
   StartupStore(TEXT("Send: %s"), szTmp);
   SendNmea(d,szTmp);
- /* Poco::Thread::sleep(REQ_DEADTIME);
-  SendNmea(d,_T("LXDT,GET,MC_BAL"));*/
+
 return true;
 
 }
@@ -1940,8 +1998,7 @@ TCHAR  szTmp[MAX_NMEA_LEN];
   _sntprintf(szTmp,MAX_NMEA_LEN, TEXT("LXDT,SET,MC_BAL,,%.0f,,,,"),GlidePolar::BallastLitres);
   StartupStore(TEXT("Send: %s"), szTmp);
   SendNmea(d,szTmp);
- /* Poco::Thread::sleep(REQ_DEADTIME);
-  SendNmea(d,_T("LXDT,GET,MC_BAL"));*/
+
 
 
 return(TRUE);
@@ -1959,9 +2016,7 @@ BOOL DevLX_EOS_ERA::EOSPutBugs(PDeviceDescriptor_t d, double Bugs){
   _sntprintf(szTmp,MAX_NMEA_LEN, TEXT("LXDT,SET,MC_BAL,,,%.0f,,,"),fLXBugs);
   StartupStore(TEXT("Send: %s"), szTmp);
   SendNmea(d,szTmp);
-  /*
-  Poco::Thread::sleep(REQ_DEADTIME);
-  SendNmea(d,_T("LXDT,GET,MC_BAL"));*/
+
 
 
 return(TRUE);

--- a/Common/Source/Devices/devLX_EOS_ERA.cpp
+++ b/Common/Source/Devices/devLX_EOS_ERA.cpp
@@ -273,7 +273,7 @@ static char lastSec =0;
     {      
       if(fabs( oldQNH - QNH) > 0.1)   
       { TCHAR szTmp[MAX_NMEA_LEN];
-        _stprintf(szTmp,  TEXT("LXDT,SET,MC_BAL,,,,,,,%4u"),(int) QNH );
+        _stprintf(szTmp,  TEXT("LXDT,SET,MC_BAL,,,,,,,%4u"),(int) (QNH+0.5) );
         SendNmea(d, szTmp);
         oldQNH = QNH;
       }
@@ -1738,21 +1738,21 @@ static int iNoFlights=0;
     if(ParToDouble(sentence, 5, &fTmp)) {}  // Screen brightness in percent
     if(ParToDouble(sentence, 6, &fTmp)) {}  // Variometer volume in percent
     if(ParToDouble(sentence, 7, &fTmp)) {}  // SC volume in percent
-    if(ParToDouble(sentence, 8, &fTmp)) {}  // QNH in hPa (NEW)
-
-    if(IsDirInput(PortIO[d->PortNumber].QNHDir))
-    { 
-      static double oldQNH = -1;
-      if ( fabs( oldQNH - fTmp) > 0.1)
-      {
-        UpdateQNH( fTmp);
-        oldQNH = fTmp;
-      }
-    }  
-    NMEAParser::ExtractParameter(sentence, szTmp, 8);
-    SetDataText( _QNH,   szTmp);
-    LX_EOS_ERA_bValid = true;
- 
+    if(ParToDouble(sentence, 8, &fTmp))   // QNH in hPa (NEW)
+    {
+      if(IsDirInput(PortIO[d->PortNumber].QNHDir))
+      { 
+        _stprintf( szTmp, _T("%4.0f hPa"),fTmp);      
+        SetDataText( _QNH,   szTmp);
+        static double oldQNH = -1;
+        if ( fabs( oldQNH - fTmp) > 0.1)
+        {
+          UpdateQNH( fTmp);
+          oldQNH = fTmp;
+        }
+      }  
+    }
+    LX_EOS_ERA_bValid = true;    
   }
   else
   if(_tcsncmp(szTmp, _T("FLIGHTS_NO"), 10) == 0)

--- a/Common/Source/Dialogs/dlgEOSIGCDownload.cpp
+++ b/Common/Source/Dialogs/dlgEOSIGCDownload.cpp
@@ -1,0 +1,842 @@
+/*
+   LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+   Released under GNU/GPL License v.2
+   See CREDITS.TXT file for authors and copyrights
+
+   $Id$
+*/
+#include "externs.h"
+#include "dlgTools.h"
+#include "Dialogs.h"
+#include "WindowControls.h"
+#include "resource.h"
+#include "Util/Clamp.hpp"
+#include "OS/Sleep.h"
+#include "devLX_EOS_ERA.h"
+#include "dlgEOSIGCDownload.h"
+#include "dlgIGCProgress.h"
+
+
+#define EOS_PRPGRESS_DLG    
+  
+#define LST_STRG_LEN          100
+#define STATUS_TXT_LEN        100
+#define GC_IDLETIME           4
+#define GC_TIMER_INTERVAL     750
+
+#define deb_                  (0)  // debug output switch
+
+ Mutex DLmutex;
+
+int ReadEOS_IGCFile(DeviceDescriptor_t *d, uint8_t IGC_FileIndex) ;
+static void UpdateList(void);
+
+TCHAR DownoadIGCFilename[MAX_PATH];
+TCHAR szEOS_DL_StatusText[STATUS_TXT_LEN];
+volatile bool  bDlgShown = false; 
+
+enum thread_state {
+  IDLE_STATE,
+  READRECORD_STATE_TX,
+  READRECORD_STATE_RX,
+  START_DOWNLOAD_STATE,
+  ABORT_STATE,
+  ERROR_STATE,
+  SIGNAL_STATE,
+  ALL_RECEIVED_STATE,
+  CLOSE_STATE
+};
+
+volatile thread_state EOS_ThreadState = IDLE_STATE;
+
+
+
+
+typedef struct {
+  TCHAR Line1[LST_STRG_LEN];
+  TCHAR Line2[LST_STRG_LEN];
+  uint32_t filesize;
+} EOSListElementType;
+
+
+
+
+static bool OnTimer(WndForm *pWnd) ;
+class LK_EOS_IGCReadDlg {
+public:
+  LK_EOS_IGCReadDlg();
+
+  ~LK_EOS_IGCReadDlg();
+
+
+  void DrawIndex(uint uIdx) { m_IGC_DrawListIndex = uIdx; };
+
+  uint DrawIndex() { return m_IGC_DrawListIndex; };
+
+  void CurIndex(uint uIdx) { m_IGC_CurIndex = uIdx; };
+
+  uint CurIndex() { return m_IGC_CurIndex; };
+
+  void DownloadIndex(uint uIdx) { m_IGC_DownloadIndex = uIdx; };
+
+  uint DownloadIndex() { return m_IGC_DownloadIndex; };
+
+  std::vector<EOSListElementType> *FileList() { return &m_IGCFileList; };
+
+  void DownloadError(int bDLE) { m_iEOSDownloadError = bDLE; };
+
+  int DownloadError() { return m_iEOSDownloadError; };
+
+  
+  void ListFilled(bool bfilled) { m_ListFilled = bfilled; };
+
+  int ListFilled() { return m_ListFilled; };
+
+
+  void SelectList(WndListFrame *pLst) { m_wIGCSelectList = pLst; };
+
+  WndListFrame *SelectList() { return m_wIGCSelectList; };
+
+  void ListEntry(WndOwnerDrawFrame *pLst) { m_wIGCSelectListEntry = pLst; };
+
+  WndOwnerDrawFrame *ListEntry() { return m_wIGCSelectListEntry; };
+
+protected:
+
+  int m_iEOSDownloadError;
+  uint m_IGC_DrawListIndex;
+  uint m_IGC_CurIndex;
+  uint m_IGC_DownloadIndex;
+  bool m_ListFilled ;
+  WndListFrame *m_wIGCSelectList;
+  WndOwnerDrawFrame *m_wIGCSelectListEntry;
+
+  std::vector<EOSListElementType> m_IGCFileList;
+};
+
+
+LK_EOS_IGCReadDlg::LK_EOS_IGCReadDlg() {
+
+  m_iEOSDownloadError = REC_NO_ERROR;
+  m_IGC_DrawListIndex = 0;
+  m_IGC_CurIndex = 0;
+  m_IGC_DownloadIndex = 0;
+
+  m_ListFilled = false;
+  m_wIGCSelectList = NULL;
+  m_wIGCSelectListEntry = NULL;
+};
+
+LK_EOS_IGCReadDlg::~LK_EOS_IGCReadDlg() {
+  m_IGCFileList.clear();
+};
+
+
+LK_EOS_IGCReadDlg EOS_IGCReadDialog;
+
+
+
+void AddEOSElement(TCHAR Line1[], TCHAR Line2[], uint32_t size) {
+  EOSListElementType NewElement;
+  _tcscpy(NewElement.Line1, Line1);
+  _tcscpy(NewElement.Line2, Line2);
+  NewElement.filesize = size;
+  EOS_IGCReadDialog.FileList()->push_back(NewElement);
+  UpdateList();
+}
+
+
+void EOSListFilled(BOOL filled) {
+  EOS_IGCReadDialog.ListFilled(filled);
+}
+
+
+static void OnUpClicked(WndButton *Sender) {
+  if (EOS_IGCReadDialog.FileList()->size() == 0) return;
+  if (EOS_IGCReadDialog.CurIndex() > 0) {
+    EOS_IGCReadDialog.CurIndex(EOS_IGCReadDialog.CurIndex() - 1);
+  } else {
+    LKASSERT(EOS_IGCReadDialog.FileList()->size() > 0);
+    EOS_IGCReadDialog.CurIndex((EOS_IGCReadDialog.FileList()->size() - 1));
+  }
+  if (EOS_IGCReadDialog.SelectList() != NULL) {
+    EOS_IGCReadDialog.SelectList()->SetItemIndexPos(EOS_IGCReadDialog.CurIndex());
+    EOS_IGCReadDialog.SelectList()->Redraw();
+    if (EOS_IGCReadDialog.ListEntry())
+      EOS_IGCReadDialog.ListEntry()->SetFocus();
+  }
+}
+
+static void OnDownClicked(WndButton *pWnd) {
+  (void) pWnd;
+  if (EOS_IGCReadDialog.FileList()->size() == 0) return;
+  if (EOS_IGCReadDialog.CurIndex() < (EOS_IGCReadDialog.FileList()->size() - 1)) {
+    EOS_IGCReadDialog.CurIndex(EOS_IGCReadDialog.CurIndex() + 1);
+  } else {
+    EOS_IGCReadDialog.CurIndex(0);
+  }
+  if (EOS_IGCReadDialog.SelectList() != NULL) {
+    EOS_IGCReadDialog.SelectList()->SetItemIndexPos(EOS_IGCReadDialog.CurIndex());
+    EOS_IGCReadDialog.SelectList()->Redraw();
+    if (EOS_IGCReadDialog.ListEntry())
+      EOS_IGCReadDialog.ListEntry()->SetFocus();
+  }
+}
+
+
+static void OnMultiSelectListListInfo(WindowControl *Sender, WndListFrame::ListInfo_t *ListInfo) {
+  (void) Sender;
+  if (EOS_IGCReadDialog.FileList()->size() == 0) return;
+  if (ListInfo->DrawIndex == -1) {
+    ListInfo->ItemCount = EOS_IGCReadDialog.FileList()->size();
+  } else {
+    EOS_IGCReadDialog.DrawIndex(ListInfo->DrawIndex + ListInfo->ScrollIndex);
+    EOS_IGCReadDialog.CurIndex(ListInfo->ItemIndex + ListInfo->ScrollIndex);
+  }
+
+}
+
+bool GetEOSIGCFilename(TCHAR *IGCFilename, TCHAR *InFilename) {
+  if (IGCFilename == NULL)
+    return false;
+  TCHAR Tmp[MAX_PATH];
+
+  _tcscpy(Tmp, InFilename);
+  TCHAR *remaining;
+  TCHAR *Filename = _tcstok_r(Tmp, TEXT(" "), &remaining);
+  LocalPath(IGCFilename, _T(LKD_LOGS), Filename);
+  return true;
+}
+
+
+static void OnEnterClicked(WndButton *pWnd) {
+    (void) pWnd;
+  if((!pWnd) || (!EOS_IGCReadDialog.ListFilled())){
+    return;
+  }
+  
+  WndForm* pForm = pWnd->GetParentWndForm();
+  if(!pForm) {
+    return;
+  }
+
+
+  TCHAR Tmp[MAX_PATH];
+  if (EOS_IGCReadDialog.FileList()->size() == 0) return;
+
+
+  if (EOS_IGCReadDialog.CurIndex() >= EOS_IGCReadDialog.FileList()->size()) {
+    EOS_IGCReadDialog.CurIndex(EOS_IGCReadDialog.FileList()->size() - 1);
+  }
+  if (EOS_IGCReadDialog.FileList()->size() < (uint) EOS_IGCReadDialog.CurIndex()) return;
+  EOS_IGCReadDialog.DownloadIndex(EOS_IGCReadDialog.CurIndex());
+  
+  
+  TCHAR szTmp[MAX_NMEA_LEN];
+  _tcscpy(szTmp, EOS_IGCReadDialog.FileList()->at(EOS_IGCReadDialog.CurIndex()).Line1);
+  
+
+  
+  TCHAR *remaining;
+  TCHAR *IGCFilename = _tcstok_r( szTmp, TEXT(" "), &remaining);
+  _tcscat(IGCFilename, _T(".IGC"));  
+  _tcscpy(DownoadIGCFilename, IGCFilename);
+  _stprintf(Tmp, _T("%s %s ?"), MsgToken(2404), IGCFilename);
+  if (MessageBoxX(Tmp, MsgToken(2404), mbYesNo) == IdYes)  // _@2404 "Download"
+  {
+    /** check if file already exist and is not empty ************/
+    TCHAR PathIGCFilename  [MAX_PATH];
+    if (GetEOSIGCFilename(PathIGCFilename, IGCFilename)) {
+      if (lk::filesystem::exist(PathIGCFilename))
+        if (MessageBoxX(MsgToken(2416), MsgToken(2398), mbYesNo) ==
+            IdNo) // _@M2416_ "File already exits\n download anyway?"
+        {
+          EOS_ThreadState = IDLE_STATE;
+          return;
+        }
+    }
+    /************************************************************/
+     StartupStore(TEXT("OnEnterClicked Size START_DOWNLOAD_STATE "));
+    EOS_ThreadState = START_DOWNLOAD_STATE; // start thread IGC download
+    pForm->SetTimerNotify(GC_TIMER_INTERVAL, OnTimer); // check for end of download every 250ms
+#ifdef EOS_PRPGRESS_DLG
+    CreateIGCProgressDialog();
+#endif
+  }
+}
+
+
+static void OnMultiSelectListPaintListItem(WindowControl *Sender, LKSurface &Surface) {
+
+  if (EOS_IGCReadDialog.FileList()->size() == 0) return;
+  if (EOS_IGCReadDialog.FileList()->size() < (uint) EOS_IGCReadDialog.DrawIndex()) return;
+  if (EOS_IGCReadDialog.DrawIndex() < EOS_IGCReadDialog.FileList()->size()) {
+    Surface.SetTextColor(RGB_BLACK);
+    TCHAR szTmp[MAX_NMEA_LEN] ;
+    TCHAR text1[MAX_NMEA_LEN] = {TEXT("IGC File")};
+    TCHAR text2[MAX_NMEA_LEN] = {TEXT("date")};
+    _tcscpy(szTmp, EOS_IGCReadDialog.FileList()->at(EOS_IGCReadDialog.DrawIndex()).Line1);
+    _tcscpy(text1, EOS_IGCReadDialog.FileList()->at(EOS_IGCReadDialog.DrawIndex()).Line1);
+    _tcscpy(text2, EOS_IGCReadDialog.FileList()->at(EOS_IGCReadDialog.DrawIndex()).Line2);
+
+    TCHAR *remaining;    /* extract filname */
+    TCHAR *IGCFilename = _tcstok_r(
+        szTmp, TEXT(" "),
+            &remaining);
+
+    TCHAR PathAndFilename[MAX_PATH];
+    _tcscat(IGCFilename, _T(".IGC"));
+    LocalPath(PathAndFilename, _T(LKD_LOGS), IGCFilename);     // add path
+    TCHAR Tmp[MAX_NMEA_LEN];
+    _sntprintf(Tmp, MAX_NMEA_LEN, _T("%s"),text1);     // missing
+    if (Appearance.UTF8Pictorials)                             // use UTF8 symbols?
+    {
+      if (lk::filesystem::exist(PathAndFilename))                // check if file exists
+        _sntprintf(text1, MAX_NMEA_LEN, _T("✔ %s"), Tmp); // already copied
+    } else {
+      if (lk::filesystem::exist(PathAndFilename))                // check if file exists
+       _sntprintf(text1, MAX_NMEA_LEN, _T("* %s"), Tmp);// already copied
+    }
+    Surface.SetBkColor(LKColor(0xFF, 0xFF, 0xFF));
+    PixelRect rc = {0, 0, 0, // DLGSCALE(PICTO_WIDTH),
+                    static_cast<PixelScalar>(Sender->GetHeight()) };
+
+    /********************
+     * show text
+     ********************/
+
+    Surface.SetBackgroundTransparent();
+    Surface.SetTextColor(RGB_BLACK);
+    Surface.DrawText(rc.right + DLGSCALE(2), DLGSCALE(2), text1);
+    int ytext2 = Surface.GetTextHeight(text1);
+    Surface.SetTextColor(RGB_DARKBLUE);
+    Surface.DrawText(rc.right + DLGSCALE(2), ytext2, text2);
+  }
+}
+
+
+
+static void OnIGCListEnter(WindowControl *Sender,
+                           WndListFrame::ListInfo_t *ListInfo) {
+    if (Sender) {
+      WndForm *pForm = Sender->GetParentWndForm();
+      if (pForm) {
+        WndButton* wb = ( WndButton*)pForm->FindByName(TEXT("cmdEnter"));
+
+        if (wb)          
+         OnEnterClicked( wb);
+      }
+    }
+}
+
+
+
+static void OnCloseClicked(WndButton *pWnd) {
+  if (pWnd) {
+    WndForm *pForm = pWnd->GetParentWndForm();
+   
+    if (pForm) {
+      pForm->SetTimerNotify(0, NULL); // disable Timer
+      pForm->SetModalResult(mrCancel);
+    }
+  }
+}
+
+
+void OnAbort_EOS_IGC_FileRead(void) {
+
+      EOS_ThreadState = ABORT_STATE;
+
+}
+
+static CallBackTableEntry_t IGCCallBackTable[] = {
+        OnPaintCallbackEntry(OnMultiSelectListPaintListItem),
+        OnListCallbackEntry(OnMultiSelectListListInfo),
+        ClickNotifyCallbackEntry(OnCloseClicked),
+        ClickNotifyCallbackEntry(OnUpClicked),
+        ClickNotifyCallbackEntry(OnEnterClicked),
+        ClickNotifyCallbackEntry(OnDownClicked),
+        EndCallBackEntry()
+};
+
+
+class ResourceLock {
+public:
+  ResourceLock() {
+    StartupStore(TEXT(".... Enter ResourceLock%s"), NEWLINE);
+    StartEOS_IGCReadThread();
+      MapWindow::SuspendDrawingThread();
+  };
+  ~ResourceLock() {
+    StartupStore(TEXT(".... Leave ResourceLock%s"), NEWLINE);
+    StopEOS_IGCReadThread();
+    EOS_IGCReadDialog.FileList()->clear();
+    MapWindow::ResumeDrawingThread();
+  }
+};
+
+
+ListElement *dlgEOSIGCSelectListShowModal(void) {
+
+  ResourceLock ResourceGuard;  //simply need to exist for recource Lock/Unlock
+
+  ListElement *pIGCResult = NULL;
+
+
+  WndForm* wf = dlgLoadFromXML(IGCCallBackTable,
+                      ScreenLandscape ? IDR_XML_MULTISELECTLIST_L : IDR_XML_MULTISELECTLIST_P);
+
+  if (wf) {
+    EOS_IGCReadDialog.SelectList((WndListFrame *) wf->FindByName(TEXT("frmMultiSelectListList")));
+    LKASSERT(EOS_IGCReadDialog.SelectList() != NULL);
+    EOS_IGCReadDialog.SelectList()->SetBorderKind(BORDERLEFT);
+    EOS_IGCReadDialog.SelectList()->SetEnterCallback(OnIGCListEnter);
+
+    EOS_IGCReadDialog.ListEntry(
+            (WndOwnerDrawFrame *) wf->FindByName(TEXT("frmMultiSelectListListEntry")));
+    if (EOS_IGCReadDialog.ListEntry()) {
+      /*
+       * control height must contains 2 text Line
+       * Check and update Height if necessary
+       */
+      LKWindowSurface windowSurface(*main_window);
+      LKBitmapSurface tmpSurface(windowSurface, 1, 1);
+      const auto oldFont = tmpSurface.SelectObject(EOS_IGCReadDialog.ListEntry()->GetFont());
+      const int minHeight = 2 * tmpSurface.GetTextHeight(_T("dp")) + 2 * DLGSCALE(2);
+      tmpSurface.SelectObject(oldFont);
+      const int wHeight = EOS_IGCReadDialog.ListEntry()->GetHeight();
+      if (minHeight > wHeight) {
+        EOS_IGCReadDialog.ListEntry()->SetHeight(minHeight);
+      }
+      EOS_IGCReadDialog.ListEntry()->SetCanFocus(true);
+    } else
+      LKASSERT(0);
+
+
+    EOS_IGCReadDialog.FileList()->clear();
+    EOS_IGCReadDialog.SelectList()->ResetList();
+    wf->SetTimerNotify(GC_TIMER_INTERVAL, OnTimer); // check for end of download every 250ms
+    wf->ShowModal();
+    EOS_IGCReadDialog.FileList()->clear();
+
+
+    delete wf;
+    wf = NULL;
+  }
+  return pIGCResult;
+}
+
+
+
+
+
+int8_t CRC_Update(int8_t m_byCrc, uint8_t d)
+{
+  #define CRCPOLY    0x69
+
+  int8_t tmp;
+  uint8_t count;
+
+  for (count = 0; ++count <= 8; d <<= 1) {
+    tmp = m_byCrc ^ d;
+    m_byCrc <<= 1;
+    if (tmp < 0)
+      m_byCrc ^= CRCPOLY;
+  }
+  return m_byCrc;
+}
+
+void SendBinBlock(DeviceDescriptor_t *d, uint8_t Command, uint8_t FileId, uint16_t Sequence) 
+{
+  if (d == NULL)
+    return;
+
+uint8_t m_datagram[20];
+int8_t  m_byCrc = 0xFF;
+uint16_t byteCount=0;   
+ConvUnion BlkNo   ; 
+ConvUnion FLightNo; 
+
+  
+      BlkNo.val = Sequence;
+      FLightNo.val = FileId;
+      m_datagram[byteCount++] = STX;                                     // 1
+      m_datagram[byteCount++] = Command;                                 // 2
+      m_datagram[byteCount++] = FLightNo.byte[0];                        // 3
+      m_datagram[byteCount++] = FLightNo.byte[1];                        // 4
+      m_datagram[byteCount++] = BlkNo.byte[0];                           // 5
+      m_datagram[byteCount++] = BlkNo.byte[1];                           // 6
+
+      for (uint16_t i =0; i < byteCount; i ++)
+      {
+        d->Com->PutChar( m_datagram[i]);
+        m_byCrc= CRC_Update(m_byCrc, m_datagram[i]);
+      }
+      d->Com->PutChar(m_byCrc);
+       if (deb_) StartupStore(TEXT("Send CRC: %02X"),(uint8_t) m_byCrc); 
+
+  if (deb_) {
+    StartupStore(TEXT("\r\n===="));
+  }
+  Poco::Thread::sleep(GC_IDLETIME);
+  Poco::Thread::yield();
+}
+
+
+
+static uint8_t RecBinBlock(DeviceDescriptor_t *d, FILE *pf_IGCFile, uint16_t Sequence, uint16_t* BytesRead) {
+uint8_t error = REC_NO_ERROR;
+uint8_t CRC_in;
+uint16_t Timeout = REC_TIMEOUT;
+#define MAX_BLK_SIZE 512
+uint8_t m_datagram[MAX_BLK_SIZE];
+uint8_t m_byCrc = 0xff;
+uint8_t bRecByte = 0;;
+uint16_t byteCount=0;   
+ConvUnion BlkSize; 
+ConvUnion BlkNo; 
+ if(BytesRead)   *BytesRead =0;
+  PeriodClock clock;
+  clock.Update();
+  uint16_t cnt =0;
+  if (deb_) StartupStore(TEXT("=== RecBinBlock : "));
+  cnt = 0;
+  do {
+      error = EOSRecChar(d, &bRecByte, 500);
+      // expect ACK within next 2048 char
+      if((cnt++) > 2048) {
+        StartupStore(TEXT("ACK Timeout "));
+        return REC_TIMEOUT_ERROR; 
+      }
+  } while ((bRecByte != ACK) && (error == REC_NO_ERROR));
+  
+  if(error != REC_NO_ERROR) {
+    StartupStore(TEXT("ACK fail! Error code:%i"),error);    
+    return error;
+  }
+  
+  m_byCrc= CRC_Update(m_byCrc, bRecByte);
+
+  if (deb_) {
+     if (deb_) StartupStore(TEXT("ACK OK!"));
+  }
+                    
+  error = EOSRecChar16(d, &BlkSize.val , Timeout);
+  if (error != REC_NO_ERROR) {
+    return error;
+  }
+  m_byCrc= CRC_Update(m_byCrc, BlkSize.byte[0]);
+  m_byCrc= CRC_Update(m_byCrc, BlkSize.byte[1]);
+ 
+  if (BlkSize.val > MAX_BLK_SIZE) {
+     StartupStore(TEXT("RecBinBlock : Invalid Block Size %u"), BlkSize.val);
+    return REC_INVALID_SIZE;
+  }
+ 
+  error = EOSRecChar16(d, &BlkNo.val , Timeout);
+  if (error != REC_NO_ERROR) {
+    return error;
+  }
+  m_byCrc= CRC_Update(m_byCrc, BlkNo.byte[0]);
+  m_byCrc= CRC_Update(m_byCrc, BlkNo.byte[1]);
+ 
+  
+  if (deb_) StartupStore(TEXT("RecBinBlockNo : %u"), BlkNo.val);
+  
+
+  if (BlkSize.val > 0) {
+    for (uint16_t i = 0; i < (BlkSize.val); i++) {
+      error = EOSRecChar(d, &bRecByte , Timeout);
+      if (error != REC_NO_ERROR) {
+         if (deb_)  StartupStore(TEXT("Rec Block Body error: %u!"), error);
+        return error;       
+      }
+      else
+      {
+        m_datagram[byteCount++] = bRecByte;
+        m_byCrc= CRC_Update(m_byCrc, bRecByte);
+      }
+    }
+  }
+  
+  error = EOSRecChar(d, &CRC_in , Timeout);
+   
+  if(BlkNo.val != Sequence)
+  {
+    StartupStore(TEXT("Error: Rec-Block wrong Block :expected %i received %i!"), Sequence, BlkNo.val);
+    return REC_WRONG_BLOCK;
+  }   
+  if (m_byCrc != CRC_in) {
+    error = REC_CRC_ERROR;
+    StartupStore(TEXT("Rec Block CRC error!"));
+  } else {
+    error = REC_NO_ERROR;
+      for (uint16_t i = 0; i < (BlkSize.val); i++) {
+        fputc( m_datagram[i], pf_IGCFile);
+      if(BytesRead)   *BytesRead = BlkSize.val;
+    }    
+    if (deb_) { StartupStore(TEXT("Rec Block %i received! size:%i"),BlkNo.val, BlkSize.val ); }
+  }
+  if(BlkSize.val <= 0)
+    error = REC_ZERO_BLOCK;
+  
+
+  return error;
+}
+
+
+class EOS_IGCReadThread : public Poco::Runnable {
+public:
+  void Start() {
+    if (!Thread.isRunning()) {
+      bStop = false;
+      
+      Thread.start(*this);
+    }
+  }
+
+  void Stop() {
+    if (Thread.isRunning()) {
+      bStop = true;
+     
+      Thread.join();
+    }
+  }
+
+protected:
+  bool bStop;
+  Poco::Thread Thread;
+
+  void run() {
+    if (deb_)
+      StartupStore(TEXT("EOS IGC Thread Started !")); 
+    while (!bStop) {
+
+      ReadEOS_IGCFile(DevLX_EOS_ERA::GetDevice(), EOS_IGCReadDialog.DownloadIndex());
+
+      Poco::Thread::sleep(GC_IDLETIME);
+      Poco::Thread::yield();
+    }
+    SetEOSBinaryModeFlag(false);
+    if (deb_)
+      StartupStore(TEXT("EOS IGC Thread Stopped !"));
+
+  }
+};
+
+EOS_IGCReadThread EOS_IGCReadThreadThreadInstance;
+
+
+
+
+static void UpdateList(void) {
+  if (EOS_IGCReadDialog.SelectList() != NULL) {
+    EOS_IGCReadDialog.SelectList()->ResetList();
+    EOS_IGCReadDialog.SelectList()->Redraw();
+  }
+}
+
+void EOS_StopIGCRead(void) {
+  ScopeLock lock(DLmutex);
+  EOS_ThreadState = ABORT_STATE;
+}
+
+
+void StartEOS_IGCReadThread() {
+  if (deb_)
+    StartupStore(TEXT("Start IGC Thread !"));
+  EOS_IGCReadThreadThreadInstance.Start();
+}
+
+void StopEOS_IGCReadThread() {
+  if (deb_)
+    StartupStore(TEXT("Stop IGC Thread !"));
+  EOS_IGCReadThreadThreadInstance.Stop();
+}
+
+
+
+int ReadEOS_IGCFile(DeviceDescriptor_t *d, uint8_t IGC_FileIndex) {
+ ScopeLock lock(DLmutex);
+static volatile uint16_t BlockNo=1; 
+static uint8_t ErrCnt = 0;
+static uint32_t FileSize = 0;
+static uint32_t  BytesRead =0;
+#define MAX_ERROR_CNT 3
+uint16_t error= REC_NO_ERROR;
+  if (d == NULL)
+    return 0;
+  static FILE *pf_IGCFile= NULL;
+  TCHAR PathIGCFilename  [MAX_PATH];
+  switch (EOS_ThreadState)
+  {
+    
+    case START_DOWNLOAD_STATE:    
+      FileSize =  EOS_IGCReadDialog.FileList()->at(IGC_FileIndex).filesize;
+      BytesRead =0;
+      SetEOSBinaryModeFlag(true);
+      StartupStore(TEXT("EOS/ERA/10k IGC File Download start"));
+      BlockNo = 0;
+      ErrCnt = 0;
+      bDlgShown  = false;
+      szEOS_DL_StatusText[0] = '\0';
+    
+      GetEOSIGCFilename(PathIGCFilename, DownoadIGCFilename);
+      pf_IGCFile = _tfopen( PathIGCFilename, TEXT("w"));
+      if(pf_IGCFile == NULL) 
+      {  
+        EOS_IGCReadDialog.DownloadError(FILE_OPEN_ERROR);  
+        StartupStore(TEXT("EOS/ERA/10k IGC File open error"));
+        EOS_ThreadState = ABORT_STATE;
+      }  
+      else
+        EOS_ThreadState = READRECORD_STATE_TX;
+    break;
+    
+    case READRECORD_STATE_TX:     
+      SendBinBlock(d, GET_FLIGTH_BLK,IGC_FileIndex+1, BlockNo);
+      EOS_ThreadState = READRECORD_STATE_RX;
+    break;  
+    
+    case READRECORD_STATE_RX: 
+      if(EOSBlockReceived())
+      {uint16_t Bytes;
+        error = RecBinBlock(d, pf_IGCFile, BlockNo, &Bytes);
+        BytesRead += Bytes;
+        
+        if(FileSize > 0) // (BytesRead*100)/FileSize
+        {
+          double fPercent = ((double)BytesRead*100.0)/(double)FileSize;
+          _stprintf(szEOS_DL_StatusText, _T("%3.1f%% %s"),fPercent, DownoadIGCFilename); 
+        }
+        else
+          _stprintf(szEOS_DL_StatusText, _T("%i %s"),BlockNo, DownoadIGCFilename);
+
+        EOS_IGCReadDialog.DownloadError(error);
+        
+        EOS_ThreadState = READRECORD_STATE_TX;
+        if (error == REC_ZERO_BLOCK)
+          EOS_ThreadState = ALL_RECEIVED_STATE;
+        else        
+          if (error == REC_NO_ERROR)
+          {
+            BlockNo++;    
+            ErrCnt = 0;
+          }
+          else
+          { ErrCnt++;
+            if (deb_) StartupStore(TEXT("ErrCnt Cnt: %i"),ErrCnt);
+            if(ErrCnt > MAX_ERROR_CNT )          
+              EOS_ThreadState = SIGNAL_STATE;
+          }
+      }
+    break;     
+      
+    case ALL_RECEIVED_STATE:      
+      StartupStore(TEXT("EOS/ERA/10k IGC File Download end (%i Blocks)"),BlockNo);    
+      _stprintf(szEOS_DL_StatusText, _T("%s %s"), DownoadIGCFilename,MsgToken(2406));
+      fclose (pf_IGCFile);
+      pf_IGCFile = NULL;
+      EOS_IGCReadDialog.DownloadError(REC_NO_ERROR);
+      EOS_ThreadState = SIGNAL_STATE;     
+    break;    
+    
+
+    case ABORT_STATE:
+      fclose (pf_IGCFile);
+       pf_IGCFile = NULL;
+      GetEOSIGCFilename(PathIGCFilename, DownoadIGCFilename);   
+        _stprintf(szEOS_DL_StatusText, _T("%s %s"), DownoadIGCFilename,MsgToken(2415));
+      lk::filesystem::deleteFile( PathIGCFilename); 
+      EOS_IGCReadDialog.DownloadError(REC_ABORTED);
+      EOS_ThreadState = SIGNAL_STATE;       
+    break;
+    
+    case SIGNAL_STATE:       
+      if (bDlgShown)
+        EOS_ThreadState =  IDLE_STATE;
+      
+    break;
+    default:
+    case  IDLE_STATE:
+      SetEOSBinaryModeFlag(false);
+    break;
+  }    
+      
+  return 0;
+}
+
+
+
+
+static bool OnTimer(WndForm *pWnd) {
+  if (pWnd) {    
+    WndForm *pForm = pWnd->GetParentWndForm();
+    if (pForm) {
+     
+      if (EOS_ThreadState == IDLE_STATE) 
+      {
+         pForm->SetTimerNotify(0,NULL); 
+      }  
+      else
+      if (EOS_ThreadState == SIGNAL_STATE) 
+      {
+        pForm->SetTimerNotify(0,NULL); 
+#ifdef EOS_PRPGRESS_DLG
+        CloseIGCProgressDialog();
+#endif     
+        {
+          TCHAR Tmp[STATUS_TXT_LEN];
+
+          switch (EOS_IGCReadDialog.DownloadError()) {
+          case REC_NO_ERROR:
+            _sntprintf(Tmp, STATUS_TXT_LEN, _T("%s\n%s"),
+                       DownoadIGCFilename, MsgToken(2406));
+            break; // 	_@M2406_ "IGC File download complete"
+          case REC_TIMEOUT_ERROR:
+            _tcscpy(Tmp, MsgToken(2407));
+            break; // _@M2407_ "Error: receive timeout
+          case REC_CRC_ERROR:
+            _tcscpy(Tmp, MsgToken(2408));
+            break; // _@M2408_ "Error: CRC checksum fail"
+          case REC_ABORTED:
+            _tcscpy(Tmp, MsgToken(2415));
+            break; // _@M2415_ "IGC Download aborted!"
+          case FILENAME_ERROR:
+            _tcscpy(Tmp, MsgToken(2409));
+            break; // _@M2409_ "Error: invalid filename"
+          case FILE_OPEN_ERROR:
+            _tcscpy(Tmp, MsgToken(2410));
+            break; // _@M2410_ "Error: can't open file"
+          case IGC_RECEIVE_ERROR:
+            _tcscpy(Tmp, MsgToken(2411));
+            break; // _@M2411_ "Error: Block invalid"
+          case REC_NO_DEVICE:
+            _tcscpy(Tmp, MsgToken(2575));
+            break; // _@M2401_ "No Device found"
+          case REC_WRONG_BLOCK: 
+             _tcscpy(Tmp, MsgToken(2574)); // _@M2574_ "wrong block received"
+            break;
+          default:            
+            _tcscpy(Tmp, MsgToken(2412));
+            break; // _@M2412_ "Error: unknown"
+          }
+          if (MessageBoxX(Tmp, MsgToken(2398), mbOk) ==
+              IdYes) // _@M2406_ "Error: communication timeout"Reboot"
+          {
+
+          }
+          bDlgShown = true;
+          
+        }
+ 
+      } else {
+
+#ifdef EOS_PRPGRESS_DLG        
+        IGCProgressDialogText(szEOS_DL_StatusText); // update progress dialog text
+#endif
+      }
+    }
+  }
+  return true;
+}

--- a/Common/Source/Dialogs/dlgIGCProgress.cpp
+++ b/Common/Source/Dialogs/dlgIGCProgress.cpp
@@ -20,7 +20,8 @@
 #include "dlgTools.h"
 #include "dlgIGCProgress.h"
 
-extern void   StopIGCRead(void);
+extern void  StopIGCRead(void);
+extern void  EOS_StopIGCRead(void);
 extern void  OnAbort_IGC_FileRead(void);
 
 static bool OnIGCProgressTimer(WndForm* pWnd);
@@ -155,6 +156,7 @@ void IGCProgressDialogText(const TCHAR *text) {
 	{
 	  CloseIGCProgressDialog();
 	  StopIGCRead();
+      EOS_StopIGCRead();
 	  OnAbort_IGC_FileRead();
 	}
 

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -636,6 +636,7 @@ void LKParseProfileString(const char *sname, const char *svalue) {
 	NMEAParser::ExtractParameter(szTmp,szItem,i++); PortIO[n].POLARDir  = (DataBiIoDir) StrTol(szItem);
   NMEAParser::ExtractParameter(szTmp,szItem,i++); PortIO[n].DirLink   = (DataBiIoDir) StrTol(szItem);
   NMEAParser::ExtractParameter(szTmp,szItem,i++); PortIO[n].T_TRGTDir = (DataTP_Type) StrTol(szItem);
+    NMEAParser::ExtractParameter(szTmp,szItem,i++); PortIO[n].QNHDir    = (DataBiIoDir) StrTol(szItem);
 
 
       }

--- a/Common/Source/LKProfileResetDefault.cpp
+++ b/Common/Source/LKProfileResetDefault.cpp
@@ -442,6 +442,7 @@ void LKProfileResetDefault() {
     PortIO[i].POLARDir  = BiDirOff;
     PortIO[i].DirLink   = BiDirOff;
     PortIO[i].T_TRGTDir = TP_VTARG;
+    PortIO[i].QNHDir    = BiDirInOut;
   }
 
 

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -623,14 +623,14 @@ void LKDeviceSave(const TCHAR *szFile)
   for(int n = 0; n < NUMDEV; n++)
   {
     TCHAR szTmp[IO_PARAM_SIZE];
-    _sntprintf(szTmp,IO_PARAM_SIZE, _T("%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u"),
+    _sntprintf(szTmp,IO_PARAM_SIZE, _T("%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u"),
 	       (uint)PortIO[n].MCDir    ,(uint)PortIO[n].BUGDir  ,(uint)PortIO[n].BALDir   ,
 	       (uint)PortIO[n].STFDir   ,(uint)PortIO[n].WINDDir ,(uint)PortIO[n].BARODir  ,
 	       (uint)PortIO[n].VARIODir ,(uint)PortIO[n].SPEEDDir,(uint)PortIO[n].R_TRGTDir,
 	       (uint)PortIO[n].RADIODir ,(uint)PortIO[n].TRAFDir ,(uint)PortIO[n].GYRODir  ,
 	       (uint)PortIO[n].GFORCEDir,(uint)PortIO[n].OATDir  ,(uint)PortIO[n].BAT1Dir  ,
 	       (uint)PortIO[n].BAT2Dir  ,(uint)PortIO[n].POLARDir,(uint)PortIO[n].DirLink  ,
-	       (uint)PortIO[n].T_TRGTDir
+	       (uint)PortIO[n].T_TRGTDir,(uint)PortIO[n].QNHDir
 	     );
 
     char szKey[20] = ("");

--- a/Makefile
+++ b/Makefile
@@ -1302,6 +1302,7 @@ DLGS	:=\
 	$(DLG)/dlgIGCProgress.cpp \
 	$(DLG)/dlgFlarmIGCDownload.cpp \
 	$(DLG)/dlgLXIGCDownload.cpp \
+	$(DLG)/dlgEOSIGCDownload.cpp \
 	$(DLG)/dlgWeatherStDetails.cpp \
 	
 	


### PR DESCRIPTION
EOS/ERA/10k fixes & IGC File download
-fix altitude and airspeed trnasormation becuse LX Navigation devices already give true airspeed and true altitude
-IGC file download using binary protocol
-EOS/ERA/10k need at least Firmware revision 1.6x otherwise not fully functional
-fixed QNH direction selection
Important:
-also added QNH direction to Nano3 driver (else critical bug due to shred dialog resource)
