### PR TITLE
fix MapScale Offset for 100% TopView in Multimaps

### DIFF
--- a/Common/Source/Draw/Multimaps/TopView.cpp
+++ b/Common/Source/Draw/Multimaps/TopView.cpp
@@ -257,7 +257,7 @@ _nomoredeclutter:
   // M3 has sideview always on, so wont apply here, and no need to check
   if (Current_Multimap_SizeY==SIZE4) {
     RECT rc = rct;
-    rc.Grow(0, BottomSize);
+    rc.bottom += BottomSize;
 	DrawMapScale(Surface,rc,_Proj);
   }
 

--- a/Common/Source/Draw/Multimaps/TopView.cpp
+++ b/Common/Source/Draw/Multimaps/TopView.cpp
@@ -256,7 +256,9 @@ _nomoredeclutter:
 
   // M3 has sideview always on, so wont apply here, and no need to check
   if (Current_Multimap_SizeY==SIZE4) {
-	DrawMapScale(Surface,rct,_Proj);
+    RECT rc = rct;
+    rc.Grow(0, BottomSize);
+	DrawMapScale(Surface,rc,_Proj);
   }
 
   MapWindow::zoom.RequestedScale(fOldScale);


### PR DESCRIPTION
we need an own BottomSize corrected RECT for that
otherwise we loose the sideview scaling

![image](https://user-images.githubusercontent.com/1188401/103035535-cee51600-4567-11eb-9b2a-5b7ba0aa7b1f.png)
