### PR TITLE
loading OGN Database after FlarmNet

### DIFF
--- a/Common/Header/FlarmIdFile.h
+++ b/Common/Header/FlarmIdFile.h
@@ -16,6 +16,7 @@ constexpr size_t FLARMID_SIZE_FREQ = 8;
 
 struct FlarmId {
   explicit FlarmId(const std::string& string);
+  explicit FlarmId(void);
 
   TCHAR id[FLARMID_SIZE_ID] = _T("");
   TCHAR name[FLARMID_SIZE_NAME] = _T("");
@@ -40,6 +41,13 @@ private:
 public:
   FlarmIdFile();
   ~FlarmIdFile();
+
+    void ExtractParameter(const TCHAR *Source, 
+				  TCHAR *Destination, 
+				  int DesiredFieldNumber);
+
+  void OGNIdFile(void);
+
 
   size_t Count() const {
     return flarmIds.size();

--- a/Common/Source/FlarmTools.cpp
+++ b/Common/Source/FlarmTools.cpp
@@ -47,7 +47,7 @@ void OpenFLARMDetails() {
 
   flarmnet_database = std::make_unique<FlarmIdFile>();
 
-  StartupStore(_T(". FLARMNET database, found %u IDs"), (unsigned)flarmnet_database->Count());
+
 
   TCHAR filename[MAX_PATH];
   LocalPath(filename,TEXT(LKD_CONF),_T(LKF_FLARMIDS));


### PR DESCRIPTION
Since OGNs database is widely used (over 20k registrations), it became more important over the FlarmNet database.
This commit also loads the OGN databaste IDs on top of the FlarmNet IDs.
The OGN Data is derived from:
http://ddb.glidernet.org/
the database is not encrypted an can be loaded via
http://ddb.glidernet.org/download/
the OGN database file must be named DATA.OGN and must be placed in the LK8000\_Configuration folder similar to the DATA.FLN file of Flarmnet.

At the moment (Sept. 2022) we have 12365 FlarmNet ID and additional 16807 IDs in OGN. This can be Monitored in the runtime.log.

[078749787] . FLARMNET database, found 12365 IDs
[078749802] . found 8893 IDs also in OGN database
[078749802] . OGN database, found additinal 16807 IDs
[078749802] . total Flarm devices found 29172 IDs

regards
 AlphaLima