### PR TITLE
hide airspace 0m MSL top

### DIFF
--- a/Common/Header/LKAirspace.h
+++ b/Common/Header/LKAirspace.h
@@ -287,7 +287,7 @@ public:
 
     static void ResetSideviewNearestInstance() { _sideview_nearest_instance = NULL; }
     static CAirspace* GetSideviewNearestInstance() { return _sideview_nearest_instance; }
-
+    BOOL Is0mMSL(void){return((Top()->Base == abMSL) && (Top()->Altitude <= 0));}
 protected:
     // polygon points : circular airspace are also stored like polygon because that avoid to calculate geographic coordinate for each drawing
     // previous version draw circular airspace using circle, but it's wrong, circle in geographic coordinate are ellipsoid in screen coordinate.

--- a/Common/Source/Draw/DrawAirSpaces.cpp
+++ b/Common/Source/Draw/DrawAirSpaces.cpp
@@ -66,6 +66,7 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
        // They have to be draw later, because inside border area have to be in correct color,
        // not the color of the bigger airspace above this small one.
       for (itr=airspaces_to_draw.rbegin(); itr != airspaces_to_draw.rend(); ++itr) {
+         if(!(((*itr)->Top()->Base == abMSL) && ((*itr)->Top()->Altitude <= 0))) {
           if ((*itr)->DrawStyle() == adsFilled) {
             airspace_type = (*itr)->Type();
             if (!found) {
@@ -78,10 +79,12 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
             hdcbuffer.SelectObject(hAirspaceBrushes[iAirspaceBrush[airspace_type]]);
             (*itr)->Draw(hdcbuffer, true);
             (*itr)->Draw(hdcMask, false);
+          }
         }
       }//for
     } else {
       for (it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
+         if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) {
           if ((*it)->DrawStyle() == adsFilled) {
             airspace_type = (*it)->Type();
             if (!found) {
@@ -93,6 +96,7 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
             // get brush, can be solid or a 1bpp bitmap
             TempSurface.SelectObject(hAirspaceBrushes[iAirspaceBrush[airspace_type]]);
             (*it)->Draw(TempSurface, true);
+          }
         }
       }//for
     }
@@ -117,19 +121,22 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
     ScopeLock guard(CAirspaceManager::Instance().MutexRef());
       for (it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
         if ((*it)->DrawStyle()) {
-          airspace_type = (*it)->Type();
-          if (!found) {
-            ClearAirSpace(true, rc);
-            found = true;
+          if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) {
+            airspace_type = (*it)->Type();
+            if (!found) {
+              ClearAirSpace(true, rc);
+              found = true;
+            }
+
+            if ( (((*it)->DrawStyle()==adsFilled)&&!outlined_only&&!borders_only)  ^ (asp_selected_flash && (*it)->Selected()) ) {
+              TempSurface.SelectObject(LK_BLACK_PEN);
+            } else {
+              TempSurface.SelectObject(hAirspacePens[airspace_type]);
+            }
+            if(((*it)->DrawStyle()==adsDisabled))
+              TempSurface.SelectObject(LKPen_Grey_N1);
+            (*it)->Draw(TempSurface, false);
           }
-          if ( (((*it)->DrawStyle()==adsFilled)&&!outlined_only&&!borders_only)  ^ (asp_selected_flash && (*it)->Selected()) ) {
-            TempSurface.SelectObject(LK_BLACK_PEN);
-          } else {
-            TempSurface.SelectObject(hAirspacePens[airspace_type]);
-          }
-		  if(((*it)->DrawStyle()==adsDisabled))
-		    TempSurface.SelectObject(LKPen_Grey_N1);
-          (*it)->Draw(TempSurface, false);
         }
       }//for
     }

