### PR TITLE
add optional labels to overlays.

### DIFF
--- a/Common/Data/Dialogs/dlgOverlays.xml
+++ b/Common/Data/Dialogs/dlgOverlays.xml
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PMML version="3.0" xmlns="http://www.dmg.org/PMML-3-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema_instance" xsi:noNamespaceSchemaLocation="Dialog.xsd">
   <WndForm Name="frmSetOverlays" Type="Dialog" X="0" Y="0" Width="240" Height="240" Caption="_@M2079_" Font="2" >
-    <WndProperty Name="prpTopLeft" Caption="_@M1891_" X="5" Y="-999" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpTopLeft" Caption="_@M1891_" X="5" Y="-999" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpTopMid" Caption="_@M1892_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpTopMid" Caption="_@M1892_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpTopRight" Caption="_@M1893_" X="5" Y="-999" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpTopRight" Caption="_@M1893_" X="5" Y="-999" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpRightTop" Caption="_@M1894_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpRightTop" Caption="_@M1894_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpRightMid" Caption="_@M1895_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpRightMid" Caption="_@M1895_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpRightBottom" Caption="_@M1896_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpRightBottom" Caption="_@M1896_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpLeftTop" Caption="_@M1897_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpLeftTop" Caption="_@M1897_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpLeftMid" Caption="_@M1898_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpLeftMid" Caption="_@M1898_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpLeftBottom" Caption="_@M1899_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpLeftBottom" Caption="_@M1899_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
-    <WndProperty Name="prpLeftDown" Caption="_@M1900_" X="5" Y="-1" Width="-1" Height="20" CaptionWidth="110" Font="2" Help="_@H1293_">
+    <WndProperty Name="prpLeftDown" Caption="_@M1900_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
+      <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
+    </WndProperty>
+    <WndProperty Name="prpOvTitle" Caption="_@M2026_" X="5" Y="-1" Width="-1" Height="19" CaptionWidth="110" Font="2" Help="_@H1293_">
       <DataField Name="" DataType="enum" Min="0" Max="30" Step="1" />
     </WndProperty>
     <WndButton  Caption="_@M186_" X="130" Y="195" Width="105" Height="20" Font="2" OnClickNotify="OnCloseClicked" Tag="1"/>

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -207,6 +207,7 @@ GEXTERN short Overlay_LeftDown;
 GEXTERN short Overlay_RightTop;
 GEXTERN short Overlay_RightMid;
 GEXTERN short Overlay_RightBottom;
+GEXTERN short Overlay_Title;
 
 #ifdef _WGS84
 GEXTERN bool earth_model_wgs84;

--- a/Common/Header/LKProfiles.h
+++ b/Common/Header/LKProfiles.h
@@ -375,6 +375,7 @@ extern const char szRegistryOverlay_RightTop[];
 extern const char szRegistryOverlay_RightMid[];
 extern const char szRegistryOverlay_RightBottom[];
 extern const char szRegistryAdditionalContestRule[];
+extern const char szRegistryOverlay_Title[];
 
 #ifdef _WGS84
 extern const char szRegistry_earth_model_wgs84[];

--- a/Common/Source/Dialogs/dlgOverlays.cpp
+++ b/Common/Source/Dialogs/dlgOverlays.cpp
@@ -37,6 +37,16 @@ static void setVariables(void) {
 	dfe->Set(Overlay_TopLeft);
 	wp->RefreshDisplay();
   }
