### PR TITLE
store serial numbers in device descriptor (not in  global GPS data)

### DIFF
--- a/Common/Header/Parser.h
+++ b/Common/Header/Parser.h
@@ -144,11 +144,7 @@ struct NMEA_INFO
   int  FLARMTRACE_iLastPtr;
   FANET_WEATHER FANET_Weather[MAXFANETWEATHER];
   FANET_NAME FanetName[MAXFANETDEVICES];
-#ifdef DEVICE_SERIAL
-  int HardwareId;
-  int SerialNumber;
-  double SoftwareVer;
-#endif
+
   #if LOGFRECORD
   int SatelliteIDs[MAXSATELLITES];
   #endif

--- a/Common/Header/device.h
+++ b/Common/Header/device.h
@@ -167,7 +167,11 @@ struct DeviceDescriptor_t {
   unsigned ErrTx;
   // Com ports hearth beats, based on LKHearthBeats
   unsigned HB;
-  
+#ifdef DEVICE_SERIAL
+  int HardwareId;
+  int SerialNumber;
+  double SoftwareVer;
+#endif
   NMEAParser nmeaParser;
 //  DeviceIO PortIO[NUMDEV];
   void InitStruct(int i);

--- a/Common/Source/Calc/Vario.cpp
+++ b/Common/Source/Calc/Vario.cpp
@@ -19,7 +19,8 @@ bool VarioAvailable(const NMEA_INFO& Info) {
 }
 
 void UpdateVarioSource( NMEA_INFO& Info, const DeviceDescriptor_t& d, double Vario) {
-  if((unsigned)d.PortNumber <= Info.VarioSourceIdx) {
+  if((unsigned)d.PortNumber <= Info.VarioSourceIdx) 
+  {
 
     Info.VarioSourceIdx = d.PortNumber;
     Info.Vario = Vario;

--- a/Common/Source/Calc/Vario.cpp
+++ b/Common/Source/Calc/Vario.cpp
@@ -18,9 +18,17 @@ bool VarioAvailable(const NMEA_INFO& Info) {
   return (!ReplayLogger::IsEnabled()) && (Info.VarioSourceIdx < std::numeric_limits<unsigned>::max());
 }
 
+const DeviceDescriptor_t* getVarioDevice(const NMEA_INFO& Info) {
+  if (VarioAvailable(Info)) {
+    if (Info.VarioSourceIdx < std::size(DeviceList)) {
+      return &DeviceList[Info.VarioSourceIdx];
+    }
+  }
+  return nullptr;
+}
+
 void UpdateVarioSource( NMEA_INFO& Info, const DeviceDescriptor_t& d, double Vario) {
-  if((unsigned)d.PortNumber <= Info.VarioSourceIdx) 
-  {
+  if((unsigned)d.PortNumber <= Info.VarioSourceIdx) {
 
     Info.VarioSourceIdx = d.PortNumber;
     Info.Vario = Vario;

--- a/Common/Source/Calc/Vario.h
+++ b/Common/Source/Calc/Vario.h
@@ -19,6 +19,8 @@ void ResetVarioAvailable(NMEA_INFO& Info);
 
 bool VarioAvailable(const NMEA_INFO& Info);
 
+const DeviceDescriptor_t* getVarioDevice(const NMEA_INFO& Info);
+
 void Vario(const NMEA_INFO& Info, DERIVED_INFO& Calculated);
 
 #endif // _CALC_VARIO_H_

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -446,6 +446,12 @@ void DeviceDescriptor_t::InitStruct(int i) {
     iSharedPort = -1;
     m_bAdvancedMode = false;
     bNMEAOut = false;
+
+#ifdef DEVICE_SERIAL
+    HardwareId = 0;
+    SerialNumber = 0;
+    SoftwareVer = 0;
+#endif
 }
 
 bool devNameCompare(const DeviceRegister_t& dev, const TCHAR *DeviceName) {

--- a/Common/Source/Devices/devLX.cpp
+++ b/Common/Source/Devices/devLX.cpp
@@ -179,7 +179,7 @@ TCHAR ctemp[180];
 static int NoMsg=0;
 static int oldSerial=0;
 if(_tcslen(String) < 180)
-  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
+  if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -188,23 +188,23 @@ if(_tcslen(String) < 180)
     StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);
-	pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-	oldSerial = pGPS->SerialNumber;
-	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+	d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+	oldSerial = d->SerialNumber;
+	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,2);
-	pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+	d->SoftwareVer= StrToDouble(ctemp,NULL);
+	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,3);
-    pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+    d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
 	StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
-    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
     DoStatusMessage(ctemp);
   }
   // nothing to do

--- a/Common/Source/Devices/devLX16xx.cpp
+++ b/Common/Source/Devices/devLX16xx.cpp
@@ -391,7 +391,7 @@ TCHAR ctemp[180];
 static int NoMsg=0;
 static int oldSerial=0;
 if(_tcslen(String) < 180)
-  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
+  if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -401,23 +401,23 @@ if(_tcslen(String) < 180)
     StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);
-	pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-	oldSerial = pGPS->SerialNumber;
-	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+	d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+	oldSerial = d->SerialNumber;
+	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,2);
-	pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+	d->SoftwareVer= StrToDouble(ctemp,NULL);
+	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,3);
-    pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+    d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
 	StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
-    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
     DoStatusMessage(ctemp);
   }
   // nothing to do

