### PR TITLE
No checksum if sending '$$$' from the terminal on KOBO

### DIFF
--- a/Common/Source/Dialogs/dlgTerminal.cpp
+++ b/Common/Source/Dialogs/dlgTerminal.cpp
@@ -185,6 +185,14 @@ TCHAR  szCheck[254];
    _tcscat(szStrg,_T("\r\n"));
    return -1;
  }
+
+#if defined(KOBO)
+if ( _tcscmp(szStrg,"$$$") == 0)  { // sent "$$$" probably for puting a RN42 BT chip in command mode
+   _tcscat(szStrg,_T("\r\n"));
+   return -1;
+ }
+#endif
+
  iCheckSum = szStrg[1];
   for (i=2; i < (int)_tcslen(szStrg); i++)
   {

--- a/Common/Source/Dialogs/dlgTerminal.cpp
+++ b/Common/Source/Dialogs/dlgTerminal.cpp
@@ -186,12 +186,10 @@ TCHAR  szCheck[254];
    return -1;
  }
 
-#if defined(KOBO)
 if ( _tcscmp(szStrg,"$$$") == 0)  { // sent "$$$" probably for puting a RN42 BT chip in command mode
    _tcscat(szStrg,_T("\r\n"));
    return -1;
  }
-#endif
 
  iCheckSum = szStrg[1];
   for (i=2; i < (int)_tcslen(szStrg); i++)


### PR DESCRIPTION
The command '$$$' put a RN43 BT module in command mode. No checksum is required in that case.

TODO. Maybe an option to enable/disable/auto the checksum will be more flexible.