### PR TITLE
Update Model.cpp add ID for my Kobo Clara HD Model

### DIFF
--- a/Common/Source/xcs/Kobo/Model.cpp
+++ b/Common/Source/xcs/Kobo/Model.cpp
@@ -66,6 +66,7 @@ static constexpr struct {
   { "SN-N437", KoboModel::GLO_HD },
   { "SN-RN437", KoboModel::GLO_HD },
   { "SN-N249", KoboModel::CLARA_HD },
+  { "SN-R2493", KoboModel::CLARA_HD },
   { "SN-N506", KoboModel::CLARA_2E },
   { "SN-N306", KoboModel::NIA },
   { "SN-N418", KoboModel::LIBRA2 },


### PR DESCRIPTION
Set up LK8000 7.5.0 on my new Kobo Klara HD. Wifi did not work because the model was not detected as Clara HD so no driver was loaded.
The model number I found is "SN-R2493" so I added this to Model.cpp. Verified this for version  LK8000-7.4.24  