+  
+  wp = (WndProperty*)wf->FindByName(TEXT("prpOvTitle"));
+  if (wp) {
+	DataField* dfe = wp->GetDataField();
+        dfe->addEnumText(MsgToken(491)); // OFF
+        dfe->addEnumText(MsgToken(894)); // ON
+	dfe->Set(Overlay_Title);
+	wp->RefreshDisplay();
+  }
+
   wp = (WndProperty*)wf->FindByName(TEXT("prpTopMid"));
   if (wp) {
 	DataField* dfe = wp->GetDataField();
@@ -126,10 +136,11 @@ static void setVariables(void) {
 	DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(491)); // OFF
     dfe->addEnumText(MsgToken(2090)); // Default
+    /*
     for (int i=0; i<NumDataOptions; i++) {
       dfe->addEnumText(LKGetText(Data_Options[i].Description));
     }
-    dfe->Sort(2);
+    dfe->Sort(2);*/
     if ( Overlay_RightTop < 2 )
       dfe->Set(Overlay_RightTop);
     else
@@ -141,10 +152,10 @@ static void setVariables(void) {
 	DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(491)); // OFF
     dfe->addEnumText(MsgToken(2090)); // Default
-    for (int i=0; i<NumDataOptions; i++) {
+ /*   for (int i=0; i<NumDataOptions; i++) {
       dfe->addEnumText(LKGetText(Data_Options[i].Description));
     }
-    dfe->Sort(2);
+    dfe->Sort(2);*/
     if ( Overlay_RightMid < 2 )
       dfe->Set(Overlay_RightMid);
     else
@@ -156,10 +167,10 @@ static void setVariables(void) {
 	DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(491)); // OFF
     dfe->addEnumText(MsgToken(2090)); // Default
-    for (int i=0; i<NumDataOptions; i++) {
+ /*   for (int i=0; i<NumDataOptions; i++) {
       dfe->addEnumText(LKGetText(Data_Options[i].Description));
     }
-    dfe->Sort(2);
+    dfe->Sort(2);*/
     if ( Overlay_RightBottom < 2 )
       dfe->Set(Overlay_RightBottom);
     else
@@ -265,6 +276,10 @@ void dlgOverlaysShowModal(void){
   wp = (WndProperty*)wf->FindByName(TEXT("prpTopLeft"));
   if (wp) Overlay_TopLeft = (wp->GetDataField()->GetAsInteger());
 
+  wp = (WndProperty*)wf->FindByName(TEXT("prpOvTitle"));
+  if (wp) Overlay_Title = (wp->GetDataField()->GetAsInteger());
+ 
+
   wp = (WndProperty*)wf->FindByName(TEXT("prpTopMid"));
   if (wp) Overlay_TopMid = (wp->GetDataField()->GetAsInteger());
 
@@ -336,6 +351,8 @@ void dlgOverlaysShowModal(void){
     else
       Overlay_RightBottom = dataField+1000-2; // Custom overlay have a code LKValue+1000
   }
+  
+
 
   delete wf;
   wf = NULL;

--- a/Common/Source/Dialogs/dlgOverlays.cpp
+++ b/Common/Source/Dialogs/dlgOverlays.cpp
@@ -136,11 +136,11 @@ static void setVariables(void) {
 	DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(491)); // OFF
     dfe->addEnumText(MsgToken(2090)); // Default
-    /*
+    
     for (int i=0; i<NumDataOptions; i++) {
       dfe->addEnumText(LKGetText(Data_Options[i].Description));
     }
-    dfe->Sort(2);*/
+    dfe->Sort(2);
     if ( Overlay_RightTop < 2 )
       dfe->Set(Overlay_RightTop);
     else
@@ -152,10 +152,10 @@ static void setVariables(void) {
 	DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(491)); // OFF
     dfe->addEnumText(MsgToken(2090)); // Default
- /*   for (int i=0; i<NumDataOptions; i++) {
+   for (int i=0; i<NumDataOptions; i++) {
       dfe->addEnumText(LKGetText(Data_Options[i].Description));
     }
-    dfe->Sort(2);*/
+    dfe->Sort(2);
     if ( Overlay_RightMid < 2 )
       dfe->Set(Overlay_RightMid);
     else
@@ -167,10 +167,10 @@ static void setVariables(void) {
 	DataField* dfe = wp->GetDataField();
     dfe->addEnumText(MsgToken(491)); // OFF
     dfe->addEnumText(MsgToken(2090)); // Default
- /*   for (int i=0; i<NumDataOptions; i++) {
+   for (int i=0; i<NumDataOptions; i++) {
       dfe->addEnumText(LKGetText(Data_Options[i].Description));
     }
-    dfe->Sort(2);*/
+    dfe->Sort(2);
     if ( Overlay_RightBottom < 2 )
       dfe->Set(Overlay_RightBottom);
     else

--- a/Common/Source/Draw/LKDrawLook8000.cpp
+++ b/Common/Source/Draw/LKDrawLook8000.cpp
@@ -808,11 +808,12 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
           cy = topmargin;
         }
         LKWriteText(Surface, BufferValue, cx, cy,
-                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);          
+                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);     
+        /*
         if(Overlay_Title){
           Surface.SelectObject(LK8OverlaySmallFont);                
           LKWriteText(Surface, BufferTitle, cx , cy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
-        }          
+        } */         
  
     }
 

--- a/Common/Source/Draw/LKDrawLook8000.cpp
+++ b/Common/Source/Draw/LKDrawLook8000.cpp
@@ -32,6 +32,7 @@
 #define RIGHTMARGIN   NIBLSCALE(2) // spacing on right border
 #define MAPSCALE_SIZE NIBLSCALE(46)
 
+
 namespace {
 
 // For Overlay we use :  0       : Hidden
@@ -251,11 +252,11 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         //
         // TARGET DISTANCE
         //
-
+        LKFormatValue(LK_START_DIST, false, BufferValue, BufferUnit, BufferTitle);
         if (gateinuse >= -1) {
             // if we are still painting , it means we did not start yet..so we use colors
             if (!CorrectSide()) distcolor = AMBERCOLOR;
-            LKFormatValue(LK_START_DIST, false, BufferValue, BufferUnit, BufferTitle);
+         
         } else {
             if (!Overlay_TopRight) goto _skip_TopRight;
             // Using FormatDist will give PGs 3 decimal units on overlay only
@@ -266,16 +267,24 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
 
         if ( !OverlayClock && ScreenLandscape && (!((gTaskType==TSK_GP) && UseGates()))) {
             _stprintf(BufferValue + _tcslen(BufferValue), _T(" %s"), BufferUnit);
-            LKWriteText(Surface, BufferValue, compass.cx, topmargin, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+             Surface.GetTextSize(BufferValue, &TextSize);
+            LKWriteText(Surface, BufferValue, compass.cx+TextSize.cx, topmargin, WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+             if(Overlay_Title){
+                  Surface.SelectObject(LK8OverlaySmallFont);                          
+                  LKWriteText(Surface, BufferTitle, compass.cx, topmargin-SizeSmallFont.cy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                }
         } else {
             LKWriteText(Surface, BufferValue, rcx , topmargin + SizeMediumFont.cy, WTMODE_OUTLINED, WTALIGN_LEFT, distcolor, true);
-
+            Surface.GetTextSize(BufferValue, &TextSize);
             if (!HideUnits) {
-                Surface.GetTextSize(BufferValue, &TextSize);
+             
                 Surface.SelectObject(MapScaleFont);
                 LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, yDistUnit, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
             }
-
+             if(Overlay_Title){
+                  Surface.SelectObject(LK8OverlaySmallFont);                          
+                  LKWriteText(Surface, BufferTitle, rcx + TextSize.cx, yDistUnit-SizeSmallFont.cy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                }
         }
 
         _skip_TopRight:
@@ -437,8 +446,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 }
 
                 color=(redwarning&&!isOverlayCustom(Overlay_RightBottom))?AMBERCOLOR:OverColorRef;
-                LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, WTMODE_OUTLINED, WTALIGN_RIGHT, color, true);
-
+                LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, WTMODE_OUTLINED, WTALIGN_RIGHT, color, true); 
                 //
                 // (GLIDERS) SAFETY ALTITUDE INDICATOR
                 // For PGs there is a separate drawing, although it should be identical right now.
@@ -448,7 +456,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                     Surface.SelectObject(LK8OverlaySmallFont);
                     _stprintf(BufferValue, _T(" + %.0f %s "), SAFETYALTITUDEARRIVAL / 10 * ALTITUDEMODIFY,
                             Units::GetUnitName(Units::GetUserAltitudeUnit()));
-                    LKWriteBoxedText(Surface, rc, BufferValue, rcx, yAltSafety, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);
+                    LKWriteBoxedText(Surface, rc, BufferValue, rcx, yAltSafety, WTALIGN_RIGHT, RGB_WHITE, RGB_WHITE);                    
                 }
                 _skip_glider_RightBottom: ;
             } else { // ISGLIDER
@@ -476,9 +484,17 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 } else {
                     LKFormatAltDiff(OverTargetIndex, false, BufferValue, BufferUnit);
                 }
+                if(Overlay_Title){
+                  Surface.SelectObject(LK8OverlaySmallFont);      
+                  LKWriteText(Surface, BufferTitle, rcx, yrightoffset-SizeSmallFont.cy , WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                }  
+                
                 color=(redwarning&&!isOverlayCustom(Overlay_RightBottom))?AMBERCOLOR:OverColorRef;
                 LKWriteText(Surface, BufferValue, rcx, yrightoffset - fixBigInterline, WTMODE_OUTLINED, WTALIGN_RIGHT,color, true);
-
+                if(Overlay_Title){
+                  Surface.SelectObject(LK8OverlaySmallFont);      
+                  LKWriteText(Surface, BufferTitle, rcx, yrightoffset+SizeSmallFont.cy , WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                 }  
                 //
                 // SAFETY ALTITUDE INDICATOR (FOR PARAGLIDERS)
                 // Should be identical to that for other aircrafts, normally.
@@ -491,7 +507,7 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
 
                 }
                 _skip_para_RightBottom: ;
-            } 
+            }
         } // end no UseGates()
 
 
@@ -563,7 +579,11 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
                 LKWriteText(Surface, amcmode, rightmargin + NIBLSCALE(1), yMcMode,
                         // We paint white on black always here, but WriteText can invert them. So we reverse.
                         WTMODE_NORMAL, WTALIGN_LEFT, INVERTCOLORS?RGB_WHITE:RGB_BLACK, true);
-
+                
+                if(Overlay_Title){
+                  Surface.SelectObject(LK8OverlaySmallFont);                          
+                  LKWriteText(Surface, BufferTitle, rightmargin, yMcMode-SizeSmallFont.cy/2, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+                }
             } // AutoMacCready true AUTO MC INDICATOR
         } // overlay RighTop
     }
