### PR TITLE
Radio best alternate rebased

### DIFF
--- a/Common/Data/Language/Translations/en.json
+++ b/Common/Data/Language/Translations/en.json
@@ -2569,6 +2569,8 @@
     "_@M002477_": "DiffMtg",
     "_@M002478_": "Alternate1 QNH arrival",
     "_@M002479_": "Atn1QNH",
+    "_@M002490_": "Invalid radio frequency/chanal input!",
+    "_@M002491_": "Input Error",  
 
     "_@H001361_": "[Task Type]\n[Default]\n[AAT]\nEnables AAT tasks. When enabled, the AAT observation parameters can be set for each turnpoint.\n[Grand Prix / Race To Goal]\nCommon Task Type for Paraglider or Grand Prix Task Type for Glider.",
 

--- a/Common/Header/Globals.h
+++ b/Common/Header/Globals.h
@@ -61,6 +61,12 @@ typedef struct _Radio_t
 	BOOL RX_standy;            // Radio reception on passive        (standby) station
 	BOOL lowBAT;               // Battery low flag                  (TRUE = Batt low)
 	BOOL TXtimeout;            // Timeout while transmission (2Min)
+	BOOL ActiveValid;          // active Frequency received flag
+	BOOL PassiveValid;         // standy Frequency received flag
+	BOOL VolValid;             // Volume received flag
+	BOOL SqValid;              // Squelch received flag
+	BOOL DualValid;            // Dual received flag
+        
 }Radio_t;
 
 GEXTERN bool MenuActive GEXTFALSE;

--- a/Common/Header/NavFunctions.h
+++ b/Common/Header/NavFunctions.h
@@ -4,6 +4,8 @@
 
 void xXY_Brg_Rng(double X_1, double Y_1, double X_2, double Y_2, double *Bearing, double *Range);
 
+double StraightDistance(double lat1, double lon1, double lat2, double lon2);
+
 void DistanceBearing(double lat1, double lon1,
                      double lat2, double lon2,
                      double *Distance, double *Bearing);

--- a/Common/Header/Radio.h
+++ b/Common/Header/Radio.h
@@ -1,0 +1,20 @@
+/*
+   LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+   Released under GNU/GPL License v.2
+   See CREDITS.TXT file for authors and copyrights
+
+   $Id: Radio.h,v 1.1 2020/22/12 
+*/
+
+#ifndef __RADIO_H__
+#define __RADIO_H__
+
+BOOL ValidFrequency(double Freq);
+double ExtractFrequency(const TCHAR *text);
+int SearchNearestStationWithFreqency(double Freq);
+int SearchNearestStation(void);
+int SearchBestStation(void);
+
+BOOL CopyActiveStationNameByIndex( int Idx);
+BOOL CopyPassiveStationNameByIndex( int Idx);
+#endif

--- a/Common/Header/externs.h
+++ b/Common/Header/externs.h
@@ -51,6 +51,7 @@
 #include "LKLanguage.h"
 #include "Window/WndMain.h"
 #include "LKCpu.h"
+#include "Radio.h"
 
 // Include header for heap allocation checking
 // #include "utils/heapcheck.h"

--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -47,7 +47,6 @@ unsigned int OutsideAirspaceCnt =0;
 #define DEBUG_AIRSPACE
 #endif
 
-extern	  double  ExtractFrequency(const TCHAR*);
 
 static const int k_nAreaCount = 17;
 static const TCHAR* k_strAreaStart[k_nAreaCount] = {

--- a/Common/Source/Calc/BestAlternate.cpp
+++ b/Common/Source/Calc/BestAlternate.cpp
@@ -580,20 +580,25 @@ void SearchBestAlternate(NMEA_INFO *Basic,
 		AlertBestAlternate(1);
 	}
 
+	if(bAutoActive || bAutoPassiv) // auto frequency selection?
+	{
+		int Idx = SearchBestStation();
+		if(ValidWayPoint(Idx)) {
 
-		if(ValidWayPoint(BestAlternate))
-		{
-			double fFreq = StrToDouble(WayPointList[BestAlternate].Freq,NULL);
-			if(bAutoActive)			{
-				devPutFreqActive(fFreq, WayPointList[BestAlternate].Name);
+			double fFreq = StrToDouble(WayPointList[Idx].Freq,NULL);
+			if(bAutoActive)	{
+				if(devPutFreqActive(fFreq, WayPointList[Idx].Name))
+					RadioPara.Changed = true;
 			}
 
 			if(bAutoPassiv) {
-				devPutFreqStandby(fFreq, WayPointList[BestAlternate].Name);
+				if(devPutFreqStandby(fFreq, WayPointList[Idx].Name))
+					RadioPara.Changed = true;
 			}
 		}
+	}
 
-  }
+	}
 } // end of search for the holy grail
 
 