--- a/Common/Source/Devices/devLXNano3.cpp
+++ b/Common/Source/Devices/devLXNano3.cpp
@@ -1549,7 +1549,7 @@ TCHAR ctemp[MAX_NMEA_LEN];
 static int NoMsg=0;
 static int oldSerial=0;
 if(_tcslen(String) < 180)
-  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
+  if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
     NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -1558,23 +1558,23 @@ if(_tcslen(String) < 180)
     StartupStore(_T(". %s\n"),ctemp);
 
     NMEAParser::ExtractParameter(String,ctemp,1);
-    pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-    oldSerial = pGPS->SerialNumber;
-    _stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+    d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+    oldSerial = d->SerialNumber;
+    _stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
     StartupStore(_T(". %s\n"),ctemp);
 
     NMEAParser::ExtractParameter(String,ctemp,2);
-    pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-    _stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+    d->SoftwareVer= StrToDouble(ctemp,NULL);
+    _stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
     StartupStore(_T(". %s\n"),ctemp);
 
     NMEAParser::ExtractParameter(String,ctemp,3);
-    pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-    _stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+    d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+    _stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
     StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
-    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
     DoStatusMessage(ctemp);
   }
   // nothing to do
@@ -2405,7 +2405,7 @@ TCHAR  szTmp[MAX_NMEA_LEN];
   {
     NMEAParser::ExtractParameter(sentence,szTmp,5);
     {
-      info->SerialNumber = (int) StrToDouble(szTmp,NULL);
+      d->SerialNumber = (int) StrToDouble(szTmp,NULL);
     }
 
     double Batt;

--- a/Common/Source/Devices/devLXNano3.cpp
+++ b/Common/Source/Devices/devLXNano3.cpp
@@ -2403,11 +2403,14 @@ TCHAR  szTmp[MAX_NMEA_LEN];
 
   NMEAParser::ExtractParameter(sentence,szTmp,0);
   {
+#ifdef DEVICE_SERIAL     
     NMEAParser::ExtractParameter(sentence,szTmp,5);
     {
-      d->SerialNumber = (int) StrToDouble(szTmp,NULL);
-    }
 
+      d->SerialNumber = (int) StrToDouble(szTmp,NULL);
+
+    }
+#endif      
     double Batt;
     if (ParToDouble(sentence, 7, &Batt))
     {

--- a/Common/Source/Devices/devLXV7.cpp
+++ b/Common/Source/Devices/devLXV7.cpp
@@ -428,7 +428,7 @@ bool DevLXV7::LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* pGPS)
   static int NoMsg=0;
   static int oldSerial=0;
 if(_tcslen(String) < 180) {
-  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
+  if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -438,23 +438,23 @@ if(_tcslen(String) < 180) {
     StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);
-	pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-	oldSerial = pGPS->SerialNumber;
-	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+	d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+	oldSerial = d->SerialNumber;
+	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,2);
-	pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+	d->SoftwareVer= StrToDouble(ctemp,NULL);
+	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,3);
-    pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+    d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
 	StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
-    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
     DoStatusMessage(ctemp);
   }
 }

--- a/Common/Source/Devices/devLXV7_EXP.cpp
+++ b/Common/Source/Devices/devLXV7_EXP.cpp
@@ -627,7 +627,7 @@ TCHAR ctemp[180];
 static int NoMsg=0;
 static int oldSerial=0;
 if(_tcslen(String) < 180)
-  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
+  if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -636,23 +636,23 @@ if(_tcslen(String) < 180)
     StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);
-	pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-	oldSerial = pGPS->SerialNumber;
-	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+	d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+	oldSerial = d->SerialNumber;
+	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,2);
-	pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+	d->SoftwareVer= StrToDouble(ctemp,NULL);
+	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,3);
-    pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+    d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
 	StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