@@ -599,11 +619,16 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         //
         rcy = yMcValue;
         LKWriteText(Surface, BufferValue, rcx, rcy+yoffset, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
-        if (!HideUnits) {
+
             Surface.GetTextSize(BufferValue, &TextSize);
+        if (!HideUnits) {    
             Surface.SelectObject(MapScaleFont);
             LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, rcy+yoffset+unitbigoffset, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
+        if(Overlay_Title){
+          Surface.SelectObject(LK8OverlaySmallFont);                 
+          LKWriteText(Surface, BufferTitle, rcx + TextSize.cx, rcy+yoffset+unitbigoffset-SizeSmallFont.cy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        }        
     } // LeftTop
 
     //
@@ -634,11 +659,17 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         rcy = yrightoffset - SizeBigFont.cy +yoffset;
 
         LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
-        if (!HideUnits) {
-            Surface.GetTextSize(BufferValue, &TextSize);
+        Surface.GetTextSize(BufferValue, &TextSize);
+        if (!HideUnits) {  
             Surface.SelectObject(MapScaleFont);
             LKWriteText(Surface, BufferUnit, rcx + TextSize.cx , rcy + unitbigoffset, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
+     
+        if(Overlay_Title){
+          Surface.SelectObject(LK8OverlaySmallFont);         
+          LKWriteText(Surface, BufferTitle, rcx + TextSize.cx, rcy + unitbigoffset-SizeSmallFont.cy , WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        }
+     
     } // LeftMid
 
     //
@@ -661,12 +692,16 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
         Surface.SelectObject(LK8OverlayBigFont);
         rcy=yrightoffset - fixBigInterline+yoffset;
         LKWriteText(Surface, BufferValue, rcx, rcy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        Surface.GetTextSize(BufferValue, &TextSize);
         if (!HideUnits) {
-            Surface.GetTextSize(BufferValue, &TextSize);
             Surface.SelectObject(MapScaleFont);
             LKWriteText(Surface, BufferUnit, rcx + TextSize.cx, rcy + unitbigoffset,
                 WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
+        if(Overlay_Title){
+          Surface.SelectObject(LK8OverlaySmallFont);     
+          LKWriteText(Surface, BufferTitle, rcx + TextSize.cx, rcy + unitbigoffset-SizeSmallFont.cy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        }        
     }
 
     //
@@ -675,13 +710,23 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
     if ((OverlayClock && Overlay_TopRight) || ((gTaskType==TSK_GP) && UseGates())) {
         LKFormatValue(LK_TIME_LOCALSEC, false, BufferValue, BufferUnit, BufferTitle);
         Surface.SelectObject(LK8OverlayMediumFont);
+        int cx,cy;
         if (!ScreenLandscape) {
             LKWriteText(Surface, BufferValue, rightmargin, compass.cy,
-                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);    
+            cx = rightmargin;
+            cy = compass.cy;
         } else {
-            LKWriteText(Surface, BufferValue, compass.cx, topmargin,
-                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);
+          cx = compass.cx;
+          cy = topmargin;
         }
+        LKWriteText(Surface, BufferValue, cx, cy,
+                WTMODE_OUTLINED, WTALIGN_RIGHT, OverColorRef, true);          
+        if(Overlay_Title){
+          Surface.SelectObject(LK8OverlaySmallFont);                
+          LKWriteText(Surface, BufferTitle, cx , cy, WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        }          
+ 
     }
 
     //
@@ -707,6 +752,10 @@ void MapWindow::DrawLook8000(LKSurface& Surface, const RECT& rc) {
             LKWriteText(Surface, BufferUnit, leftmargin + TextSize.cx, yLeftWind + unitmediumoffset,
                 WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
         }
+        if(Overlay_Title){
+          Surface.SelectObject(LK8OverlaySmallFont);      
+          LKWriteText(Surface, BufferTitle, leftmargin + TextSize.cx, yLeftWind+SizeSmallFont.cy/2 , WTMODE_OUTLINED, WTALIGN_LEFT, OverColorRef, true);
+        }   
     } // LeftDown
 
 

--- a/Common/Source/Globals.cpp
+++ b/Common/Source/Globals.cpp
@@ -692,6 +692,7 @@ void Globals_Init(void) {
   Overlay_RightTop=1;
   Overlay_RightMid=1;
   Overlay_RightBottom=1;
+  Overlay_Title= 0;
 
   FontMapWaypoint=MAXFONTRESIZE;
   FontMapTopology=MAXFONTRESIZE;

--- a/Common/Source/LKProfileLoad.cpp
+++ b/Common/Source/LKProfileLoad.cpp
@@ -962,6 +962,10 @@ void LKParseProfileString(const char *sname, const char *svalue) {
   PREAD(sname,svalue,szRegistryAdditionalContestRule,&AdditionalContestRule);
   if (matchedstring) return;
 
+  PREAD(sname,svalue,szRegistryOverlay_Title,&Overlay_Title);
+  if (matchedstring) return;
+  
+
 #ifdef _WGS84
   PREAD(sname,svalue,szRegistry_earth_model_wgs84,&earth_model_wgs84);
   if (matchedstring) return;

--- a/Common/Source/LKProfileSave.cpp
+++ b/Common/Source/LKProfileSave.cpp
@@ -431,7 +431,9 @@ void LKProfileSave(const TCHAR *szFile)
   rprintf(szRegistryOverlay_RightTop, Overlay_RightTop);
   rprintf(szRegistryOverlay_RightMid, Overlay_RightMid);
   rprintf(szRegistryOverlay_RightBottom, Overlay_RightBottom);
+  rprintf(szRegistryOverlay_Title, Overlay_Title);
 
+  
   rprintf(szRegistryAdditionalContestRule, AdditionalContestRule);
 
 

--- a/Common/Source/LKProfiles.cpp
+++ b/Common/Source/LKProfiles.cpp
@@ -475,7 +475,9 @@ const char szRegistryOverlay_LeftDown[] = "Overlay_LeftDown";
 const char szRegistryOverlay_RightTop[] = "Overlay_RightTop";
 const char szRegistryOverlay_RightMid[] = "Overlay_RightMid";
 const char szRegistryOverlay_RightBottom[] = "Overlay_RightBottom";
+const char szRegistryOverlay_Title[] = "Overlay_Title";
 const char szRegistryAdditionalContestRule[] = "Additional_Contest_Rule";
+
 #ifdef _WGS84
 const char szRegistry_earth_model_wgs84[] = "earth_model_wgs84";
 #endif


### PR DESCRIPTION
We can't do labels that on the right side,
-there is no units but maybe indicators
No good idea to make the right overlays free configurable, indicators do not change. 
Therefore restricted configuration  to OFF and default only

![image](https://user-images.githubusercontent.com/1188401/102623608-107a5900-4143-11eb-93bb-3d485c86ce62.png)

![image](https://user-images.githubusercontent.com/1188401/102623918-88e11a00-4143-11eb-9f0f-17ffba3c6407.png)
