### PR TITLE
fix for NMEA 'AcftType' field

### DIFF
--- a/Common/Source/Comm/LKFlarm.cpp
+++ b/Common/Source/Comm/LKFlarm.cpp
@@ -606,7 +606,7 @@ BOOL NMEAParser::PFLAA(TCHAR *String, TCHAR **params, size_t nparams, NMEA_INFO 
 	traffic.TurnRate = _tcstod(params[7], nullptr);
 	traffic.Speed = _tcstod(params[8], nullptr);
 	traffic.ClimbRate = _tcstod(params[9], nullptr);
-	traffic.Type = _tcstoul(params[4], nullptr, 10);
+	traffic.Type = _tcstoul(params[10], nullptr, 16);
 
 	UpdateFlarmScale(pGPS);
 


### PR DESCRIPTION
<br>

[**FTD-012 DATA PORT INTERFACE CONTROL DOCUMENT (ICD)**](https://flarm.com/wp-content/uploads/man/FTD-012-Data-Port-Interface-Control-Document-ICD.pdf)

<br>
<br>

![](https://github.com/XCSoar/XCSoar/assets/5849637/07ef6b2f-ab35-4a7c-9fe1-ad9f9b7dd6b2)
