### PR TITLE
allow finding 0MSL Top airspaces (not drawn) in Multiselect dialog

### DIFF
--- a/Common/Source/Airspace/LKAirspace.cpp
+++ b/Common/Source/Airspace/LKAirspace.cpp
@@ -2969,7 +2969,8 @@ CAirspaceList CAirspaceManager::GetNearAirspacesAtPoint(const double &lon, const
     CAirspaceList::const_iterator it;
     ScopeLock guard(_csairspaces);
     for (it = _airspaces.begin(); it != _airspaces.end(); ++it) {
-        if ((*it)->DrawStyle()) {
+        if ((*it)->DrawStyle() || (((*it)->Top()->Base == abMSL) && ((*it)->Top()->Altitude <= 0))) 
+        {
             (*it)->CalculateDistance(&HorDist, &Bearing, &VertDist, lon, lat);
             if (HorDist < searchrange) {
                 res.push_back(*it);


### PR DESCRIPTION
https://www.postfrontal.com/forum/topic.asp?whichpage=1.66666666666667&TOPIC_ID=9124&#72595