### PR TITLE
add SoftRF Ham and Midi into 'white list' of USB devices

### DIFF
--- a/android/res/xml/usb_device_filter.xml
+++ b/android/res/xml/usb_device_filter.xml
@@ -10,8 +10,10 @@
   <usb-device vendor-id="7504" product-id="24713" />  <!-- SoftRF ES -->
   <usb-device vendor-id="11914" product-id="10" />    <!-- SoftRF Lego -->
   <usb-device vendor-id="11914" product-id="61450" /> <!-- SoftRF Lego -->
-  <usb-device vendor-id="5562" product-id="68"/> <!-- SoftRF Balkan -->
-  <usb-device vendor-id="12346" product-id="33075"/> <!-- SoftRF Prime Mk3 -->
+  <usb-device vendor-id="5562" product-id="68" />     <!-- SoftRF Balkan -->
+  <usb-device vendor-id="12346" product-id="33075" /> <!-- SoftRF Prime Mk3 -->
+  <usb-device vendor-id="12346" product-id="33167" /> <!-- SoftRF Ham -->
+  <usb-device vendor-id="12346" product-id="33184" /> <!-- SoftRF Midi -->
 
   <usb-device vendor-id="1027" product-id="24577" /> <!-- FT232AM, FT232BM, FT232R FT245R -->
   <usb-device vendor-id="1027" product-id="24592" /> <!-- FT2232D, FT2232H -->

--- a/android/src/org/LK8000/UsbSerialHelper.java
+++ b/android/src/org/LK8000/UsbSerialHelper.java
@@ -80,6 +80,8 @@ public class UsbSerialHelper extends BroadcastReceiver {
             createDevice(0x2e8a, 0xf00a), // SoftRF Lego
             createDevice(0x15ba, 0x0044), // SoftRF Balkan
             createDevice(0x303a, 0x8133), // SoftRF Prime Mk3
+            createDevice(0x303a, 0x818f), // SoftRF Ham
+            createDevice(0x303a, 0x81a0), // SoftRF Midi
 
             createDevice(0x0403, 0x6001), // FT232AM, FT232BM, FT232R FT245R,
             createDevice(0x0403, 0x6010), // FT2232D, FT2232H


### PR DESCRIPTION
Brief summary of the changes
----------------------------

add USB VID/PID pairs for SoftRF Ham and Midi Editions into (Android) 'white list' of USB devices