-    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
     DoStatusMessage(ctemp);
   }
   // nothing to do

--- a/Common/Source/Devices/devLXV7easy.cpp
+++ b/Common/Source/Devices/devLXV7easy.cpp
@@ -129,7 +129,7 @@ bool LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* pGPS)
 
     if(_tcslen(String) >= 180) return true;
 
-    if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5)) {
+    if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5)) {
         NoMsg++ ;
         NMEAParser::ExtractParameter(String,ctemp,0);
         if(_tcslen(ctemp) < DEVNAMESIZE)
@@ -138,24 +138,24 @@ bool LXWP1(PDeviceDescriptor_t d, const TCHAR* String, NMEA_INFO* pGPS)
         StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,1);
-	pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-	oldSerial = pGPS->SerialNumber;
-	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+	d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+	oldSerial = d->SerialNumber;
+	_stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,2);
-	pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+	d->SoftwareVer= StrToDouble(ctemp,NULL);
+	_stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
 	StartupStore(_T(". %s\n"),ctemp);
 
 	NMEAParser::ExtractParameter(String,ctemp,3);
-        pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+        d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+	_stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
 	StartupStore(_T(". %s\n"),ctemp);
-        _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+        _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
 
         DoStatusMessage(ctemp);
-        _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+        _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
         DoStatusMessage(ctemp);
     }
 #endif

