### PR TITLE
mark Radio Parameter as changed 

### DIFF
--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -1120,6 +1120,7 @@ bool devDriverActivated(const TCHAR *DeviceName) {
  * @return FALSE if error on one device.
  */
 BOOL devPutVolume(int Volume) {
+  RadioPara.Changed = true;    
   return for_all_device(&DeviceDescriptor_t::PutVolume, Volume);
 
 }
@@ -1130,6 +1131,7 @@ BOOL devPutVolume(int Volume) {
  * @return FALSE if error on one device.
  */
 BOOL devPutSquelch(int Squelch) {
+  RadioPara.Changed = true;    
   return for_all_device(&DeviceDescriptor_t::PutSquelch, Squelch);
 
 }    
@@ -1142,6 +1144,7 @@ BOOL devPutSquelch(int Squelch) {
  * @return FALSE if error on one device.
  */
 BOOL devPutRadioMode(int mode) {
+  RadioPara.Changed = true;    
   return for_all_device(&DeviceDescriptor_t::PutRadioMode, mode);
 }
 
@@ -1150,6 +1153,7 @@ BOOL devPutRadioMode(int mode) {
  * @return FALSE if error on one device.
  */
 BOOL devPutFreqSwap() {
+  RadioPara.Changed = true;    
   return for_all_device(&DeviceDescriptor_t::StationSwap);
 
 }
@@ -1168,6 +1172,7 @@ if( ValidFrequency(Freq))
 {
   RadioPara.ActiveFrequency=  Freq;
 	CopyTruncateString(RadioPara.ActiveName, NAME_SIZE, StationName);
+  RadioPara.Changed = true;    
   return for_all_device(&DeviceDescriptor_t::PutFreqActive, Freq, StationName);
 }
 else
@@ -1181,6 +1186,7 @@ else
 BOOL devPutFreqStandby(double Freq, const TCHAR* StationName) {
   if( ValidFrequency(Freq)) {
 	  RadioPara.PassiveFrequency=  Freq;
+      RadioPara.Changed = true;
 	  CopyTruncateString(RadioPara.PassiveName, NAME_SIZE, StationName);
     return for_all_device(&DeviceDescriptor_t::PutFreqStandby, Freq, StationName);
   } else {

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -1173,6 +1173,9 @@ if( ValidFrequency(Freq))
   RadioPara.ActiveFrequency=  Freq;
 	CopyTruncateString(RadioPara.ActiveName, NAME_SIZE, StationName);
   RadioPara.Changed = true;    
+#if TESTBENCH  
+  StartupStore(TEXT("Radio:   devPutFreqActive %s %7.3f %s"),StationName,Freq,NEWLINE); 
+#endif    
   return for_all_device(&DeviceDescriptor_t::PutFreqActive, Freq, StationName);
 }
 else
@@ -1187,6 +1190,9 @@ BOOL devPutFreqStandby(double Freq, const TCHAR* StationName) {
   if( ValidFrequency(Freq)) {
 	  RadioPara.PassiveFrequency=  Freq;
       RadioPara.Changed = true;
+#if TESTBENCH  
+      StartupStore(TEXT("Radio:   devPutFreqActive %s %7.3f %s"),StationName,Freq,NEWLINE); 
+#endif       
 	  CopyTruncateString(RadioPara.PassiveName, NAME_SIZE, StationName);
     return for_all_device(&DeviceDescriptor_t::PutFreqStandby, Freq, StationName);
   } else {

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -1191,7 +1191,7 @@ BOOL devPutFreqStandby(double Freq, const TCHAR* StationName) {
 	  RadioPara.PassiveFrequency=  Freq;
       RadioPara.Changed = true;
 #if TESTBENCH  
-      StartupStore(TEXT("Radio:   devPutFreqActive %s %7.3f %s"),StationName,Freq,NEWLINE); 
+      StartupStore(TEXT("Radio:   devPutFreqStandby %s %7.3f %s"),StationName,Freq,NEWLINE); 
 #endif       
 	  CopyTruncateString(RadioPara.PassiveName, NAME_SIZE, StationName);
     return for_all_device(&DeviceDescriptor_t::PutFreqStandby, Freq, StationName);

--- a/Common/Source/Dialogs/dlgRadioSettings.cpp
+++ b/Common/Source/Dialogs/dlgRadioSettings.cpp
@@ -153,7 +153,7 @@ static int OnRemoteUpdate(void)
 int Idx=0;
   if(RadioPara.Changed)
   {
-    RadioPara.Changed =FALSE;
+
     TCHAR Name[250];
     if( _tcslen(RadioPara.ActiveName) == 0)
       Idx = SearchStation(RadioPara.ActiveFrequency);
@@ -232,6 +232,9 @@ int Idx=0;
           _stprintf(Name,_T("[Dual On]"));
         if(wpnewDual)
               wpnewDual->SetCaption(Name);
+
+      RadioPara.Changed =FALSE;
+      StartupStore(TEXT("Radio:   OnRemoteUpdate:%s"),NEWLINE);
       return 1;
     }
     return 0;


### PR DESCRIPTION
mark Radio Parameter as changed when changed outside the radio dialog
This will update the radio dialog when changed outside  (e.g. by Best Alternate).