### PR TITLE
Update device.cpp, ignore executable rights for native serial RS232

### DIFF
--- a/Common/Source/Comm/device.cpp
+++ b/Common/Source/Comm/device.cpp
@@ -186,7 +186,7 @@ void RefreshComPortList() {
       if(portok) {
         char path[512]; // at least MAX_NAME + prefix size
         sprintf(path, "/dev/%s", namelist[i]->d_name);
-        if (access(path, R_OK|W_OK) == 0 && access(path, X_OK) < 0) {
+        if (access(path, R_OK|W_OK) == 0) {
           COMMPort.emplace_back(path);
         }
       }


### PR DESCRIPTION
In order to see all serial devices on android devices that have more than one serial port, this change fixes an epic bug that required executable rights on device descriptors that makes no sense for a character device and is not present in current android OS.