### PR TITLE
Fix CUP parser ignoring '*' comment lines during format detection

### DIFF
--- a/Common/Source/Waypoints/ReadFile.cpp
+++ b/Common/Source/Waypoints/ReadFile.cpp
@@ -36,6 +36,9 @@ int ReadWayPointFile(std::istream& stream, int fileformat) {
     if (src_line.front() == 'B') {
       continue;  // Skip encoding
     }
+    if (src_line.front() == '*') {
+      continue;  // Skip comment
+    }
 
     if (src_line.starts_with("G  WGS 84") || src_line.starts_with("G WGS 84") ||
         src_line.starts_with("\xEF\xBB\xBFG  WGS 84")) {


### PR DESCRIPTION
Fixes #1695

## Problem

\`ReadWayPointFile()\` in \`Common/Source/Waypoints/ReadFile.cpp\` has two distinct loops:

1. **Format detection loop** — reads lines until it recognises the file format (\`name,code,country\` header for CUP, \`OziExplorer…\` for OZI, etc.).
2. **Data reading loop** — reads and parses waypoint entries line by line.

The data reading loop correctly skips \`*\` comment lines (line 141):
\`\`\`cpp
if (src_line.front() == '*') {
  continue;  // Skip comment
}
\`\`\`

The format detection loop, however, only skips empty lines and lines starting with \`B\` (encoding marker). It does **not** skip \`*\` comment lines.

When a \`.cup\` file begins with one or more \`*\` comment lines, the format detection loop encounters the first comment before reaching the \`name,code,country\` header. It does not recognise the comment as a known format signature, so it falls through to the extension-based fallback: it sets \`fileformat = LKW_CUP\` but **exits without initialising \`cup_header\`**.

With \`cup_header\` empty, every subsequent field lookup (\`name\`, \`lat\`, \`lon\`, \`elev\`, …) returns an empty string. Latitude and longitude validation fails for every entry, \`ParseCUPWayPointString()\` returns \`false\` on every line, and **zero waypoints are loaded** from an otherwise perfectly valid file — with no error reported to the user.

## Example

A file like:
\`\`\`
* WAYPOINTS ITALY 2026
* Author: ...
*
name,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc
SOME AIRFIELD,CS11,IT,3945.416N,01626.300E,2m,2,120,850m,130.000,SOME AIRFIELD
\`\`\`
loads **0 waypoints**, while the identical file without the leading comment lines loads correctly.

## Fix

Add the same \`*\` guard to the format detection loop, mirroring what already exists in the data reading loop:

\`\`\`cpp
if (src_line.front() == '*') {
  continue;  // Skip comment
}
\`\`\`

## Testing

Tested on all three supported platforms with a \`.cup\` file containing leading \`*\` comment lines:

- [x] **Linux** — waypoints load correctly
- [x] **Android** — waypoints load correctly (debug build, Samsung S24)
- [x] **Kobo** — waypoints load correctly

Regression: \`.cup\` files without comment lines behave identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)