--- a/Common/Source/Devices/devLX_EOS_ERA.cpp
+++ b/Common/Source/Devices/devLX_EOS_ERA.cpp
@@ -1828,7 +1828,7 @@ static int iNoFlights=0;
       if(IsDirInput(PortIO[d->PortNumber].QNHDir))
       { 
         _stprintf( szTmp, _T("%4.0f hPa"),fTmp);      
-        SetDataText( _QNH,   szTmp);
+        if(Values(d)) SetDataText( _QNH,   szTmp);
         static double oldQNH = -1;
         if ( fabs( oldQNH - fTmp) > 0.1)
         {
@@ -1937,7 +1937,7 @@ double fTmp;
 
   if(ParToDouble(sentence, ParNo++, &fTmp)) { // Outside air temperature in °C. Left empty if OAT value not valid
     _sntprintf(szTmp, MAX_NMEA_LEN, _T("%4.2f°C ($LXDT)"),fTmp);
-    SetDataText(_OAT,  szTmp);
+     if(Values(d)) SetDataText(_OAT,  szTmp);
     if(IsDirInput(PortIO[d->PortNumber].OATDir))
     {
       info->OutsideAirTemperature = fTmp;
@@ -1946,7 +1946,7 @@ double fTmp;
   }
   if(ParToDouble(sentence, ParNo++, &fTmp)) { // main power supply voltage
     _sntprintf(szTmp, MAX_NMEA_LEN, _T("%4.2fV ($LXDT)"),fTmp);
-    SetDataText(_BAT1,  szTmp);
+    if(Values(d)) SetDataText(_BAT1,  szTmp);
     if(IsDirInput(PortIO[d->PortNumber].BAT1Dir))
     {
       info->ExtBatt1_Voltage = fTmp;	
@@ -1954,7 +1954,7 @@ double fTmp;
   }
   if(ParToDouble(sentence, ParNo++, &fTmp)) { // Backup battery voltage
     _sntprintf(szTmp, MAX_NMEA_LEN, _T("%4.2fV ($LXDT)"),fTmp);
-    SetDataText(_BAT2,  szTmp);
+     if(Values(d)) SetDataText(_BAT2,  szTmp);
     if(IsDirInput(PortIO[d->PortNumber].BAT2Dir))
     {
       info->ExtBatt2_Voltage = fTmp;	
@@ -2178,7 +2178,7 @@ TCHAR szName[MAX_VAL_STR_LEN];
 #endif
   }
 
-  SetDataText( _T_TRGT,  szName);
+  if(Values(d)) SetDataText( _T_TRGT,  szName);
   DevLX_EOS_ERA::SendNmea(d,szTmp);
 
 return(true);

--- a/Common/Source/Devices/devLX_EOS_ERA.cpp
+++ b/Common/Source/Devices/devLX_EOS_ERA.cpp
@@ -1456,7 +1456,7 @@ TCHAR ctemp[MAX_NMEA_LEN];
 static int NoMsg=0;
 static int oldSerial=0;
 if(_tcslen(String) < 180)
-  if((( pGPS->SerialNumber == 0)  || ( pGPS->SerialNumber != oldSerial)) && (NoMsg < 5))
+  if((( d->SerialNumber == 0)  || ( d->SerialNumber != oldSerial)) && (NoMsg < 5))
   {
     NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
@@ -1465,23 +1465,23 @@ if(_tcslen(String) < 180)
     StartupStore(_T(". %s\n"),ctemp);
 
     NMEAParser::ExtractParameter(String,ctemp,1);
-    pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-    oldSerial = pGPS->SerialNumber;
-    _stprintf(ctemp, _T("%s Serial Number %i"), d->Name, pGPS->SerialNumber);
+    d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+    oldSerial = d->SerialNumber;
+    _stprintf(ctemp, _T("%s Serial Number %i"), d->Name, d->SerialNumber);
     StartupStore(_T(". %s\n"),ctemp);
 
     NMEAParser::ExtractParameter(String,ctemp,2);
-    pGPS->SoftwareVer= StrToDouble(ctemp,NULL);
-    _stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, pGPS->SoftwareVer);
+    d->SoftwareVer= StrToDouble(ctemp,NULL);
+    _stprintf(ctemp, _T("%s Software Vers.: %3.2f"), d->Name, d->SoftwareVer);
     StartupStore(_T(". %s\n"),ctemp);
 
     NMEAParser::ExtractParameter(String,ctemp,3);
-    pGPS->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
-    _stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(pGPS->HardwareId)/10.0);
+    d->HardwareId= (int)(StrToDouble(ctemp,NULL)*10);
+    _stprintf(ctemp, _T("%s Hardware Vers.: %3.2f"), d->Name, (double)(d->HardwareId)/10.0);
     StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
-    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  pGPS->SoftwareVer, (double)(pGPS->HardwareId)/10.0);
+    _stprintf(ctemp, _T("SW Ver: %3.2f HW Ver: %3.2f "),  d->SoftwareVer, (double)(d->HardwareId)/10.0);
     DoStatusMessage(ctemp);
   }
   // nothing to do

--- a/Common/Source/Devices/devWesterboer.cpp
+++ b/Common/Source/Devices/devWesterboer.cpp
@@ -221,12 +221,12 @@ static BOOL PWES0(PDeviceDescriptor_t d, TCHAR *String, NMEA_INFO *pGPS)
 
 
 if(_tcslen(String) < 180)
-  if(((pGPS->SerialNumber == 0) || (oldSerial != SerialNumber)) && (NoMsg < 5))
+  if(((d->SerialNumber == 0) || (oldSerial != SerialNumber)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
-    pGPS->HardwareId= (int)StrToDouble(ctemp,NULL);
-    switch (pGPS->HardwareId)
+    d->HardwareId= (int)StrToDouble(ctemp,NULL);
+    switch (d->HardwareId)
     {
       case 21:  _tcscpy(d->Name, TEXT("VW1010")); break;
       case 22:  _tcscpy(d->Name, TEXT("VW1020")); break;
@@ -235,7 +235,7 @@ if(_tcslen(String) < 180)
     }
 	StartupStore(_T(". %s\n"),ctemp);
 	_stprintf(ctemp, _T("%s  DETECTED"), d->Name);
-	oldSerial = pGPS->SerialNumber;
+	oldSerial = d->SerialNumber;
 	DoStatusMessage(ctemp);
 	StartupStore(_T(". %s\n"),ctemp);
   }
@@ -464,12 +464,12 @@ TCHAR ctemp[180];
 static int NoMsg=0;
 
 if(_tcslen(String) < 180)
-  if(((pGPS->SerialNumber == 0) || (oldSerial	!= SerialNumber)) && (NoMsg < 5))
+  if(((d->SerialNumber == 0) || (oldSerial	!= SerialNumber)) && (NoMsg < 5))
   {
 	NoMsg++ ;
     NMEAParser::ExtractParameter(String,ctemp,0);
-    pGPS->HardwareId= (int)StrToDouble(ctemp,NULL);
-    switch (pGPS->HardwareId)
+    d->HardwareId= (int)StrToDouble(ctemp,NULL);
+    switch (d->HardwareId)
     {
       case 21:  _tcscpy(d->Name, TEXT("VW1010")); break;
       case 22:  _tcscpy(d->Name, TEXT("VW1020")); break;
@@ -480,21 +480,21 @@ if(_tcslen(String) < 180)
 
 
 	NMEAParser::ExtractParameter(String,ctemp,1);
-	pGPS->SerialNumber= (int)StrToDouble(ctemp,NULL);
-	SerialNumber = pGPS->SerialNumber;
+	d->SerialNumber= (int)StrToDouble(ctemp,NULL);
+	SerialNumber = d->SerialNumber;
 
 	NMEAParser::ExtractParameter(String,ctemp,2);
 	int Year = (int)(StrToDouble(ctemp,NULL));
 
 	NMEAParser::ExtractParameter(String,ctemp,3);
-	pGPS->SoftwareVer= StrToDouble(ctemp,NULL)/100.0;
+	d->SoftwareVer= StrToDouble(ctemp,NULL)/100.0;
 
 
 
-    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, pGPS->SerialNumber);
+    _stprintf(ctemp, _T("%s (#%i) DETECTED"), d->Name, d->SerialNumber);
     DoStatusMessage(ctemp);
 	StartupStore(_T(". %s\n"),ctemp);
-    _stprintf(ctemp, _T("SW Ver:%3.2f  HW Ver:%i "),  pGPS->SoftwareVer, Year);
+    _stprintf(ctemp, _T("SW Ver:%3.2f  HW Ver:%i "),  d->SoftwareVer, Year);
     DoStatusMessage(ctemp);
 	StartupStore(_T(". %s\n"),ctemp);
 	oldSerial	=SerialNumber;

--- a/Common/Source/Dialogs/dlgStatus.cpp
+++ b/Common/Source/Dialogs/dlgStatus.cpp
@@ -239,22 +239,17 @@ static void UpdateValuesSystem() {
     if (VarioAvailable(GPS_INFO)) {
 	// LKTOKEN  _@M199_ = "Connected"
 #ifdef DEVICE_SERIAL
-     if(GPS_INFO.HardwareId >0)
+     if(DeviceList[ GPS_INFO.VarioSourceIdx ].HardwareId >0)
      {
 	  TCHAR sDevice[32]={0};
-		if((pDevSecondaryBaroSource != NULL))
-           if(!(pDevSecondaryBaroSource->Disabled))
-           {
-             _stprintf(sDevice, TEXT("%s"), pDevSecondaryBaroSource->Name  );
-           }
 
 		if((pDevPrimaryBaroSource != NULL))
            if(!(pDevPrimaryBaroSource->Disabled))
            {
-             _stprintf(sDevice, TEXT("%s"), pDevPrimaryBaroSource->Name );
+             _stprintf(sDevice, TEXT("%s"), DeviceList[ GPS_INFO.VarioSourceIdx ].Name );
            }
 
-	  _stprintf(Temp,TEXT("%s (%i)"),sDevice, GPS_INFO.HardwareId);
+	  _stprintf(Temp,TEXT("%s (%i)"),sDevice, DeviceList[ GPS_INFO.VarioSourceIdx ].HardwareId);
 		wp->SetText(Temp);
      }
      else

--- a/Common/Source/Dialogs/dlgStatus.cpp
+++ b/Common/Source/Dialogs/dlgStatus.cpp
@@ -236,27 +236,18 @@ static void UpdateValuesSystem() {
 
   wp = (WndProperty*)wf->FindByName(TEXT("prpVario"));
   if (wp) {
-    if (VarioAvailable(GPS_INFO)) {
-	// LKTOKEN  _@M199_ = "Connected"
+    const DeviceDescriptor_t* dev = getVarioDevice(GPS_INFO);
+    if(dev) {
+      const TCHAR* devName = dev->Name;
 #ifdef DEVICE_SERIAL
-     if(DeviceList[ GPS_INFO.VarioSourceIdx ].HardwareId >0)
-     {
-	  TCHAR sDevice[32]={0};
-
-		if((pDevPrimaryBaroSource != NULL))
-           if(!(pDevPrimaryBaroSource->Disabled))
-           {
-             _stprintf(sDevice, TEXT("%s"), DeviceList[ GPS_INFO.VarioSourceIdx ].Name );
-           }
-
-	  _stprintf(Temp,TEXT("%s (%i)"),sDevice, DeviceList[ GPS_INFO.VarioSourceIdx ].HardwareId);
-		wp->SetText(Temp);
-     }
-     else
+      if(dev->HardwareId > 0) {
+        _stprintf(Temp,TEXT("%s (%i)"),dev->Name, dev->HardwareId);
+        devName = Temp;
+      }
 #endif
-	   wp->SetText(MsgToken(199));
+      wp->SetText(devName);
     } else {
-	// LKTOKEN  _@M240_ = "Disconnected"
+      // LKTOKEN  _@M240_ = "Disconnected"
       wp->SetText(MsgToken(240));
     }
     wp->RefreshDisplay();


### PR DESCRIPTION
Important if two devices are connected, otherwise the DoStatusMessage is toggeling between the devices

fixed vario source in status dialog, same problem