--- a/Common/Source/Calc/Radio.cpp
+++ b/Common/Source/Calc/Radio.cpp
@@ -1,0 +1,211 @@
+/*
+   LK8000 Tactical Flight Computer -  WWW.LK8000.IT
+   Released under GNU/GPL License v.2
+   See CREDITS.TXT file for authors and copyrights
+
+   $Id: Radio.h,v 1.1 2020/22/12 
+*/
+
+#include "externs.h"
+#include "Util/TruncateString.hpp"
+
+
+BOOL ValidFrequency(double Freq)
+{
+BOOL Valid =FALSE;
+int Frac = 	(int)(Freq*1000.0+0.05) - 100*((int) (Freq *10.0+0.05));
+
+  if(Freq >= 118.0)
+    if(Freq <= 137.0)
+      switch(Frac)
+      {
+        case 0:
+        case 25:
+        case 50:
+        case 75:
+          Valid = TRUE;
+        break;
+
+        case 5:
+        case 10:
+        case 15:
+        case 30:
+        case 35:
+        case 40:
+        case 55:
+        case 60:
+        case 65:
+        case 80:
+        case 85:
+        case 90:
+          if(RadioPara.Enabled8_33)
+            Valid = TRUE;
+        break;
+
+        default:
+        break;
+      }
+
+
+  return Valid;
+}
+
+double  ExtractFrequency(const TCHAR *text)
+{
+	if(text == NULL)
+		return 0.0;
+double fFreq = 0.0;
+int iTxtlen = (int)_tcslen(text);
+int i,Mhz=0,kHz=0;
+
+	for (i=0; i < iTxtlen; i++)
+	{
+		if (text[i] == '1')
+		{
+			Mhz  = _tcstol(&text[i], nullptr, 10);
+			if(Mhz >= 118)
+				if(Mhz <= 138)
+					if((i+3) < iTxtlen)
+					{
+						if((text[i+3] == '.') || (text[i+3] == ','))
+						{
+							kHz =0;
+							if((i+4) < iTxtlen)
+								if((text[i+4] >= '0') && (text[i+4] <= '9'))
+									kHz += (text[i+4]-'0') * 100;
+
+							if((i+5) < iTxtlen)
+								if((text[i+5] >= '0') && (text[i+5] <= '9'))
+									kHz += (text[i+5]-'0') * 10;
+
+							if((i+6) < iTxtlen)
+								if((text[i+6] >= '0') && (text[i+6] <= '9'))
+									kHz += (text[i+6]-'0');
+
+							fFreq = (double) Mhz+ (double)kHz/1000.0f;
+							return fFreq;
+						}
+					}
+		}
+	}
+
+ return fFreq;
+}
+
+int SearchNearestStationWithFreqency(double Freq)
+{
+	double fDist, minDist =9999999;
+	double fWpFreq;
+	int minIdx=0;
+	
+  if(!ValidFrequency( Freq))
+		return 0;
+	for (size_t i = NUMRESWP; i < WayPointList.size(); ++i)
+	{
+		LockTaskData();		
+		LKASSERT(ValidWayPointFast(i));
+		if (WayPointList[i].Latitude!=RESWP_INVALIDNUMBER)
+		{
+	
+			fWpFreq = StrToDouble(WayPointList[i].Freq,NULL);
+			if(fabs(Freq - fWpFreq )< 0.001)
+			{					
+				fDist = StraightDistance(GPS_INFO.Latitude,
+																 GPS_INFO.Longitude,
+																 WayPointList[i].Latitude,
+																 WayPointList[i].Longitude);
+				if(fDist < minDist)
+				{
+					minDist = fDist;
+					minIdx =i;
+				}
+			}
+		}
+		UnlockTaskData();		
+	}
+	return minIdx;
+}
+
+
+int SearchNearestStation(void)
+{
+	double fDist, minDist =9999999;
+	double fWpFreq;
+	int minIdx=0;
+	
+
+	for (size_t i = NUMRESWP; i < WayPointList.size(); ++i)
+	{
+		LockTaskData();			
+		LKASSERT(ValidWayPointFast(i));
+		if (WayPointList[i].Latitude!=RESWP_INVALIDNUMBER)
+		{
+			fWpFreq = StrToDouble(WayPointList[i].Freq,NULL);
+      if(ValidFrequency( fWpFreq))
+			{					
+				fDist = StraightDistance(GPS_INFO.Latitude,
+																 GPS_INFO.Longitude,
+																 WayPointList[i].Latitude,
+																 WayPointList[i].Longitude);
+				if(fDist < minDist)
+				{
+					minDist = fDist;
+					minIdx =i;
+				}
+			}
+		}
+		UnlockTaskData();	
+	}
+	return minIdx;
+}
+
+
+int SearchBestStation(void)
+{
+int Idx = BestAlternate;    // begin with Best alternate
+double fFreq=0.0;
+
+	if(ValidWayPoint(Idx)) {
+		fFreq = StrToDouble(WayPointList[Idx].Freq,NULL);
+	}
+
+	if(!ValidFrequency(fFreq))	// best alternate does not have a radio?
+	{
+		Idx = SearchNearestStation(); // OK, then search for the nearest with radio!
+	}
+return Idx;
+}
+
+
+BOOL CopyActiveStationNameByIndex( int Idx)
+{
+BOOL 	ret = false;
+	if((Idx > 0) && ValidWayPoint(Idx)) {
+		LockTaskData();			
+		CopyTruncateString(RadioPara.ActiveName, NAME_SIZE ,WayPointList[Idx].Name);
+		UnlockTaskData();	
+		ret = true;
+	}
+	else
+	{
+		_tcscpy(RadioPara.ActiveName , TEXT(""));
+	}
+return ret;
+}
+
+
+BOOL CopyPassiveStationNameByIndex( int Idx)
+{
+BOOL 	ret = false;
+	if((Idx > 0) && ValidWayPoint(Idx)) {
+		LockTaskData();			
+		CopyTruncateString(RadioPara.PassiveName, NAME_SIZE ,WayPointList[Idx].Name);
+		UnlockTaskData();	
+		ret = true;
+	}
+	else
+  {
+		_tcscpy(RadioPara.PassiveName , TEXT(""));
+	}
+return ret;
+}

--- a/Common/Source/Calc/Radio.cpp
+++ b/Common/Source/Calc/Radio.cpp
@@ -57,7 +57,10 @@ double  ExtractFrequency(const TCHAR *text)
 
 	double fFreq = 0.0;
 	size_t iTxtlen = _tcslen(text);
