### PR TITLE
PowerFlarm read fix 

### DIFF
--- a/Common/Source/Dialogs/dlgIGCProgress.cpp
+++ b/Common/Source/Dialogs/dlgIGCProgress.cpp
@@ -31,6 +31,7 @@ TCHAR m_szTmp[MAX_STATUS_TXT_LEN] =_T("...");
 
 static bool OnIGCProgressTimer(WndForm *pWnd) {
   if (pWnd) {
+      pWnd->SetTimerNotify(0, NULL); 
       WindowControl *wText = pWnd->FindByName(TEXT("frmIGCText"));
       if (wText) {
         wText->SetCaption(m_szTmp);
@@ -38,6 +39,7 @@ static bool OnIGCProgressTimer(WndForm *pWnd) {
 #ifndef USE_GDI
      main_window->Refresh();
 #endif
+        pWnd->SetTimerNotify(500, OnIGCProgressTimer); 
       }
 
     if (bClose)


### PR DESCRIPTION
improved Kobo response times
turn off timer in timer function and re-enable it at the end to prevent timer overruns. Disable draw thread while FLARM IGC download.

PowerFlarm compatible
resend the binary mode command before a new IGC file donwload, because PowerFlarm automatically return from binary mode after a while so we must re-enable it in case user waited too long to start download

adjusted timouts for PowerFlarm and Classic Flarm