### PR TITLE
Cast fontsize to int to prevent implicit conversion.

### DIFF
--- a/Common/Source/Fonts1.cpp
+++ b/Common/Source/Fonts1.cpp
@@ -70,7 +70,7 @@ void ApplyFontSize(LOGFONT *logfont) {
 void ApplyCustomResize(LOGFONT *logfont, short change) {
   if (change != MAXFONTRESIZE) {
     int f = change - MAXFONTRESIZE;
-    logfont->lfHeight += logfont->lfHeight * f / 16;
+    logfont->lfHeight += (int)logfont->lfHeight * f / 16;
   }
 }
 


### PR DESCRIPTION
Convertion from negative int to uint give huge numbers.

Calculation was wrong on Linux where fontsize is unsigned.