--- a/Common/Source/Draw/DrawAirSpaces.cpp
+++ b/Common/Source/Draw/DrawAirSpaces.cpp
@@ -66,7 +66,7 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
        // They have to be draw later, because inside border area have to be in correct color,
        // not the color of the bigger airspace above this small one.
       for (itr=airspaces_to_draw.rbegin(); itr != airspaces_to_draw.rend(); ++itr) {
-         if(!(((*itr)->Top()->Base == abMSL) && ((*itr)->Top()->Altitude <= 0))) {
+         if(!(*itr)->Is0mMSL()) {
           if ((*itr)->DrawStyle() == adsFilled) {
             airspace_type = (*itr)->Type();
             if (!found) {
@@ -84,7 +84,7 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
       }//for
     } else {
       for (it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
-         if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) {
+         if(!(*it)->Is0mMSL()) {
           if ((*it)->DrawStyle() == adsFilled) {
             airspace_type = (*it)->Type();
             if (!found) {
@@ -121,7 +121,7 @@ void MapWindow::DrawAirSpacePattern(LKSurface& Surface, const RECT& rc)
     ScopeLock guard(CAirspaceManager::Instance().MutexRef());
       for (it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
         if ((*it)->DrawStyle()) {
-          if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) {
+          if(!(*it)->Is0mMSL()) {
             airspace_type = (*it)->Type();
             if (!found) {
               ClearAirSpace(true, rc);

--- a/Common/Source/Draw/DrawAirSpacesBorders.cpp
+++ b/Common/Source/Draw/DrawAirSpacesBorders.cpp
@@ -22,7 +22,7 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
        * draw underlying aispaces first (reverse order) with bigger pen
        * *********************************************************************/
       for (CAirspaceList::const_reverse_iterator it=airspaces_to_draw.rbegin(); it != airspaces_to_draw.rend(); ++it) {
-        if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) 
+        if(!(*it)->Is0mMSL()) 
         {  // don't draw on map if upper limit is on sea level or below
           if ((*it)->DrawStyle()) {
 
@@ -45,7 +45,7 @@ void MapWindow::DrawAirSpaceBorders(LKSurface& Surface, const RECT& rc)
        ***********************************************************************/
 
       for (CAirspaceList::const_iterator it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
-        if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) 
+        if(!(*it)->Is0mMSL())  
         {  // don't draw on map if upper limit is on sea level or below
           if ((*it)->DrawStyle() ) {
             if ( asp_selected_flash && (*it)->Selected() ) {

--- a/Common/Source/Draw/MapWindowA.cpp
+++ b/Common/Source/Draw/MapWindowA.cpp
@@ -117,7 +117,7 @@ DrawAirSpaceBorders(Surface, rc);
        // They have to be draw later, because inside border area have to be in correct color,
        // not the color of the bigger airspace above this small one.
       for (itr=airspaces_to_draw.rbegin(); itr != airspaces_to_draw.rend(); ++itr) {
-         if(!(((*itr)->Top()->Base == abMSL) && ((*itr)->Top()->Altitude <= 0))) {
+         if(!((*itr)->Is0mMSL())) {
             if ((*itr)->DrawStyle() == adsFilled) {
               airspace_type = (*itr)->Type();
               if (!found) {
@@ -134,7 +134,7 @@ DrawAirSpaceBorders(Surface, rc);
     } else {
        // Draw in direct order!
       for (it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
-         if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) {
+         if(!(*it)->Is0mMSL())  {
             if ((*it)->DrawStyle() == adsFilled) {
               airspace_type = (*it)->Type();
               if (!found) {
@@ -218,7 +218,7 @@ void MapWindow::DrawTptAirSpace(LKSurface& Surface, const RECT& rc) {
     for (auto it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
 
         if (((*it)->DrawStyle() == adsHidden) ||
-          ((  (*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))){
+          ((*it)->Is0mMSL()) ){
           continue;  // don't draw on map if hidden or upper limit is on sea level or below
         }
 

--- a/Common/Source/Draw/MapWindowA.cpp
+++ b/Common/Source/Draw/MapWindowA.cpp
@@ -117,6 +117,7 @@ DrawAirSpaceBorders(Surface, rc);
        // They have to be draw later, because inside border area have to be in correct color,
        // not the color of the bigger airspace above this small one.
       for (itr=airspaces_to_draw.rbegin(); itr != airspaces_to_draw.rend(); ++itr) {
+         if(!(((*itr)->Top()->Base == abMSL) && ((*itr)->Top()->Altitude <= 0))) {
             if ((*itr)->DrawStyle() == adsFilled) {
               airspace_type = (*itr)->Type();
               if (!found) {
@@ -128,10 +129,12 @@ DrawAirSpaceBorders(Surface, rc);
               (*itr)->Draw(hdcbuffer, true);
               (*itr)->Draw(hdcMask, false);
             }
+          }
       }//for
     } else {
        // Draw in direct order!
       for (it=airspaces_to_draw.begin(); it != airspaces_to_draw.end(); ++it) {
+         if(!(((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) {
             if ((*it)->DrawStyle() == adsFilled) {
               airspace_type = (*it)->Type();
               if (!found) {
@@ -142,6 +145,7 @@ DrawAirSpaceBorders(Surface, rc);
               TempSurface.SelectObject(GetAirSpaceSldBrushByClass(airspace_type));
               (*it)->Draw(TempSurface, true);
             }
+          }
       }//for
     }//else borders_only
     }//mutex release


### PR DESCRIPTION
don't draw airspaces defined with 0m MSL top also for pattern and outline modes as well like semi transparent.
This is used to hide specific airspaces e.g. for radio frequencies of FIS (Flight information service) regions.