-
+	
+	if(iTxtlen < 3)
+		return 0.0;
+	
 	for (size_t i = 0; i < (iTxtlen - 3); i++)
 	{
 		if (text[i] == '1')

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -1121,6 +1121,7 @@ bool devDriverActivated(const TCHAR *DeviceName) {
  * @return FALSE if error on one device.
  */
 BOOL devPutVolume(int Volume) {
+  RadioPara.VolValid = false;
   return for_all_device(&DeviceDescriptor_t::PutVolume, Volume);
 
 }
@@ -1131,6 +1132,7 @@ BOOL devPutVolume(int Volume) {
  * @return FALSE if error on one device.
  */
 BOOL devPutSquelch(int Squelch) {
+  RadioPara.SqValid = false;
   return for_all_device(&DeviceDescriptor_t::PutSquelch, Squelch);
 
 }    
@@ -1143,6 +1145,7 @@ BOOL devPutSquelch(int Squelch) {
  * @return FALSE if error on one device.
  */
 BOOL devPutRadioMode(int mode) {
+  RadioPara.DualValid = false;
   return for_all_device(&DeviceDescriptor_t::PutRadioMode, mode);
 }
 
@@ -1151,6 +1154,8 @@ BOOL devPutRadioMode(int mode) {
  * @return FALSE if error on one device.
  */
 BOOL devPutFreqSwap() {
+  RadioPara.ActiveValid = false;
+  RadioPara.PassiveValid = false;
   return for_all_device(&DeviceDescriptor_t::StationSwap);
 
 }
@@ -1166,6 +1171,7 @@ BOOL devPutFreqSwap() {
 BOOL devPutFreqActive(double Freq, const TCHAR* StationName) {
 if( ValidFrequency(Freq))
 {
+  RadioPara.ActiveValid = false;
   RadioPara.ActiveFrequency=  Freq;
   CopyTruncateString(RadioPara.ActiveName, NAME_SIZE, StationName);
   return for_all_device(&DeviceDescriptor_t::PutFreqActive, Freq, StationName);
@@ -1181,6 +1187,7 @@ else
 BOOL devPutFreqStandby(double Freq, const TCHAR* StationName) {
 if( ValidFrequency(Freq))
 {
+    RadioPara.PassiveValid = false;
     RadioPara.PassiveFrequency=  Freq;
     CopyTruncateString(RadioPara.PassiveName, NAME_SIZE, StationName);
     return for_all_device(&DeviceDescriptor_t::PutFreqStandby, Freq, StationName);

--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -1162,13 +1162,12 @@ BOOL devPutFreqSwap() {
  * @return FALSE if error on one device.
  */
 
-extern BOOL ValidFrequency(double Freq);
 
 BOOL devPutFreqActive(double Freq, const TCHAR* StationName) {
 if( ValidFrequency(Freq))
 {
   RadioPara.ActiveFrequency=  Freq;
-	CopyTruncateString(RadioPara.ActiveName, NAME_SIZE, StationName);
+  CopyTruncateString(RadioPara.ActiveName, NAME_SIZE, StationName);
   return for_all_device(&DeviceDescriptor_t::PutFreqActive, Freq, StationName);
 }
 else
@@ -1180,12 +1179,13 @@ else
  * @return FALSE if error on one device.
  */
 BOOL devPutFreqStandby(double Freq, const TCHAR* StationName) {
-  if( ValidFrequency(Freq)) {
-	  RadioPara.PassiveFrequency=  Freq;
-	  CopyTruncateString(RadioPara.PassiveName, NAME_SIZE, StationName);
+if( ValidFrequency(Freq))
+{
+    RadioPara.PassiveFrequency=  Freq;
+    CopyTruncateString(RadioPara.PassiveName, NAME_SIZE, StationName);
     return for_all_device(&DeviceDescriptor_t::PutFreqStandby, Freq, StationName);
   } else {
-	  return false;
+    return false;
   }
 }
 

--- a/Common/Source/Devices/devAR620x.cpp
+++ b/Common/Source/Devices/devAR620x.cpp
@@ -454,7 +454,6 @@ return  RadioPara.Changed;
 }
 
 
-extern int SearchStation(double Freq);
 
 /*****************************************************************************
  * this function converts a KRT answer sting to a NMEA answer
@@ -543,17 +542,17 @@ LKASSERT(d !=NULL);
         sFrequency.intVal8[1] = szCommand[4] ;
         sFrequency.intVal8[0] = szCommand[5] ;
         RadioPara.ActiveFrequency =  Idx2Freq(sFrequency.intVal16);
-        Idx = SearchStation(RadioPara.ActiveFrequency);
-        if(Idx != 0)   _sntprintf(RadioPara.ActiveName, NAME_SIZE,_T("%s"),WayPointList[Idx].Name);
-        else _sntprintf(RadioPara.PassiveName , NAME_SIZE,_T("  ???   "));
+        Idx = SearchNearestStationWithFreqency(RadioPara.ActiveFrequency);
+        CopyActiveStationNameByIndex(Idx);
+
         if(iAR620DebugLevel ) StartupStore(_T("AR620x <AF %u  %7.3f%s"), sFrequency.intVal16, RadioPara.ActiveFrequency ,NEWLINE);
 
         sFrequency.intVal8[1] = szCommand[6];
         sFrequency.intVal8[0] = szCommand[7] ;
         RadioPara.PassiveFrequency =  Idx2Freq(sFrequency.intVal16);
-        Idx = SearchStation(RadioPara.PassiveFrequency);
-        if(Idx != 0)  _sntprintf(RadioPara.PassiveName, NAME_SIZE ,_T("%s"),WayPointList[Idx].Name);
-        else _sntprintf(RadioPara.PassiveName , NAME_SIZE,_T("  ???   "));
+        Idx = SearchNearestStationWithFreqency(RadioPara.PassiveFrequency);
+        CopyPassiveStationNameByIndex(Idx);				
+
         if(iAR620DebugLevel ) StartupStore(_T("AR620x <PF: %u %7.3f%s"), sFrequency.intVal16, RadioPara.PassiveFrequency ,NEWLINE);
         RadioPara.Changed = true;
       }

--- a/Common/Source/Devices/devATR833.cpp
+++ b/Common/Source/Devices/devATR833.cpp
@@ -451,7 +451,8 @@ int Idx=0;
 
       Idx = SearchNearestStationWithFreqency(RadioPara.PassiveFrequency);
       CopyPassiveStationNameByIndex(Idx);
-
+      RadioPara.ActiveValid = false;
+      RadioPara.PassiveValid = false;
       if (iATR833DebugLevel) StartupStore(_T("ATR833 Swap %s"),    NEWLINE);
       processed  = 1;
     break;
@@ -464,7 +465,7 @@ int Idx=0;
       CopyPassiveStationNameByIndex(Idx);
 
       if (iATR833DebugLevel)StartupStore(_T("%s %s %s"),szTempStr,RadioPara.PassiveName, NEWLINE);
-
+      RadioPara.PassiveValid = true;
       RadioPara.Changed = true;
       processed  = 3;
     break;
@@ -478,6 +479,7 @@ int Idx=0;
       if (iATR833DebugLevel)StartupStore(_T("%s %s %s"),szTempStr,RadioPara.ActiveName, NEWLINE);
 
       RadioPara.Changed = true;
+      RadioPara.ActiveValid = true;
       processed  = 3;
     break;
     /*****************************************************************************************/
@@ -489,6 +491,7 @@ int Idx=0;
     case 0x16:               // Volume
       RadioPara.Volume = szCommand[1] ;
       RadioPara.Changed = true;
+      RadioPara.VolValid = true;
       if (iATR833DebugLevel) StartupStore(_T("ATR833 Volume %i %s"),   RadioPara.Volume, NEWLINE);
       processed  = 2;
     break;
@@ -496,6 +499,7 @@ int Idx=0;
     case 0x17:               // Squelch
       RadioPara.Squelch = szCommand[1] ;
       RadioPara.Changed = true;
+      RadioPara.SqValid = true;
       if (iATR833DebugLevel) StartupStore(_T("ATR833 Squelch %i %s"),   RadioPara.Squelch, NEWLINE);
       processed  = 2;
     break;
@@ -510,6 +514,7 @@ int Idx=0;
     case 0x19:               // Dual
       RadioPara.Dual = szCommand[1] ;
       RadioPara.Changed = true;
+      RadioPara.DualValid = true;
       if (iATR833DebugLevel) StartupStore(_T("ATR833 Dual %i %s"),   RadioPara.Dual, NEWLINE);
       processed  = 2;
     break;
@@ -550,6 +555,11 @@ int Idx=0;
         RadioPara.Enabled8_33  = true;
       RadioPara.Dual = szCommand[12];
       RadioPara.Changed = true;
+      RadioPara.ActiveValid  = true;
+      RadioPara.PassiveValid = true;
+      RadioPara.VolValid     = true;
+      RadioPara.SqValid      = true;
+      RadioPara.DualValid    = true;
       if (iATR833DebugLevel) StartupStore(_T("ATR833 received all Data %s"),  NEWLINE);
 
       _stprintf(szTempStr,_T("ATR833 Active: %7.3fMHz"),  RadioPara.ActiveFrequency );

--- a/Common/Source/Devices/devATR833.cpp
+++ b/Common/Source/Devices/devATR833.cpp
@@ -405,8 +405,6 @@ static uint8_t  converted[REC_BUFSIZE];
 return RadioPara.Changed;
 }
 
-extern int SearchStation(double Freq);
-
 
 
 /*****************************************************************************
@@ -448,12 +446,12 @@ int Idx=0;
        fTmp =  RadioPara.PassiveFrequency;
       RadioPara.PassiveFrequency =  RadioPara.ActiveFrequency;
       RadioPara.ActiveFrequency = fTmp;
-      Idx = SearchStation(RadioPara.ActiveFrequency);
-      if(Idx != 0)
-        _sntprintf(RadioPara.ActiveName,NAME_SIZE,_T("%s"),WayPointList[Idx].Name);
-      Idx = SearchStation(RadioPara.PassiveFrequency);
-      if(Idx != 0)
-        _sntprintf(RadioPara.PassiveName,NAME_SIZE,_T("%s"),WayPointList[Idx].Name);
+      Idx = SearchNearestStationWithFreqency(RadioPara.ActiveFrequency);
+      CopyActiveStationNameByIndex(Idx);
+
+      Idx = SearchNearestStationWithFreqency(RadioPara.PassiveFrequency);
+      CopyPassiveStationNameByIndex(Idx);
+
       if (iATR833DebugLevel) StartupStore(_T("ATR833 Swap %s"),    NEWLINE);
       processed  = 1;
     break;
@@ -462,9 +460,9 @@ int Idx=0;
       RadioPara.PassiveFrequency = (double)szCommand[1] +(((double) szCommand[2] * 5.0) / 1000.0);
       _stprintf(szTempStr,_T("ATR833 Passive: %7.3fMHz"),  RadioPara.PassiveFrequency );
       if (iATR833DebugLevel)  StartupStore(_T("%s %s"),szTempStr, NEWLINE);
-      Idx = SearchStation(RadioPara.PassiveFrequency);
-      if(Idx != 0) _sntprintf(RadioPara.PassiveName,NAME_SIZE ,_T("%s"),WayPointList[Idx].Name);
-      else RadioPara.PassiveName[0] = _T('\0');
+      Idx = SearchNearestStationWithFreqency(RadioPara.PassiveFrequency);
+      CopyPassiveStationNameByIndex(Idx);
+
       if (iATR833DebugLevel)StartupStore(_T("%s %s %s"),szTempStr,RadioPara.PassiveName, NEWLINE);
 
       RadioPara.Changed = true;
@@ -474,9 +472,9 @@ int Idx=0;
     case 0x13:               // Active Frequency
       RadioPara.ActiveFrequency = (double) szCommand[1] +(((double) szCommand[2] * 5.0) /1000.0);
       _stprintf(szTempStr,_T("ATR833 Active:  %7.3fMHz"),  RadioPara.ActiveFrequency );
-      Idx = SearchStation(RadioPara.ActiveFrequency);
-      if(Idx != 0)_sntprintf(RadioPara.ActiveName,NAME_SIZE,_T("%s"),WayPointList[Idx].Name);
-      else RadioPara.ActiveName[0] = _T('\0');
+      Idx = SearchNearestStationWithFreqency(RadioPara.ActiveFrequency);
+      CopyActiveStationNameByIndex(Idx);
+
       if (iATR833DebugLevel)StartupStore(_T("%s %s %s"),szTempStr,RadioPara.ActiveName, NEWLINE);
 
       RadioPara.Changed = true;
@@ -555,16 +553,16 @@ int Idx=0;
       if (iATR833DebugLevel) StartupStore(_T("ATR833 received all Data %s"),  NEWLINE);
 
       _stprintf(szTempStr,_T("ATR833 Active: %7.3fMHz"),  RadioPara.ActiveFrequency );
-      Idx = SearchStation(RadioPara.ActiveFrequency);
-      if(Idx != 0)_sntprintf(RadioPara.ActiveName,NAME_SIZE,_T("%s"),WayPointList[Idx].Name);
-      else RadioPara.ActiveName[0] = _T('\0');
+      Idx = SearchNearestStationWithFreqency(RadioPara.ActiveFrequency);
+      CopyActiveStationNameByIndex(Idx);
+
       if (iATR833DebugLevel)StartupStore(_T("%s %s %s"),szTempStr,RadioPara.ActiveName, NEWLINE);
 
 
       _stprintf(szTempStr,_T("ATR833 Passive: %7.3fMHz"),  RadioPara.PassiveFrequency );
-      Idx = SearchStation(RadioPara.PassiveFrequency);
-      if(Idx != 0) _sntprintf(RadioPara.PassiveName,NAME_SIZE ,_T("%s"),WayPointList[Idx].Name);
-      else RadioPara.PassiveName[0] = _T('\0');
+      Idx = SearchNearestStationWithFreqency(RadioPara.PassiveFrequency);
+      CopyPassiveStationNameByIndex(Idx);
+
       if (iATR833DebugLevel)  StartupStore(_T("%s %s %s"),szTempStr,RadioPara.PassiveName, NEWLINE);
 
       if (iATR833DebugLevel) StartupStore(_T("ATR833 Volume %i %s"),   RadioPara.Volume, NEWLINE);

--- a/Common/Source/Devices/devKRT2.cpp
+++ b/Common/Source/Devices/devKRT2.cpp
@@ -284,12 +284,14 @@ static int counter =0;
         switch (szCommand[1])
         {
           case 'U':
+            RadioPara.ActiveValid = false;
             if(len >= 13)
             {
               if(szCommand[12] != (szCommand[2] ^ szCommand[3]))
                 DoStatusMessage(_T("Checksum Fail"));
               else
               {
+                RadioPara.ActiveValid = true;
                 RadioPara.ActiveFrequency=  ((double)(unsigned char)szCommand[2]) + ((double)(unsigned char)szCommand[3])/ 200.0;
                 for(unsigned i=0; i < 8; i++)
                   RadioPara.ActiveName[i] =   szCommand[4+i];
@@ -308,12 +310,14 @@ static int counter =0;
           break;
 
           case 'R':
+            RadioPara.PassiveValid = false;
             if(len >= 13)
             {
               if(szCommand[12] != (szCommand[2] ^ szCommand[3]))
                 DoStatusMessage(_T("Checksum Fail"));
               else
               {
+                RadioPara.PassiveValid = true;
                 RadioPara.PassiveFrequency =  ((double)(unsigned char)szCommand[2]) + ((double)(unsigned char)szCommand[3])/ 200.0;
                 for(unsigned i=0; i < 8; i++)
                   RadioPara.PassiveName[i] =   szCommand[4+i];
@@ -333,12 +337,17 @@ static int counter =0;
           break;
 
           case 'A':
+            RadioPara.VolValid = false;
+            RadioPara.SqValid = false;
             if(len >= 6)
             {
               if( szCommand[5] != (szCommand[3]+ szCommand[4]))
                 DoStatusMessage(_T("Checksum Fail"));
               else
               {
+                RadioPara.VolValid = true;
+                RadioPara.SqValid = true;
+
                 if(RadioPara.Volume != (int)szCommand[2])
                 {
                   RadioPara.Volume = (int)szCommand[2];
@@ -360,6 +369,8 @@ static int counter =0;
             } else processed =0;
           break;
           case 'C':
+            RadioPara.ActiveValid = false;
+            RadioPara.PassiveValid = false;
             if(len >= 2)
             {
               std::swap(RadioPara.ActiveFrequency, RadioPara.PassiveFrequency);
@@ -368,15 +379,19 @@ static int counter =0;
             }
           break;
           case 'O':
+            RadioPara.DualValid = false;
             if(len >= 2)
             {
+              RadioPara.DualValid = true;
              RadioPara.Dual = true;
              _stprintf(szTempStr,_T("Dual ON "));
             }
           break;
           case 'o':
+            RadioPara.DualValid = false;
             if(len >= 2)
             {
+              RadioPara.DualValid = true;
              RadioPara.Dual = false;
              _stprintf(szTempStr,_T("Dual OFF "));
 

--- a/Common/Source/Devices/devKRT2.cpp
+++ b/Common/Source/Devices/devKRT2.cpp
@@ -295,7 +295,13 @@ static int counter =0;
                   RadioPara.ActiveName[i] =   szCommand[4+i];
                 RadioPara.ActiveName[8] =0;
                 TrimRight(RadioPara.ActiveName);
-                   _stprintf(szTempStr,_T("Active: %s %7.3fMHz"),  RadioPara.ActiveName,RadioPara.ActiveFrequency );
+                if( _tcslen(RadioPara.ActiveName) == 0)
+                {
+                  int Idx = SearchNearestStationWithFreqency(RadioPara.ActiveFrequency);
+                  if(Idx > 0)
+                    devPutFreqActive(RadioPara.ActiveFrequency, WayPointList[Idx].Name);
+                }
+                _stprintf(szTempStr,_T("Active: %s %7.3fMHz"),  RadioPara.ActiveName,RadioPara.ActiveFrequency );
                 processed = 13;
               }
             } else processed=0;
@@ -313,6 +319,13 @@ static int counter =0;
                   RadioPara.PassiveName[i] =   szCommand[4+i];
                 RadioPara.PassiveName[8] =0;
                 TrimRight(RadioPara.PassiveName);
+                if( _tcslen(RadioPara.PassiveName) == 0)
+                {
+                   int Idx = SearchNearestStationWithFreqency(RadioPara.PassiveFrequency);
+                  if(Idx > 0)
+                     devPutFreqStandby(RadioPara.PassiveFrequency, WayPointList[Idx].Name);
+                }
+
                 _stprintf(szTempStr,_T("Passive: %s %7.3fMHz"),  RadioPara.PassiveName,RadioPara.PassiveFrequency );
                 processed = 13;
               }

--- a/Common/Source/Devices/devLX_EOS_ERA.cpp
+++ b/Common/Source/Devices/devLX_EOS_ERA.cpp
@@ -1787,7 +1787,6 @@ BOOL DevLX_EOS_ERA::LXWP4(PDeviceDescriptor_t d, const TCHAR* sentence, NMEA_INF
 } // LXWP4()
 
 
-extern BOOL ValidFrequency(double Freq);
 
 BOOL DevLX_EOS_ERA::LXDT(PDeviceDescriptor_t d, const TCHAR* sentence, NMEA_INFO* info)
 {

--- a/Common/Source/Dialogs/dlgAirspaceDetails.cpp
+++ b/Common/Source/Dialogs/dlgAirspaceDetails.cpp
@@ -17,7 +17,6 @@
 #include "LKObjects.h"
 #include "Sound/Sound.h"
 #include "resource.h"
-extern BOOL ValidFrequency(double Freq);
 
 static CAirspaceBase airspace_copy;
 static void OnDetailsClicked(WndButton* pWnd);
@@ -111,46 +110,6 @@ static bool OnTimer(WndForm* pWnd){
   return true;
 }
 
-double  ExtractFrequency(const TCHAR *text)
-{
-    if(text == NULL)
-        return 0.0;
- double fFreq = 0.0;
- int iTxtlen = (int)_tcslen(text);
- int i,Mhz=0,kHz=0;
- for (i=0; i < iTxtlen; i++)
- {
-   if (text[i] == '1')
-   {
-     Mhz  = _tcstol(&text[i], nullptr, 10);
-	 if(Mhz >= 118)
-	   if(Mhz <= 138)
-	         if((i+3) < iTxtlen)
-	         {
-		       if((text[i+3] == '.') || (text[i+3] == ','))
-		       {
-		    	 kHz =0;
-		    	 if((i+4) < iTxtlen)
-			       if((text[i+4] >= '0') && (text[i+4] <= '9'))
-			    	   kHz += (text[i+4]-'0') * 100;
-
-		    	 if((i+5) < iTxtlen)
-			       if((text[i+5] >= '0') && (text[i+5] <= '9'))
-			    	   kHz += (text[i+5]-'0') * 10;
-
-		    	 if((i+6) < iTxtlen)
-			       if((text[i+6] >= '0') && (text[i+6] <= '9'))
-			    	   kHz += (text[i+6]-'0');
-
-		    	 fFreq = (double) Mhz+ (double)kHz/1000.0f;
-		    	 return fFreq;
-		       }
-	         }
-	   }
-   }
-
- return fFreq;
-}
 
 static void OnSetFrequency(WndButton* pWnd){
 

--- a/Common/Source/Dialogs/dlgLKTraffic.cpp
+++ b/Common/Source/Dialogs/dlgLKTraffic.cpp
@@ -180,8 +180,8 @@ static void OnRenameClicked(WndButton* pWnd){
 }
 
 
-extern double  ExtractFrequency(const TCHAR*);
-extern BOOL ValidFrequency(double Freq);
+
+
 
 static void OnFlarmFreqSelectEnter(WndButton*  Sender) {
   TCHAR Tmp[255];

--- a/Common/Source/Dialogs/dlgRadioSettings.cpp
+++ b/Common/Source/Dialogs/dlgRadioSettings.cpp
@@ -89,7 +89,11 @@ static int OnRemoteUpdate(void)
       if(RadioPara.RX_active)
         _stprintf(Name,_T("<%s>"),ActiveName);
       else
-        _stprintf(Name,_T("[%s]"),ActiveName);
+        if(RadioPara.ActiveValid)
+          _stprintf(Name,_T("[%s]"),ActiveName);
+        else
+          _stprintf(Name,_T("%s"),ActiveName);
+      
     if(wpnewActive)
       wpnewActive->SetCaption(Name);
     _stprintf(Name,_T("%6.03f"),RadioPara.ActiveFrequency);
@@ -102,7 +106,11 @@ static int OnRemoteUpdate(void)
     if(RadioPara.RX_standy)
       _stprintf(Name,_T("<%s>"),PassiveName);
     else
-      _stprintf(Name,_T("[%s]"),PassiveName);
+      if(RadioPara.PassiveValid)
+        _stprintf(Name,_T("[%s]"),PassiveName);
+      else
+        _stprintf(Name,_T("%s"),PassiveName);
+    
     if(wpnewPassive)
      wpnewPassive->SetCaption(Name);
     _stprintf(Name,_T("%6.03f"),RadioPara.PassiveFrequency);
@@ -121,17 +129,33 @@ static int OnRemoteUpdate(void)
         lVolume =  RadioPara.Volume;
         if(wpnewVol)
         {
-      if(VolMode == VOL)
-            _stprintf(Name,_T("V[%i]"),RadioPara.Volume);
-      else
-        _stprintf(Name,_T("S [%i]"),RadioPara.Squelch);
+          if(VolMode == VOL)
+          {
+            if(RadioPara.VolValid)
+              _stprintf(Name,_T("V[%i]"),RadioPara.Volume);
+            else
+              _stprintf(Name,_T("V %i"),RadioPara.Volume);
+          }
+          else
+          {
+            if(RadioPara.SqValid)
+              _stprintf(Name,_T("S [%i]"),RadioPara.Squelch);
+            else
+              _stprintf(Name,_T("S %i"),RadioPara.Squelch);
+          }
           wpnewVol->SetCaption(Name);
         }
 
         if(RadioPara.Dual)
-          _stprintf(Name,_T("[Dual Off]"));
+          if(RadioPara.DualValid)
+            _stprintf(Name,_T("[Dual Off]"));
+          else
+            _stprintf(Name,_T("Dual Off"));
         else
-          _stprintf(Name,_T("[Dual On]"));
+          if(RadioPara.DualValid) 
+            _stprintf(Name,_T("[Dual On]"));
+          else
+            _stprintf(Name,_T("Dual On"));            
         if(wpnewDual)
               wpnewDual->SetCaption(Name);
 

--- a/Common/Source/Dialogs/dlgRadioSettings.cpp
+++ b/Common/Source/Dialogs/dlgRadioSettings.cpp
@@ -221,7 +221,7 @@ static void OnActiveButton(WndButton* pWnd){
     if(res > RESWP_END )
     if(ValidWayPoint(res))
     {
-      double  Frequency = StrToDouble(WayPointList[res].Freq,NULL);
+      double  Frequency = ExtractFrequency(WayPointList[res].Freq);
       if(!ValidFrequency(Frequency))
       {
         MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //   "_@M002490_": "Invalid radio frequency/channel input!",
@@ -248,7 +248,7 @@ static void OnPassiveButton(WndButton* pWnd){
    if(res > RESWP_END )
      if(ValidWayPoint(res))
     {
-      double Frequency = StrToDouble(WayPointList[res].Freq,NULL);
+      double Frequency = ExtractFrequency(WayPointList[res].Freq);
       if(!ValidFrequency(Frequency))
       {
         MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //    "_@M002490_": "Invalid radio frequency/channel input!",
@@ -262,7 +262,6 @@ static void OnPassiveButton(WndButton* pWnd){
         OnUpdate();
         HoldOff = HOLDOFF_TIME;
       }
-      MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //   "_@M002490_": "Invalid radio frequency/channel input!",
     }
   }
 }
@@ -275,7 +274,7 @@ static void OnActiveFreq(WndButton* pWnd){
 
   dlgNumEntryShowModal(szFreq,8);
 
-  double Frequency = StrToDouble(szFreq, nullptr);
+  double Frequency = ExtractFrequency(szFreq);
   while(Frequency > 1000.0)
     Frequency /=10;
 
@@ -298,9 +297,8 @@ static void OnPassiveFreq(WndButton* pWnd){
 
   dlgNumEntryShowModal(szFreq,8);
 
-  double Frequency = StrToDouble(szFreq, nullptr);
-  while(Frequency > 1000)
-    Frequency /=10;
+  double Frequency = ExtractFrequency(szFreq);
+
 
   if(!ValidFrequency(Frequency))
   {
@@ -325,7 +323,7 @@ static void OnRadioActiveAutoClicked(WndButton* pWnd){
 	int Idx = SearchBestStation();
 	if ( ValidWayPoint(Idx))
 	{
-		double fFreq = StrToDouble(WayPointList[Idx].Freq,NULL);
+		double fFreq = ExtractFrequency(WayPointList[Idx].Freq);
 		devPutFreqActive(	fFreq , WayPointList[Idx].Name);
 	}
 
@@ -344,7 +342,7 @@ static void OnRadioStandbyAutoClicked(WndButton* pWnd)
 	int Idx = SearchBestStation();
 	if ( ValidWayPoint(Idx))
 	{
-		double fFreq = StrToDouble(WayPointList[Idx].Freq,NULL);
+		double fFreq = ExtractFrequency(WayPointList[Idx].Freq);
 		devPutFreqStandby(	fFreq , WayPointList[Idx].Name);
 	}
 

--- a/Common/Source/Dialogs/dlgRadioSettings.cpp
+++ b/Common/Source/Dialogs/dlgRadioSettings.cpp
@@ -215,17 +215,18 @@ static void OnActiveButton(WndButton* pWnd){
       double  Frequency = StrToDouble(WayPointList[res].Freq,NULL);
       if(!ValidFrequency(Frequency))
       {
-   // 	DoStatusMessage(_T("No valid Frequency!") );
-	return;
+        MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //   "_@M002490_": "Invalid radio frequency/chanal input!",
       }
-      devPutFreqActive(Frequency, WayPointList[res].Name);
+      else
+      {
+        devPutFreqActive(Frequency, WayPointList[res].Name);
     	_tcscpy(RadioPara.ActiveName, WayPointList[res].Name);
-      RadioPara.ActiveFrequency = Frequency;
-
-      ActiveRadioIndex = res;
+        RadioPara.ActiveFrequency = Frequency;
+        ActiveRadioIndex = res;  
+        OnUpdate();
+        HoldOff = HOLDOFF_TIME;
+      }
     }
-    OnUpdate();
-    HoldOff = HOLDOFF_TIME;
   }
 }
 
@@ -239,20 +240,20 @@ static void OnPassiveButton(WndButton* pWnd){
      if(ValidWayPoint(res))
     {
       double Frequency = StrToDouble(WayPointList[res].Freq,NULL);
-      if(Frequency < 100.0)
+      if(!ValidFrequency(Frequency))
       {
-     //    DoStatusMessage(_T("No valid Frequency!") );
-        return;
+        MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //    "_@M002490_": "Invalid radio frequency/chanal input!",
       }
-      devPutFreqStandby(Frequency, WayPointList[res].Name);
-
-
-      _tcscpy(RadioPara.PassiveName, WayPointList[res].Name);
-      RadioPara.PassiveFrequency = Frequency;
-      PassiveRadioIndex = res;
+      else
+      { 
+        devPutFreqStandby(Frequency, WayPointList[res].Name);
+        _tcscpy(RadioPara.PassiveName, WayPointList[res].Name);
+        RadioPara.PassiveFrequency = Frequency;
+        PassiveRadioIndex = res;
+        OnUpdate();
+        HoldOff = HOLDOFF_TIME;
+      }
     }
-    OnUpdate();
-    HoldOff = HOLDOFF_TIME;
   }
 }
 
@@ -266,13 +267,18 @@ _stprintf(szFreq, _T("%7.3f"),RadioPara.ActiveFrequency);
     double Frequency = StrToDouble(szFreq,NULL);
     while(Frequency > 1000.0)
 	   Frequency /=10;
-    if(ValidFrequency(Frequency))
+    if(!ValidFrequency(Frequency))
+    {        
+      MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //   "_@M002490_": "Invalid radio frequency/chanal input!",
+    }
+    else
     {
       int iIdx = SearchNearestStationWithFreqency(Frequency);
       CopyActiveStationNameByIndex(iIdx);
       devPutFreqActive(Frequency,RadioPara.ActiveName);
+      OnUpdate();
     }
-    OnUpdate();
+
 }
 
 static void OnPassiveFreq(WndButton* pWnd){
@@ -285,13 +291,18 @@ _stprintf(szFreq,  _T("%7.3f"),RadioPara.PassiveFrequency);
    while(Frequency > 1000)
 	   Frequency /=10;
 
-   if(ValidFrequency(Frequency))
-   {
-     int iIdx = SearchNearestStationWithFreqency(Frequency);
-     CopyPassiveStationNameByIndex(iIdx);
-     devPutFreqStandby(Frequency,RadioPara.PassiveName);
-   }
-   OnUpdate();
+    if(!ValidFrequency(Frequency))
+    {        
+      MessageBoxX(MsgToken(2490), MsgToken(2494), mbOk); //    "_@M002490_": "Invalid radio frequency/chanal input!",
+    }
+    else
+    {
+      int iIdx = SearchNearestStationWithFreqency(Frequency);
+      CopyPassiveStationNameByIndex(iIdx);
+      devPutFreqStandby(Frequency,RadioPara.PassiveName);
+      OnUpdate();
+    }
+   
 }
 
 

--- a/Common/Source/Dialogs/dlgWayPointDetails.cpp
+++ b/Common/Source/Dialogs/dlgWayPointDetails.cpp
@@ -324,7 +324,6 @@ static CallBackTableEntry_t CallBackTable[]={
   EndCallBackEntry()
 };
 
-extern    double  ExtractFrequency(const TCHAR*);
 
 static void OnMultiSelectEnter(WindowControl * Sender,
                                        WndListFrame::ListInfo_t *ListInfo) {

--- a/Common/Source/Library/NavFunctions.cpp
+++ b/Common/Source/Library/NavFunctions.cpp
@@ -17,6 +17,15 @@ using GeographicLib::Geodesic;
 const std::runtime_error err(std::string("")); // requiered for avoid link error with mingw 5.4.0
 #endif
 
+double StraightDistance(double lat1, double lon1, double lat2, double lon2)
+{
+double la = lat2 - lat1;
+double lo = lon2 - lon1;
+
+return sqrt( la*la + lo*lo);
+
+}
+
 void DistanceBearing(double lat1, double lon1, double lat2, double lon2,
                      double *Distance, double *Bearing) {
 

--- a/Makefile
+++ b/Makefile
@@ -1065,6 +1065,7 @@ CALC	:=\
 	$(CLC)/windstore.cpp 	\
 	$(CLC)/WindEKF.cpp 	\
 	$(CLC)/WindKalman.cpp 	\
+	$(CLC)/Radio.cpp \
 
 
 TASK	:=\


### PR DESCRIPTION
replaces #1519 
improve radio station handling

-add own radio calculation/util functions in separate file Radio.cpp (removed a lot of "external" declaration)
-new function NearestStation with quick search for station names by straight line (Manhattan) distance calculation
-made thread save using LockTaskData();/UnlockTaskData();
-added BestStation analog to BestAlternate but searches for the nearest station if BestAlternate has no valid Radio frequency (e.g. outlanding fields)
-own copy functions for station names by Index for a better code understanding
-moved radiodevice station name updated for device into the driver.
-checked for correct ident